### PR TITLE
Change `Truncated<T>` from 8 -> 12 bytes

### DIFF
--- a/design/protocol.md
+++ b/design/protocol.md
@@ -199,5 +199,3 @@ For signature verification, CBOR encoding must be deterministic:
 - Map keys sorted by encoded length, then lexicographically
 - Integers use smallest encoding
 - No indefinite-length arrays/maps
-
-The `minicbor` crate enforces this by default.

--- a/design/sedimentree.md
+++ b/design/sedimentree.md
@@ -54,17 +54,22 @@ A checkpoint grouping multiple commits at a specific depth:
 
 ```rust
 struct Fragment {
-    summary: FragmentSummary,   // Head + boundary
-    checkpoints: Vec<Digest>,  // Interior checkpoints
-    digest: Digest,            // Hash of the fragment itself
+    summary: FragmentSummary,         // Head + boundary
+    checkpoints: BTreeSet<Checkpoint>, // Interior checkpoints (truncated)
+    digest: Digest,                   // Hash of the fragment itself
 }
 
 struct FragmentSummary {
-    head: Digest,              // Most recent commit
-    boundary: Vec<Digest>,     // Ending commits
+    head: Digest,                     // Most recent commit
+    boundary: BTreeSet<Digest>,       // Ending commits
     blob_meta: BlobMeta,
 }
+
+/// A 12-byte truncation of a commit digest for compact storage.
+struct Checkpoint(Truncated<Digest, 12>);
 ```
+
+Checkpoints use 12-byte truncated digests (96 bits) instead of full 32-byte digests, saving ~62% on wire size while maintaining negligible collision probability (~10⁻¹⁷ at 1M items).
 
 Fragments consolidate history, reducing the number of items to track and sync.
 

--- a/sedimentree_core/src/fragment/checkpoint.rs
+++ b/sedimentree_core/src/fragment/checkpoint.rs
@@ -13,17 +13,17 @@ use crate::{
 
 /// A truncated commit digest marking a commit within a fragment's range.
 ///
-/// Checkpoints are stored as 16-byte truncations of the full 32-byte BLAKE3
+/// Checkpoints are stored as 12-byte truncations of the full 32-byte BLAKE3
 /// commit digest. This provides:
-/// - Compact storage (~50% savings vs full digest)
-/// - Negligible random collision probability (~10⁻²⁷ at 1M items)
+/// - Compact storage (~62% savings vs full digest)
+/// - Negligible random collision probability (~10⁻¹⁷ at 1M items)
 /// - Efficient set membership checks
 ///
 /// # Security Properties
 ///
-/// - **Random collision**: ~N²/2¹²⁸ where N is set size
-/// - **Adversarial collision**: ~2⁶⁴ work (birthday attack on 128 bits)
-/// - **Preimage**: ~2¹²⁸ work
+/// - **Random collision**: ~N²/2⁹⁶ where N is set size
+/// - **Adversarial collision**: ~2⁴⁸ work (birthday attack on 96 bits)
+/// - **Preimage**: ~2⁹⁶ work
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, minicbor::Encode, minicbor::Decode)]
 #[cbor(transparent)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -33,7 +33,7 @@ pub struct Checkpoint(#[n(0)] Truncated<Digest<LooseCommit>>);
 impl Checkpoint {
     /// Create a checkpoint from a full commit digest.
     ///
-    /// The digest is truncated to 16 bytes.
+    /// The digest is truncated to 12 bytes.
     #[must_use]
     pub fn new(digest: Digest<LooseCommit>) -> Self {
         Self(Truncated::new(digest))
@@ -53,7 +53,7 @@ impl Checkpoint {
 
     /// The raw bytes of the truncated checkpoint.
     #[must_use]
-    pub const fn as_bytes(&self) -> &[u8; 16] {
+    pub const fn as_bytes(&self) -> &[u8; 12] {
         self.0.as_bytes()
     }
 }
@@ -105,7 +105,7 @@ mod tests {
     fn checkpoint_from_digest() {
         let digest = Digest::<LooseCommit>::from_bytes([42u8; 32]);
         let checkpoint = Checkpoint::new(digest);
-        assert_eq!(checkpoint.as_bytes(), &[42u8; 16]);
+        assert_eq!(checkpoint.as_bytes(), &[42u8; 12]);
     }
 
     #[test]
@@ -125,6 +125,6 @@ mod tests {
 
         let a = Checkpoint::new(Digest::<LooseCommit>::from_bytes(bytes_a));
         let b = Checkpoint::new(Digest::<LooseCommit>::from_bytes(bytes_b));
-        assert_eq!(a, b); // Same first 16 bytes
+        assert_eq!(a, b); // Same first 12 bytes
     }
 }


### PR DESCRIPTION
TLDR
* 256-bits is cryptographically safe, but more metadata than content
* 64-bits pragmatic but non-malicious collisions possible in practice
* 128-bits has effectively 0 collisions (under our threat model) but still lot of space
* 96-bits still has effectively 0 collisions, but less space than 128-bits