### PR TITLE
ACTUALLY bump the `tungstenite` max size

### DIFF
--- a/subduction_cli/src/server.rs
+++ b/subduction_cli/src/server.rs
@@ -692,6 +692,7 @@ async fn handle_websocket(
 ) {
     let mut ws_config = WebSocketConfig::default();
     ws_config.max_message_size = Some(max_message_size);
+    ws_config.max_frame_size = Some(max_message_size);
 
     let ws_stream = match async_tungstenite::tokio::accept_hdr_async_with_config(
         tcp,
@@ -887,6 +888,7 @@ async fn try_connect_ws(
 
     let mut ws_config = WebSocketConfig::default();
     ws_config.max_message_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
+    ws_config.max_frame_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
     let (ws_stream, _resp) =
         async_tungstenite::tokio::connect_async_with_config(uri.clone(), Some(ws_config)).await?;
 

--- a/subduction_websocket/src/tokio/client.rs
+++ b/subduction_websocket/src/tokio/client.rs
@@ -90,6 +90,7 @@ impl<R: Signer<Sendable> + Clone + Send + Sync> TokioWebSocketClient<R> {
         tracing::info!("Connecting to WebSocket server at {address}");
         let mut ws_config = WebSocketConfig::default();
         ws_config.max_message_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
+        ws_config.max_frame_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
         let (ws_stream, _resp) =
             connect_async_with_config(address.clone(), Some(ws_config)).await?;
 

--- a/subduction_websocket/src/tokio/server.rs
+++ b/subduction_websocket/src/tokio/server.rs
@@ -157,6 +157,7 @@ where
                                     async move {
                                         let mut ws_config = WebSocketConfig::default();
                                         ws_config.max_message_size = Some(max_message_size);
+                                        ws_config.max_frame_size = Some(max_message_size);
 
                                         // Step 1: WebSocket protocol upgrade
                                         let ws_stream = match accept_hdr_async_with_config(tcp, NoCallback, Some(ws_config)).await {
@@ -371,6 +372,7 @@ where
 
         let mut ws_config = WebSocketConfig::default();
         ws_config.max_message_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
+        ws_config.max_frame_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
         let (ws_stream, _resp) = connect_async_with_config(uri, Some(ws_config))
             .await
             .map_err(TryConnectError::WebSocket)?;
@@ -480,6 +482,7 @@ where
 
         let mut ws_config = WebSocketConfig::default();
         ws_config.max_message_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
+        ws_config.max_frame_size = Some(DEFAULT_MAX_MESSAGE_SIZE);
         let (ws_stream, _resp) = connect_async_with_config(uri, Some(ws_config))
             .await
             .map_err(TryConnectError::WebSocket)?;


### PR DESCRIPTION
I'm still seeing messages like this in the server logs:

```console
Apr 10 23:19:37 bedrock-subduction subduction_cli[947704]: 2026-04-10T23:19:37.625236Z ERROR subduction_websocket::websocket: error reading from websocket: Space limit exceeded: Message too long: 21596597 > 16777216
Apr 10 23:19:39 bedrock-subduction subduction_cli[947704]: 2026-04-10T23:19:39.597853Z ERROR subduction_websocket::websocket: error reading from websocket: Space limit exceeded: Message too long: 21596597 > 16777216
Apr 10 23:19:39 bedrock-subduction subduction_cli[947704]: 2026-04-10T23:19:39.654773Z ERROR subduction_websocket::websocket: error reading from websocket: Space limit exceeded: Message too long: 21596597 > 16777216 
```

I thought that I had fixed this, but evidently I had missed a config option :weary: 