### PR TITLE
Remove `MAX_STRATA_DEPTH`

### DIFF
--- a/sedimentree_core/src/commit.rs
+++ b/sedimentree_core/src/commit.rs
@@ -7,10 +7,7 @@ use core::error::Error;
 use thiserror::Error;
 
 use crate::{
-    blob::BlobMeta,
-    depth::{Depth, DepthMetric},
-    fragment::Fragment,
-    id::SedimentreeId,
+    blob::BlobMeta, depth::DepthMetric, fragment::Fragment, id::SedimentreeId,
     loose_commit::id::CommitId,
 };
 
@@ -94,7 +91,7 @@ pub trait CommitStore<'a> {
         strategy: &D,
     ) -> Result<FragmentState<Self::Node>, FragmentError<'a, Self>> {
         let head_depth = strategy.to_depth(head_id);
-        if head_depth == Depth(0) {
+        if !head_depth.is_boundary() {
             return Err(FragmentError::DepthZeroHead(head_id));
         }
 
@@ -128,7 +125,7 @@ pub trait CommitStore<'a> {
             } else {
                 // Same or shallower depth: absorbed into this fragment.
                 members.insert(id);
-                if depth > Depth(0) && depth < head_depth {
+                if depth.is_boundary() && depth < head_depth {
                     // Shallower stratum boundary within this fragment.
                     // Retained so we can determine the "supports"
                     // relationship between strata.
@@ -193,7 +190,7 @@ pub trait CommitStore<'a> {
 
             // Depth-0 commits are loose commits, not fragment heads.
             // Walk their parents so we still discover deeper boundaries.
-            if strategy.to_depth(head) == Depth(0) {
+            if !strategy.to_depth(head).is_boundary() {
                 if let Some(node) = self.lookup(head).map_err(FragmentError::LookupError)? {
                     queue.extend(node.parents());
                 }
@@ -276,13 +273,13 @@ pub trait CommitStore<'a> {
                 let mut visited_d0: Set<CommitId> = Set::new();
                 let mut pending: Vec<CommitId> = Vec::new();
                 horizon.retain(|&h| {
-                    if strategy.to_depth(h) == Depth(0) {
+                    if strategy.to_depth(h).is_boundary() {
+                        true
+                    } else {
                         if visited_d0.insert(h) {
                             pending.push(h);
                         }
                         false
-                    } else {
-                        true
                     }
                 });
 
@@ -294,12 +291,10 @@ pub trait CommitStore<'a> {
                         if known_fragment_states.contains_key(&p) {
                             continue;
                         }
-                        if strategy.to_depth(p) == Depth(0) {
-                            if visited_d0.insert(p) {
-                                pending.push(p);
-                            }
-                        } else {
+                        if strategy.to_depth(p).is_boundary() {
                             horizon.push(p);
+                        } else if visited_d0.insert(p) {
+                            pending.push(p);
                         }
                     }
                 }

--- a/sedimentree_core/src/depth.rs
+++ b/sedimentree_core/src/depth.rs
@@ -36,11 +36,11 @@ use crate::loose_commit::id::CommitId;
 pub struct Depth(pub u32);
 
 impl Depth {
-    /// Whether this depth qualifies as a fragment boundary.
+    /// Whether this depth qualifies the commit as an eligible fragment head.
     ///
     /// Commits at depth 0 are ordinary commits that live only in the
     /// shallowest stratum. Any nonzero depth indicates the commit can
-    /// serve as a head or boundary for a fragment at that stratum level.
+    /// head a fragment at that stratum level.
     #[must_use]
     pub const fn is_boundary(&self) -> bool {
         self.0 > 0

--- a/sedimentree_core/src/depth.rs
+++ b/sedimentree_core/src/depth.rs
@@ -35,6 +35,18 @@ use crate::loose_commit::id::CommitId;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Depth(pub u32);
 
+impl Depth {
+    /// Whether this depth qualifies as a fragment boundary.
+    ///
+    /// Commits at depth 0 are ordinary commits that live only in the
+    /// shallowest stratum. Any nonzero depth indicates the commit can
+    /// serve as a head or boundary for a fragment at that stratum level.
+    #[must_use]
+    pub const fn is_boundary(&self) -> bool {
+        self.0 > 0
+    }
+}
+
 impl core::fmt::Display for Depth {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Depth({})", self.0)

--- a/sedimentree_core/src/depth.rs
+++ b/sedimentree_core/src/depth.rs
@@ -4,9 +4,6 @@ use alloc::boxed::Box;
 
 use crate::loose_commit::id::CommitId;
 
-/// The maximum depth of strata that a [`Sedimentree`] can go to.
-pub const MAX_STRATA_DEPTH: Depth = Depth(2);
-
 /// How deep in the Sedimentree a stratum is.
 ///
 /// The greater the depth, the more leading zeros, the (probabilistically) larger,

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -15,7 +15,7 @@ use crate::{
         digest::Digest,
         fingerprint::{Fingerprint, FingerprintSeed},
     },
-    depth::{Depth, DepthMetric, MAX_STRATA_DEPTH},
+    depth::{Depth, DepthMetric},
     fragment::{Fragment, checkpoint::Checkpoint},
     loose_commit::{LooseCommit, id::CommitId},
     topsorted::Topsorted,
@@ -890,16 +890,6 @@ impl From<[u8; 32]> for MinimalTreeHash {
     fn from(value: [u8; 32]) -> Self {
         Self(value)
     }
-}
-
-/// Checks if any of the given commits has a commit boundary.
-pub fn has_commit_boundary<I: IntoIterator<Item = D>, D: Into<CommitId>, M: DepthMetric>(
-    commits: I,
-    depth_metric: &M,
-) -> bool {
-    commits
-        .into_iter()
-        .any(|id| depth_metric.to_depth(id.into()) <= MAX_STRATA_DEPTH)
 }
 
 #[cfg(test)]
@@ -2289,7 +2279,7 @@ mod tests {
     /// ```text
     /// Depth 0:  [0x01, 0x00, ..., N]   — no leading zero bytes
     /// Depth 1:  [0x00, 0x01, ..., N]   — one leading zero byte
-    /// Depth 2+: [0x00, 0x00, 0x01, N]  — two leading zero bytes (≥ MAX_STRATA_DEPTH)
+    /// Depth 2+: [0x00, 0x00, 0x01, N]  — two leading zero bytes (checkpoint depth)
     /// ```
     ///
     /// The trailing byte `N` distinguishes commits at the same depth.
@@ -2327,7 +2317,7 @@ mod tests {
             CommitId::new(b)
         }
 
-        /// Commit identifier at depth 2 (two leading zero bytes, ≥ `MAX_STRATA_DEPTH`).
+        /// Commit identifier at depth 2 (two leading zero bytes, checkpoint depth).
         ///
         /// Layout: `[0, 0, n, 0, ..., 0]` — two leading zeros, then non-zero.
         /// The distinguishing byte `n` is at index 2, well within the

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -11,7 +11,7 @@ use alloc::{vec, vec::Vec};
 
 use crate::{
     collections::{Map, Set},
-    depth::{Depth, DepthMetric},
+    depth::DepthMetric,
     fragment::Fragment,
     loose_commit::{LooseCommit, id::CommitId},
 };
@@ -199,11 +199,6 @@ impl CommitDag {
         // in a block which is covered by at least one stratum in the tree.
 
         // Identify blocks by their end hash and store a mapping from commit hash to block end hash.
-        //
-        // A commit is a "checkpoint" (block boundary) when the depth metric
-        // assigns it depth >= 1 — i.e. it has enough leading zero bytes (or
-        // equivalent metric property) to serve as a fragment head. Commits at
-        // depth 0 are ordinary "loose commits".
         let mut commits_to_blocks = Map::new();
         let mut blockless_commits = Set::new();
 
@@ -217,8 +212,8 @@ impl CommitDag {
             let mut block: Option<(CommitId, Vec<CommitId>)> = None;
             for id in self.reverse_topo(tip) {
                 let depth = strategy.to_depth(id);
-                if depth >= Depth(1) {
-                    // We're in a block and we just found a checkpoint, this must be the start hash
+                if depth.is_boundary() {
+                    // We're in a block and we just found a boundary, this must be the start hash
                     // for the block we're in. Flush the current block and start a new one.
                     if let Some((block, commits)) = block.take() {
                         for commit in commits {
@@ -232,10 +227,10 @@ impl CommitDag {
                     block = Some((id, vec![id]));
                 }
                 if let Some((_, commits)) = &mut block {
-                    if depth < Depth(1) {
+                    if !depth.is_boundary() {
                         commits.push(id);
                     }
-                } else if !commits_to_blocks.contains_key(&id) && depth < Depth(1) {
+                } else if !commits_to_blocks.contains_key(&id) && !depth.is_boundary() {
                     blockless_commits.insert(id);
                 }
             }

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -11,7 +11,7 @@ use alloc::{vec, vec::Vec};
 
 use crate::{
     collections::{Map, Set},
-    depth::{DepthMetric, MAX_STRATA_DEPTH},
+    depth::{Depth, DepthMetric},
     fragment::Fragment,
     loose_commit::{LooseCommit, id::CommitId},
 };
@@ -198,7 +198,12 @@ impl CommitDag {
         // Now, which commits can be discarded? It is any commit which is only
         // in a block which is covered by at least one stratum in the tree.
 
-        // Identify blocks by their end hash and store a mapping from commit hash to block end hash
+        // Identify blocks by their end hash and store a mapping from commit hash to block end hash.
+        //
+        // A commit is a "checkpoint" (block boundary) when the depth metric
+        // assigns it depth >= 1 — i.e. it has enough leading zero bytes (or
+        // equivalent metric property) to serve as a fragment head. Commits at
+        // depth 0 are ordinary "loose commits".
         let mut commits_to_blocks = Map::new();
         let mut blockless_commits = Set::new();
 
@@ -212,7 +217,7 @@ impl CommitDag {
             let mut block: Option<(CommitId, Vec<CommitId>)> = None;
             for id in self.reverse_topo(tip) {
                 let depth = strategy.to_depth(id);
-                if depth >= MAX_STRATA_DEPTH {
+                if depth >= Depth(1) {
                     // We're in a block and we just found a checkpoint, this must be the start hash
                     // for the block we're in. Flush the current block and start a new one.
                     if let Some((block, commits)) = block.take() {
@@ -227,10 +232,10 @@ impl CommitDag {
                     block = Some((id, vec![id]));
                 }
                 if let Some((_, commits)) = &mut block {
-                    if depth < MAX_STRATA_DEPTH {
+                    if depth < Depth(1) {
                         commits.push(id);
                     }
-                } else if !commits_to_blocks.contains_key(&id) && depth < MAX_STRATA_DEPTH {
+                } else if !commits_to_blocks.contains_key(&id) && depth < Depth(1) {
                     blockless_commits.insert(id);
                 }
             }

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -147,8 +147,8 @@ impl CommitDag {
 
     pub(crate) fn simplify<S: DepthMetric>(&self, fragments: &[Fragment], strategy: &S) -> Self {
         // The work here is to identify which parts of a commit DAG can be
-        // discarded based on the strata we have. This is a little bit fiddly.
-        // Imagine this graph:
+        // discarded based on the fragments we have. This is a little bit
+        // fiddly. Imagine this graph:
         //
         //        ┌─┐
         //        │A│
@@ -176,31 +176,36 @@ impl CommitDag {
         //              │G│         │H│
         //              └─┘         └─┘
         //
-        // Let's say we have a checkpoint commit at F, D, I, and A and we have
-        // strata containing A and F, which commits can we discard? Well, we
-        // can't discard G or H because they are not in any blocks. We can't
-        // discard I or B because they are not in any blocks that we have strata
-        // for.
+        // Let's say we have boundary commits at F, D, I, and A, and we
+        // have fragments covering A and F. Which commits can we discard?
+        // We can't discard G or H because they are not in any fragment
+        // range. We can't discard I or B because they are not in any
+        // fragment range that we actually have fragments for.
         //
-        // The invariant we must maintain is that we always have a path from
-        // some commit back to the last checkpoint commit (a commit with two
-        // leading zeros). How do we identify the commits that can be discarded?
+        // The invariant we must maintain is that we always have a path
+        // from some commit back to the last boundary commit. How do we
+        // identify the commits that can be discarded?
         //
-        // If we start from the heads of the graph then we can walk up the graph
-        // in a (reverse) depth first topological sort. First, this allows us to
-        // easily identify which commits are not in a block (a range of commits
-        // bounded by checkpoint commits) - it's all the commits which we
-        // encounter in this traversal before we have ever encountered a
-        // checkpoint commit. This same technique also allows us to identify all
-        // the blocks in the graph and which commits are in each block (note
-        // that a commit can be in multiple blocks).
+        // Walking from the tips in reverse topological order lets us
+        // identify which commits are not in any fragment range (those
+        // encountered before the first boundary commit), and which
+        // fragment ranges exist (ranges bounded by boundary commits).
+        // A commit can appear in multiple ranges.
         //
-        // Now, which commits can be discarded? It is any commit which is only
-        // in a block which is covered by at least one stratum in the tree.
+        // A commit can be discarded when every fragment range it belongs
+        // to is covered by at least one existing fragment.
 
-        // Identify blocks by their end hash and store a mapping from commit hash to block end hash.
-        let mut commits_to_blocks = Map::new();
-        let mut blockless_commits = Set::new();
+        // Identify fragment ranges (runs between boundary commits) and
+        // record which range(s) each commit belongs to. A commit is a
+        // boundary when `Depth::is_boundary` returns true (nonzero depth
+        // from the metric). Commits at depth 0 are ordinary loose commits
+        // that live inside fragment ranges.
+        //
+        // The walk is in reverse topological order (tips → roots), so the
+        // first boundary we encounter is the range's head (newest end)
+        // and subsequent non-boundary commits are its interior.
+        let mut commits_to_ranges = Map::new();
+        let mut rangeless_commits = Set::new();
 
         let mut tips = self.tips().collect::<Vec<_>>();
         tips.sort_by_key(|idx| {
@@ -209,39 +214,40 @@ impl CommitDag {
         });
 
         for tip in tips {
-            let mut block: Option<(CommitId, Vec<CommitId>)> = None;
+            let mut range: Option<(CommitId, Vec<CommitId>)> = None;
             for id in self.reverse_topo(tip) {
                 let depth = strategy.to_depth(id);
                 if depth.is_boundary() {
-                    // We're in a block and we just found a boundary, this must be the start hash
-                    // for the block we're in. Flush the current block and start a new one.
-                    if let Some((block, commits)) = block.take() {
+                    // Found a boundary — flush the current range and start a new one
+                    // keyed by this boundary commit.
+                    if let Some((range_head, commits)) = range.take() {
                         for commit in commits {
-                            blockless_commits.remove(&commit);
-                            commits_to_blocks
+                            rangeless_commits.remove(&commit);
+                            commits_to_ranges
                                 .entry(commit)
                                 .or_insert_with(Vec::new)
-                                .push(block);
+                                .push(range_head);
                         }
                     }
-                    block = Some((id, vec![id]));
+                    range = Some((id, vec![id]));
                 }
-                if let Some((_, commits)) = &mut block {
+                if let Some((_, commits)) = &mut range {
                     if !depth.is_boundary() {
                         commits.push(id);
                     }
-                } else if !commits_to_blocks.contains_key(&id) && !depth.is_boundary() {
-                    blockless_commits.insert(id);
+                } else if !commits_to_ranges.contains_key(&id) && !depth.is_boundary() {
+                    rangeless_commits.insert(id);
                 }
             }
-            // We never found a start hash for this block, so the start must be the root hash
-            if let Some((end, commits)) = block.take() {
-                commits_to_blocks
+            // No boundary was found before reaching the root — treat the
+            // accumulated range as unbounded at its oldest end.
+            if let Some((end, commits)) = range.take() {
+                commits_to_ranges
                     .entry(end)
                     .or_insert_with(Vec::new)
                     .push(end);
                 for commit in commits {
-                    commits_to_blocks
+                    commits_to_ranges
                         .entry(commit)
                         .or_insert_with(Vec::new)
                         .push(end);
@@ -249,20 +255,20 @@ impl CommitDag {
             }
         }
 
-        // The commits we can discard are the ones where the blocks they are in are all supported
-        let remaining_commits = commits_to_blocks
+        // Discard commits whose ranges are all covered by existing fragments.
+        let remaining_commits = commits_to_ranges
             .into_iter()
-            .filter_map(|(commit, blocks)| {
-                if blocks
+            .filter_map(|(commit, ranges)| {
+                if ranges
                     .iter()
-                    .all(|&b| fragments.iter().any(|s| s.supports_block(b)))
+                    .all(|&r| fragments.iter().any(|f| f.supports_block(r)))
                 {
                     None
                 } else {
                     Some(commit)
                 }
             })
-            .chain(blockless_commits)
+            .chain(rangeless_commits)
             .collect::<Vec<_>>();
 
         let nodes = remaining_commits
@@ -465,9 +471,9 @@ mod tests {
         }
     }
 
-    /// No fragments: all commits with depth >= threshold remain as block boundaries.
+    /// No fragments: all boundary commits remain as potential fragment heads.
     #[test]
-    fn simplify_block_boundaries_without_fragments() {
+    fn simplify_fragment_boundaries_without_fragments() {
         let sedimentree_id = make_sedimentree_id(1);
 
         // Create commits: b is root, a has b as parent
@@ -488,14 +494,14 @@ mod tests {
             .commit_ids()
             .collect::<Set<_>>();
 
-        // With no fragments, simplify keeps block boundaries + heads
-        // Both a and b should remain (a is head, b would be pruned but there's no fragment)
+        // With no fragments, simplify keeps boundary commits + heads
+        // Both a and b should remain (a is boundary, b would be pruned but there's no fragment)
         assert_eq!(simplified, Set::from([a_id, b_id]));
     }
 
-    /// Two consecutive block boundary commits (both depth >= threshold).
+    /// Two consecutive boundary commits (both with nonzero depth).
     #[test]
-    fn simplify_consecutive_block_boundary_commits_without_fragments() {
+    fn simplify_consecutive_boundary_commits_without_fragments() {
         let sedimentree_id = make_sedimentree_id(1);
 
         // Create commits: b is root, a has b as parent
@@ -516,7 +522,7 @@ mod tests {
             .commit_ids()
             .collect::<Set<_>>();
 
-        // Both are block boundaries, both remain
+        // Both are boundary commits, both remain
         assert_eq!(simplified, Set::from([a_id, b_id]));
     }
 

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -118,7 +118,7 @@ use sedimentree_core::{
     },
     commit::CountLeadingZeroBytes,
     crypto::{digest::Digest, fingerprint::FingerprintSeed},
-    depth::{Depth, DepthMetric},
+    depth::DepthMetric,
     fragment::Fragment,
     id::SedimentreeId,
     loose_commit::{LooseCommit, id::CommitId},
@@ -1226,7 +1226,7 @@ where
 
         let mut maybe_requested_fragment = None;
         let depth = self.depth_metric.to_depth(commit_head);
-        if depth != Depth(0) {
+        if depth.is_boundary() {
             maybe_requested_fragment = Some(FragmentRequested::new(commit_head, depth));
         }
 

--- a/subduction_core/tests/convergence.rs
+++ b/subduction_core/tests/convergence.rs
@@ -383,7 +383,7 @@ async fn multi_round_convergence_with_fragments() -> TestResult {
 
 /// A depth metric that assigns `Depth(2)` to every commit digest.
 ///
-/// With `MAX_STRATA_DEPTH = Depth(2)`, every commit becomes a checkpoint
+/// With depth 2 assigned to every commit, every commit becomes a checkpoint
 /// (block boundary). This means a fragment whose head/boundary/checkpoints
 /// include a commit's digest will cause `minimize` to prune that commit.
 #[derive(Debug, Clone, Copy, Default)]


### PR DESCRIPTION
Confusingly, it was being used both as a minimum AND a maximum :sweat_smile: Luckily it's completely vestigial since the `DepthMetric` allows users to pick how they want to chunk up a graph, including introducing a "max" (i.e. "and everything else").