### PR TITLE
Improve `minimize` performance

### DIFF
--- a/automerge_sedimentree/tests/real_world_ingestion.rs
+++ b/automerge_sedimentree/tests/real_world_ingestion.rs
@@ -519,39 +519,16 @@ fn fingerprint_summary_includes_all_items_after_ingestion() {
 /// verifying that the recovered document has the same heads and change
 /// count as the original.
 ///
-/// **Currently fails on documents where `ingest` produces multiple
-/// fragments at compatible depths.** Verified pre-existing on pristine
-/// `main` (the perf/minimize work did not introduce this).
+/// This is the most direct correctness test for `Sedimentree::minimize`
+/// in the Automerge use case: minimize must never drop a fragment whose
+/// blob data isn't physically contained in some kept fragment's blob.
 ///
-/// Root cause (preliminary diagnosis 2026-05-06):
-///
-/// `Sedimentree::minimize` drops a fragment F when F's head and boundary
-/// `CommitId`s appear in the running `supported: Set<Checkpoint>` accumulated
-/// from kept fragments' `head ∪ boundary ∪ checkpoints`. This is a
-/// *structural* dominance check on identifiers, but says nothing about
-/// whether F's *blob contents* (the actual change data for F's `members`)
-/// are also represented in any kept fragment's blob.
-///
-/// `automerge_sedimentree::ingest::compress_one_fragment` produces a
-/// fragment's blob from *only* its own member changes. So when minimize
-/// drops F based on structural dominance, F's blob — and thus its
-/// constituent Automerge changes — are no longer reachable from the
-/// kept tree, even though kept tree's metadata "knows about" F's
-/// boundary commits.
-///
-/// Concrete failure: A1 ingest produces 7 fragments. `minimize` keeps
-/// only 2–3 of them (varies by mutual-dominance resolution). The
-/// reassembled document has zero heads — `load_incremental` accepts the
-/// kept fragments' blobs but can't link them up because their dependency
-/// changes are inside the dropped fragments' blobs.
-///
-/// This is a real correctness issue but out of scope for the
-/// `perf/minimize` branch. Tracked in `.ignore/FIXME.md`. The S1/S2/S3
-/// vectors pass because they have 0 fragments (so minimize is a no-op).
-///
-/// Until fixed, this helper is `#[ignore]`d on the multi-fragment
-/// vectors. The S* tests run unconditionally to guard against
-/// regression on the no-fragment case.
+/// Regression coverage for the fix that requires *strict-deeper*
+/// dominance (or exact-equality) before a fragment is dropped. The
+/// previous "structural reachability of head + boundary in any kept
+/// fragment's `head ∪ boundary ∪ checkpoints`" check was unsafe for
+/// merge-heavy docs (typical Automerge workload) where many same-depth
+/// fragments cross-reference each other's heads in their boundaries.
 fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
     let doc = Automerge::load(bytes).expect(name);
     let original_heads = doc.get_heads();
@@ -662,31 +639,181 @@ fn ingest_minimize_roundtrip_s3() {
 }
 
 #[test]
-#[ignore = "fails on multi-fragment docs: minimize structural dominance \
-            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+#[cfg_attr(debug_assertions, ignore = "too slow in debug mode")]
 fn ingest_minimize_roundtrip_a1() {
     ingest_minimize_roundtrip("A1", include_bytes!("../test-vectors/A1.am"));
 }
 
 #[test]
-#[ignore = "fails on multi-fragment docs: minimize structural dominance \
-            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+#[cfg_attr(debug_assertions, ignore = "too slow in debug mode")]
 fn ingest_minimize_roundtrip_a2() {
     ingest_minimize_roundtrip("A2", include_bytes!("../test-vectors/A2.am"));
 }
 
 #[test]
-#[ignore = "fails on multi-fragment docs: minimize structural dominance \
-            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+#[cfg_attr(debug_assertions, ignore = "too slow in debug mode")]
 fn ingest_minimize_roundtrip_c1() {
     ingest_minimize_roundtrip("C1", include_bytes!("../test-vectors/C1.am"));
 }
 
 #[test]
-#[ignore = "fails on multi-fragment docs: minimize structural dominance \
-            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+#[cfg_attr(debug_assertions, ignore = "too slow in debug mode")]
 fn ingest_minimize_roundtrip_c2() {
     ingest_minimize_roundtrip("C2", include_bytes!("../test-vectors/C2.am"));
+}
+
+/// Snapshot of structural metrics for each test vector.
+///
+/// Pins the expected (change_count, fragment_count, uncovered_count)
+/// triple for the egwalker vectors. Drift in any of these signals a
+/// behavioural change in `ingest_automerge` or its dependencies
+/// (`build_fragment_store`, `CountLeadingZeroBytes`).
+///
+/// These are *snapshots* — when intentional changes shift these
+/// numbers, update the table and explain why in the commit message.
+#[test]
+#[cfg_attr(debug_assertions, ignore = "needs get_changes; release-only")]
+fn egwalker_vector_snapshots() {
+    /// `(name, bytes, expected_changes, expected_fragments, expected_uncovered)`
+    const SNAPSHOTS: &[(&str, &[u8], usize, usize, usize)] = &[
+        (
+            "S1",
+            include_bytes!("../test-vectors/S1.am"),
+            2,
+            0,
+            2,
+        ),
+        (
+            "S2",
+            include_bytes!("../test-vectors/S2.am"),
+            2,
+            0,
+            2,
+        ),
+        (
+            "S3",
+            include_bytes!("../test-vectors/S3.am"),
+            2,
+            0,
+            2,
+        ),
+        (
+            "A1",
+            include_bytes!("../test-vectors/A1.am"),
+            956,
+            7,
+            184,
+        ),
+        (
+            "A2",
+            include_bytes!("../test-vectors/A2.am"),
+            3208,
+            8,
+            228,
+        ),
+        (
+            "C1",
+            include_bytes!("../test-vectors/C1.am"),
+            93152,
+            380,
+            564,
+        ),
+        (
+            "C2",
+            include_bytes!("../test-vectors/C2.am"),
+            134477,
+            542,
+            0,
+        ),
+    ];
+
+    for (name, bytes, exp_changes, exp_fragments, exp_uncovered) in SNAPSHOTS {
+        let doc = Automerge::load(bytes).expect(name);
+        let d = decompose_meta(&doc);
+        assert_eq!(
+            d.change_count, *exp_changes,
+            "{name}: change_count drift (got {} expected {exp_changes})",
+            d.change_count
+        );
+        assert_eq!(
+            d.fragment_count, *exp_fragments,
+            "{name}: fragment_count drift (got {} expected {exp_fragments})",
+            d.fragment_count
+        );
+        assert_eq!(
+            d.uncovered_count, *exp_uncovered,
+            "{name}: uncovered_count drift (got {} expected {exp_uncovered})",
+            d.uncovered_count
+        );
+    }
+}
+
+/// Snapshot of `MinimalTreeHash` for each test vector after ingest +
+/// minimize.
+///
+/// This is the strongest possible regression test for sync-correctness:
+/// `MinimalTreeHash` is the canonical content-addressed identity of a
+/// minimized tree. Two peers with identical content must compute
+/// identical hashes for the sync protocol to work. If `minimize` ever
+/// changes its output for these vectors, this test fires and the
+/// expected-hash table needs to be updated alongside an explanation.
+///
+/// Pinned hashes also confirm that `minimize` is deterministic across
+/// runs (within and across processes) for these vectors — a regression
+/// against the determinism fix would surface here.
+#[test]
+#[cfg_attr(debug_assertions, ignore = "needs get_changes; release-only")]
+fn egwalker_minimal_hash_snapshots() {
+    use sedimentree_core::sedimentree::MinimalTreeHash;
+
+    /// `(name, bytes, expected_hash_hex)`
+    const SNAPSHOTS: &[(&str, &[u8])] = &[
+        ("S1", include_bytes!("../test-vectors/S1.am")),
+        ("S2", include_bytes!("../test-vectors/S2.am")),
+        ("S3", include_bytes!("../test-vectors/S3.am")),
+        ("A1", include_bytes!("../test-vectors/A1.am")),
+        ("A2", include_bytes!("../test-vectors/A2.am")),
+        ("C1", include_bytes!("../test-vectors/C1.am")),
+        ("C2", include_bytes!("../test-vectors/C2.am")),
+    ];
+
+    for (name, bytes) in SNAPSHOTS {
+        let doc = Automerge::load(bytes).expect(name);
+        let sed_id = sed_id(bytes);
+        let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id)
+            .expect("ingest");
+
+        // Compute hash twice and assert determinism within this run.
+        let h1: MinimalTreeHash = result.sedimentree.minimal_hash(&CountLeadingZeroBytes);
+        let h2: MinimalTreeHash = result.sedimentree.minimal_hash(&CountLeadingZeroBytes);
+        assert_eq!(
+            h1.as_bytes(),
+            h2.as_bytes(),
+            "{name}: minimal_hash differs across consecutive calls within one process \
+             — DETERMINISM REGRESSION",
+        );
+
+        // Re-ingest and re-hash. With the perf/minimize determinism fix
+        // these should match, since the underlying ingest result depends
+        // only on the document bytes.
+        let result2 = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id)
+            .expect("re-ingest");
+        let h3: MinimalTreeHash = result2.sedimentree.minimal_hash(&CountLeadingZeroBytes);
+        assert_eq!(
+            h1.as_bytes(),
+            h3.as_bytes(),
+            "{name}: minimal_hash differs across re-ingest in one process \
+             — likely a determinism issue",
+        );
+
+        // Hex-encode for diagnostic output.
+        let mut hex = String::with_capacity(64);
+        for b in h1.as_bytes() {
+            use core::fmt::Write;
+            write!(&mut hex, "{b:02x}").unwrap();
+        }
+        eprintln!("{name}: minimal_hash = {hex}");
+    }
 }
 
 /// Stress: minimize twice and confirm the round-trip still works.

--- a/automerge_sedimentree/tests/real_world_ingestion.rs
+++ b/automerge_sedimentree/tests/real_world_ingestion.rs
@@ -662,7 +662,7 @@ fn ingest_minimize_roundtrip_c2() {
 
 /// Snapshot of structural metrics for each test vector.
 ///
-/// Pins the expected (change_count, fragment_count, uncovered_count)
+/// Pins the expected (`change_count`, `fragment_count`, `uncovered_count`)
 /// triple for the egwalker vectors. Drift in any of these signals a
 /// behavioural change in `ingest_automerge` or its dependencies
 /// (`build_fragment_store`, `CountLeadingZeroBytes`).
@@ -678,18 +678,18 @@ fn egwalker_vector_snapshots() {
         ("S2", include_bytes!("../test-vectors/S2.am"), 2, 0, 2),
         ("S3", include_bytes!("../test-vectors/S3.am"), 2, 0, 2),
         ("A1", include_bytes!("../test-vectors/A1.am"), 956, 7, 184),
-        ("A2", include_bytes!("../test-vectors/A2.am"), 3208, 8, 228),
+        ("A2", include_bytes!("../test-vectors/A2.am"), 3_208, 8, 228),
         (
             "C1",
             include_bytes!("../test-vectors/C1.am"),
-            93152,
+            93_152,
             380,
             564,
         ),
         (
             "C2",
             include_bytes!("../test-vectors/C2.am"),
-            134477,
+            134_477,
             542,
             0,
         ),

--- a/automerge_sedimentree/tests/real_world_ingestion.rs
+++ b/automerge_sedimentree/tests/real_world_ingestion.rs
@@ -515,6 +515,229 @@ fn fingerprint_summary_includes_all_items_after_ingestion() {
     );
 }
 
+/// Round-trip an Automerge document through ingest → minimize → reassemble,
+/// verifying that the recovered document has the same heads and change
+/// count as the original.
+///
+/// **Currently fails on documents where `ingest` produces multiple
+/// fragments at compatible depths.** Verified pre-existing on pristine
+/// `main` (the perf/minimize work did not introduce this).
+///
+/// Root cause (preliminary diagnosis 2026-05-06):
+///
+/// `Sedimentree::minimize` drops a fragment F when F's head and boundary
+/// `CommitId`s appear in the running `supported: Set<Checkpoint>` accumulated
+/// from kept fragments' `head ∪ boundary ∪ checkpoints`. This is a
+/// *structural* dominance check on identifiers, but says nothing about
+/// whether F's *blob contents* (the actual change data for F's `members`)
+/// are also represented in any kept fragment's blob.
+///
+/// `automerge_sedimentree::ingest::compress_one_fragment` produces a
+/// fragment's blob from *only* its own member changes. So when minimize
+/// drops F based on structural dominance, F's blob — and thus its
+/// constituent Automerge changes — are no longer reachable from the
+/// kept tree, even though kept tree's metadata "knows about" F's
+/// boundary commits.
+///
+/// Concrete failure: A1 ingest produces 7 fragments. `minimize` keeps
+/// only 2–3 of them (varies by mutual-dominance resolution). The
+/// reassembled document has zero heads — `load_incremental` accepts the
+/// kept fragments' blobs but can't link them up because their dependency
+/// changes are inside the dropped fragments' blobs.
+///
+/// This is a real correctness issue but out of scope for the
+/// `perf/minimize` branch. Tracked in `.ignore/FIXME.md`. The S1/S2/S3
+/// vectors pass because they have 0 fragments (so minimize is a no-op).
+///
+/// Until fixed, this helper is `#[ignore]`d on the multi-fragment
+/// vectors. The S* tests run unconditionally to guard against
+/// regression on the no-fragment case.
+fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
+    let doc = Automerge::load(bytes).expect(name);
+    let original_heads = doc.get_heads();
+    let original_count = doc.get_changes(&[]).len();
+
+    let sed_id = sed_id(bytes);
+    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
+
+    // Apply minimize.
+    let minimized = result
+        .sedimentree
+        .minimize(&CountLeadingZeroBytes);
+
+    // The blobs collected during ingest are still our source of truth
+    // for raw bytes — `minimize` removes Sedimentree entries but doesn't
+    // touch blob storage. Build the digest → bytes map from `result.blobs`.
+    let blob_by_digest: Map<Digest<Blob>, &[u8]> = result
+        .blobs
+        .iter()
+        .map(|blob| (Digest::hash(blob), blob.as_slice()))
+        .collect();
+
+    // For every kept item in the minimized tree, look up its blob and
+    // verify it's available. (Any reachable blob must be stored — if a
+    // blob is missing, minimize has implicitly orphaned data.)
+    let kept_fragments: Vec<_> = minimized.fragments().collect();
+    let kept_loose: Vec<_> = minimized.loose_commits().collect();
+
+    for f in &kept_fragments {
+        let d = f.summary().blob_meta().digest();
+        assert!(
+            blob_by_digest.contains_key(&d),
+            "{name}: minimized fragment references blob {d:?} we don't have",
+        );
+    }
+    for c in &kept_loose {
+        let d = c.blob_meta().digest();
+        assert!(
+            blob_by_digest.contains_key(&d),
+            "{name}: minimized loose commit references blob {d:?} we don't have",
+        );
+    }
+
+    // Reassemble the document by topsorting the *minimized* tree and
+    // concatenating each item's blob bytes.
+    let order = minimized
+        .topsorted_blob_order()
+        .expect("no cycles in minimized tree");
+
+    let mut buf = Vec::new();
+    for item in &order {
+        let digest = match item {
+            SedimentreeItem::Fragment(i) => kept_fragments[*i].summary().blob_meta().digest(),
+            SedimentreeItem::LooseCommit(i) => kept_loose[*i].blob_meta().digest(),
+        };
+        let raw = blob_by_digest
+            .get(&digest)
+            .unwrap_or_else(|| panic!("{name}: blob not found for {item:?}"));
+        buf.extend_from_slice(raw);
+    }
+
+    let mut rebuilt = Automerge::new();
+    rebuilt
+        .load_incremental(&buf)
+        .expect("load minimized blobs");
+
+    assert_eq!(
+        rebuilt.get_heads(),
+        original_heads,
+        "{name}: heads diverged after minimize round-trip \
+         (ingest produced {} fragments / {} loose; \
+          after minimize {} fragments / {} loose)",
+        result.fragment_count,
+        result.loose_count,
+        kept_fragments.len(),
+        kept_loose.len(),
+    );
+    assert_eq!(
+        rebuilt.get_changes(&[]).len(),
+        original_count,
+        "{name}: change count diverged after minimize round-trip \
+         (original={original_count}, rebuilt={})",
+        rebuilt.get_changes(&[]).len(),
+    );
+
+    // Spot-check that the rebuilt doc agrees on the root keyset.
+    let orig_keys: Vec<_> = doc.keys(&ROOT).collect();
+    let rebuilt_keys: Vec<_> = rebuilt.keys(&ROOT).collect();
+    assert_eq!(
+        orig_keys, rebuilt_keys,
+        "{name}: root keys diverged after minimize round-trip",
+    );
+}
+
+#[test]
+fn ingest_minimize_roundtrip_s1() {
+    ingest_minimize_roundtrip("S1", include_bytes!("../test-vectors/S1.am"));
+}
+
+#[test]
+fn ingest_minimize_roundtrip_s2() {
+    ingest_minimize_roundtrip("S2", include_bytes!("../test-vectors/S2.am"));
+}
+
+#[test]
+fn ingest_minimize_roundtrip_s3() {
+    ingest_minimize_roundtrip("S3", include_bytes!("../test-vectors/S3.am"));
+}
+
+#[test]
+#[ignore = "fails on multi-fragment docs: minimize structural dominance \
+            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+fn ingest_minimize_roundtrip_a1() {
+    ingest_minimize_roundtrip("A1", include_bytes!("../test-vectors/A1.am"));
+}
+
+#[test]
+#[ignore = "fails on multi-fragment docs: minimize structural dominance \
+            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+fn ingest_minimize_roundtrip_a2() {
+    ingest_minimize_roundtrip("A2", include_bytes!("../test-vectors/A2.am"));
+}
+
+#[test]
+#[ignore = "fails on multi-fragment docs: minimize structural dominance \
+            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+fn ingest_minimize_roundtrip_c1() {
+    ingest_minimize_roundtrip("C1", include_bytes!("../test-vectors/C1.am"));
+}
+
+#[test]
+#[ignore = "fails on multi-fragment docs: minimize structural dominance \
+            doesn't imply blob-level data preservation. See test docs + FIXME.md"]
+fn ingest_minimize_roundtrip_c2() {
+    ingest_minimize_roundtrip("C2", include_bytes!("../test-vectors/C2.am"));
+}
+
+/// Stress: minimize twice and confirm the round-trip still works.
+/// Re-minimization on already-minimized output must remain stable;
+/// regression coverage for the determinism fix at the Automerge level.
+#[test]
+fn ingest_double_minimize_roundtrip_s1() {
+    let bytes = include_bytes!("../test-vectors/S1.am");
+    let doc = Automerge::load(bytes).expect("S1");
+    let original_heads = doc.get_heads();
+
+    let sed_id = sed_id(bytes);
+    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
+
+    let once = result.sedimentree.minimize(&CountLeadingZeroBytes);
+    let twice = once.minimize(&CountLeadingZeroBytes);
+    assert_eq!(
+        once, twice,
+        "minimize is not idempotent on real Automerge document",
+    );
+
+    // And the round-trip still works on the doubly-minimized tree.
+    let blob_by_digest: Map<Digest<Blob>, &[u8]> = result
+        .blobs
+        .iter()
+        .map(|blob| (Digest::hash(blob), blob.as_slice()))
+        .collect();
+
+    let kept_fragments: Vec<_> = twice.fragments().collect();
+    let kept_loose: Vec<_> = twice.loose_commits().collect();
+
+    let order = twice.topsorted_blob_order().expect("no cycles");
+    let mut buf = Vec::new();
+    for item in &order {
+        let digest = match item {
+            SedimentreeItem::Fragment(i) => kept_fragments[*i].summary().blob_meta().digest(),
+            SedimentreeItem::LooseCommit(i) => kept_loose[*i].blob_meta().digest(),
+        };
+        let raw = blob_by_digest
+            .get(&digest)
+            .expect("blob not found after double minimize");
+        buf.extend_from_slice(raw);
+    }
+
+    let mut rebuilt = Automerge::new();
+    rebuilt
+        .load_incremental(&buf)
+        .expect("load double-minimized");
+    assert_eq!(rebuilt.get_heads(), original_heads, "heads diverged after double minimize");
+}
+
 /// Ingest A2 (3,208 changes) via the production `ingest_automerge` API
 /// and verify the roundtrip: topsorted reassembly must produce the same
 /// document heads and change count.

--- a/automerge_sedimentree/tests/real_world_ingestion.rs
+++ b/automerge_sedimentree/tests/real_world_ingestion.rs
@@ -538,9 +538,7 @@ fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
     let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
 
     // Apply minimize.
-    let minimized = result
-        .sedimentree
-        .minimize(&CountLeadingZeroBytes);
+    let minimized = result.sedimentree.minimize(&CountLeadingZeroBytes);
 
     // The blobs collected during ingest are still our source of truth
     // for raw bytes — `minimize` removes Sedimentree entries but doesn't
@@ -676,41 +674,11 @@ fn ingest_minimize_roundtrip_c2() {
 fn egwalker_vector_snapshots() {
     /// `(name, bytes, expected_changes, expected_fragments, expected_uncovered)`
     const SNAPSHOTS: &[(&str, &[u8], usize, usize, usize)] = &[
-        (
-            "S1",
-            include_bytes!("../test-vectors/S1.am"),
-            2,
-            0,
-            2,
-        ),
-        (
-            "S2",
-            include_bytes!("../test-vectors/S2.am"),
-            2,
-            0,
-            2,
-        ),
-        (
-            "S3",
-            include_bytes!("../test-vectors/S3.am"),
-            2,
-            0,
-            2,
-        ),
-        (
-            "A1",
-            include_bytes!("../test-vectors/A1.am"),
-            956,
-            7,
-            184,
-        ),
-        (
-            "A2",
-            include_bytes!("../test-vectors/A2.am"),
-            3208,
-            8,
-            228,
-        ),
+        ("S1", include_bytes!("../test-vectors/S1.am"), 2, 0, 2),
+        ("S2", include_bytes!("../test-vectors/S2.am"), 2, 0, 2),
+        ("S3", include_bytes!("../test-vectors/S3.am"), 2, 0, 2),
+        ("A1", include_bytes!("../test-vectors/A1.am"), 956, 7, 184),
+        ("A2", include_bytes!("../test-vectors/A2.am"), 3208, 8, 228),
         (
             "C1",
             include_bytes!("../test-vectors/C1.am"),
@@ -766,22 +734,51 @@ fn egwalker_vector_snapshots() {
 fn egwalker_minimal_hash_snapshots() {
     use sedimentree_core::sedimentree::MinimalTreeHash;
 
-    /// `(name, bytes, expected_hash_hex)`
-    const SNAPSHOTS: &[(&str, &[u8])] = &[
-        ("S1", include_bytes!("../test-vectors/S1.am")),
-        ("S2", include_bytes!("../test-vectors/S2.am")),
-        ("S3", include_bytes!("../test-vectors/S3.am")),
-        ("A1", include_bytes!("../test-vectors/A1.am")),
-        ("A2", include_bytes!("../test-vectors/A2.am")),
-        ("C1", include_bytes!("../test-vectors/C1.am")),
-        ("C2", include_bytes!("../test-vectors/C2.am")),
+    /// `(name, bytes, expected_hash_hex)` — pinned post-fix.
+    /// If `minimize` ever changes its output for these vectors,
+    /// update the table and explain why in the commit message.
+    const SNAPSHOTS: &[(&str, &[u8], &str)] = &[
+        (
+            "S1",
+            include_bytes!("../test-vectors/S1.am"),
+            "eb4edf5719382f067537124deec2696937125cb11ba0fd7f4e54d9abf36282ad",
+        ),
+        (
+            "S2",
+            include_bytes!("../test-vectors/S2.am"),
+            "455c9e3a257f1eae359403408e22347c6856ae60fe00262ddc7a8e7da5c619bd",
+        ),
+        (
+            "S3",
+            include_bytes!("../test-vectors/S3.am"),
+            "ea65d7e84b1b1cc0b0a536ab4d02cbedace6d21aaa033c626ad768fad275bc6b",
+        ),
+        (
+            "A1",
+            include_bytes!("../test-vectors/A1.am"),
+            "55cd0bf902a8f515b50ab8353c8668a89dd1c0a2f38b4e7992ee052eba0b9959",
+        ),
+        (
+            "A2",
+            include_bytes!("../test-vectors/A2.am"),
+            "813d197c265e3d72ab7147491ad2d735dc5c5bfad9c351f57891dad45eb6bcfd",
+        ),
+        (
+            "C1",
+            include_bytes!("../test-vectors/C1.am"),
+            "1aeb3a9f1f7220af7dc91dcdc62e96005d15a78091e115292d0584e7b0e421ec",
+        ),
+        (
+            "C2",
+            include_bytes!("../test-vectors/C2.am"),
+            "c2af810d5ceabd50154ed26f81d9f313962de4d9fade24d332d54a9884c3a480",
+        ),
     ];
 
-    for (name, bytes) in SNAPSHOTS {
+    for (name, bytes, expected_hex) in SNAPSHOTS {
         let doc = Automerge::load(bytes).expect(name);
         let sed_id = sed_id(bytes);
-        let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id)
-            .expect("ingest");
+        let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
 
         // Compute hash twice and assert determinism within this run.
         let h1: MinimalTreeHash = result.sedimentree.minimal_hash(&CountLeadingZeroBytes);
@@ -793,26 +790,29 @@ fn egwalker_minimal_hash_snapshots() {
              — DETERMINISM REGRESSION",
         );
 
-        // Re-ingest and re-hash. With the perf/minimize determinism fix
-        // these should match, since the underlying ingest result depends
-        // only on the document bytes.
-        let result2 = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id)
-            .expect("re-ingest");
+        // Re-ingest and re-hash. Should match — ingest is a function of
+        // the document bytes alone.
+        let result2 =
+            automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("re-ingest");
         let h3: MinimalTreeHash = result2.sedimentree.minimal_hash(&CountLeadingZeroBytes);
         assert_eq!(
             h1.as_bytes(),
             h3.as_bytes(),
             "{name}: minimal_hash differs across re-ingest in one process \
-             — likely a determinism issue",
+             — DETERMINISM REGRESSION",
         );
 
-        // Hex-encode for diagnostic output.
+        // Compare against pinned snapshot.
         let mut hex = String::with_capacity(64);
         for b in h1.as_bytes() {
             use core::fmt::Write;
             write!(&mut hex, "{b:02x}").unwrap();
         }
-        eprintln!("{name}: minimal_hash = {hex}");
+        assert_eq!(
+            hex, *expected_hex,
+            "{name}: minimal_hash drift from pinned snapshot. \
+             If this is intentional, update the SNAPSHOTS table and explain why."
+        );
     }
 }
 
@@ -862,7 +862,11 @@ fn ingest_double_minimize_roundtrip_s1() {
     rebuilt
         .load_incremental(&buf)
         .expect("load double-minimized");
-    assert_eq!(rebuilt.get_heads(), original_heads, "heads diverged after double minimize");
+    assert_eq!(
+        rebuilt.get_heads(),
+        original_heads,
+        "heads diverged after double minimize"
+    );
 }
 
 /// Ingest A2 (3,208 changes) via the production `ingest_automerge` API

--- a/automerge_sedimentree/tests/real_world_ingestion.rs
+++ b/automerge_sedimentree/tests/real_world_ingestion.rs
@@ -515,20 +515,10 @@ fn fingerprint_summary_includes_all_items_after_ingestion() {
     );
 }
 
-/// Round-trip an Automerge document through ingest → minimize → reassemble,
-/// verifying that the recovered document has the same heads and change
-/// count as the original.
-///
-/// This is the most direct correctness test for `Sedimentree::minimize`
-/// in the Automerge use case: minimize must never drop a fragment whose
-/// blob data isn't physically contained in some kept fragment's blob.
-///
-/// Regression coverage for the fix that requires *strict-deeper*
-/// dominance (or exact-equality) before a fragment is dropped. The
-/// previous "structural reachability of head + boundary in any kept
-/// fragment's `head ∪ boundary ∪ checkpoints`" check was unsafe for
-/// merge-heavy docs (typical Automerge workload) where many same-depth
-/// fragments cross-reference each other's heads in their boundaries.
+/// Ingest → minimize → reassemble round-trip. The most direct
+/// correctness test for `Sedimentree::minimize` in the Automerge use
+/// case: `minimize` must never drop a fragment whose blob data isn't
+/// physically contained in some kept fragment's blob.
 fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
     let doc = Automerge::load(bytes).expect(name);
     let original_heads = doc.get_heads();
@@ -536,25 +526,22 @@ fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
 
     let sed_id = sed_id(bytes);
     let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
-
-    // Apply minimize.
     let minimized = result.sedimentree.minimize(&CountLeadingZeroBytes);
 
-    // The blobs collected during ingest are still our source of truth
-    // for raw bytes — `minimize` removes Sedimentree entries but doesn't
-    // touch blob storage. Build the digest → bytes map from `result.blobs`.
+    // `minimize` only prunes Sedimentree entries; blob storage is
+    // unaffected, so all blobs collected during ingest are still
+    // addressable.
     let blob_by_digest: Map<Digest<Blob>, &[u8]> = result
         .blobs
         .iter()
         .map(|blob| (Digest::hash(blob), blob.as_slice()))
         .collect();
 
-    // For every kept item in the minimized tree, look up its blob and
-    // verify it's available. (Any reachable blob must be stored — if a
-    // blob is missing, minimize has implicitly orphaned data.)
     let kept_fragments: Vec<_> = minimized.fragments().collect();
     let kept_loose: Vec<_> = minimized.loose_commits().collect();
 
+    // Every kept item must reference a blob we have. A miss means
+    // `minimize` orphaned data.
     for f in &kept_fragments {
         let d = f.summary().blob_meta().digest();
         assert!(
@@ -570,8 +557,6 @@ fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
         );
     }
 
-    // Reassemble the document by topsorting the *minimized* tree and
-    // concatenating each item's blob bytes.
     let order = minimized
         .topsorted_blob_order()
         .expect("no cycles in minimized tree");
@@ -612,7 +597,6 @@ fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
         rebuilt.get_changes(&[]).len(),
     );
 
-    // Spot-check that the rebuilt doc agrees on the root keyset.
     let orig_keys: Vec<_> = doc.keys(&ROOT).collect();
     let rebuilt_keys: Vec<_> = rebuilt.keys(&ROOT).collect();
     assert_eq!(
@@ -660,15 +644,10 @@ fn ingest_minimize_roundtrip_c2() {
     ingest_minimize_roundtrip("C2", include_bytes!("../test-vectors/C2.am"));
 }
 
-/// Snapshot of structural metrics for each test vector.
-///
-/// Pins the expected (`change_count`, `fragment_count`, `uncovered_count`)
-/// triple for the egwalker vectors. Drift in any of these signals a
-/// behavioural change in `ingest_automerge` or its dependencies
-/// (`build_fragment_store`, `CountLeadingZeroBytes`).
-///
-/// These are *snapshots* — when intentional changes shift these
-/// numbers, update the table and explain why in the commit message.
+/// Pins (`change_count`, `fragment_count`, `uncovered_count`) for each
+/// egwalker vector. Drift signals a behavioural change in
+/// `ingest_automerge` or `build_fragment_store`/`CountLeadingZeroBytes`.
+/// Update the table when shifting numbers intentionally.
 #[test]
 #[cfg_attr(debug_assertions, ignore = "needs get_changes; release-only")]
 fn egwalker_vector_snapshots() {
@@ -716,19 +695,13 @@ fn egwalker_vector_snapshots() {
     }
 }
 
-/// Snapshot of `MinimalTreeHash` for each test vector after ingest +
-/// minimize.
-///
-/// This is the strongest possible regression test for sync-correctness:
-/// `MinimalTreeHash` is the canonical content-addressed identity of a
-/// minimized tree. Two peers with identical content must compute
-/// identical hashes for the sync protocol to work. If `minimize` ever
-/// changes its output for these vectors, this test fires and the
-/// expected-hash table needs to be updated alongside an explanation.
-///
-/// Pinned hashes also confirm that `minimize` is deterministic across
-/// runs (within and across processes) for these vectors — a regression
-/// against the determinism fix would surface here.
+/// Pins `MinimalTreeHash` for each egwalker vector after ingest +
+/// minimize. The strongest sync-correctness regression test:
+/// `MinimalTreeHash` is the canonical content-addressed identity, so
+/// two peers with identical content must compute identical values.
+/// Also catches determinism regressions, since the hash depends on
+/// `minimize`'s output. Update the table when intentional behaviour
+/// changes shift these.
 #[test]
 #[cfg_attr(debug_assertions, ignore = "needs get_changes; release-only")]
 fn egwalker_minimal_hash_snapshots() {
@@ -780,7 +753,7 @@ fn egwalker_minimal_hash_snapshots() {
         let sed_id = sed_id(bytes);
         let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
 
-        // Compute hash twice and assert determinism within this run.
+        // Determinism within a single ingest result.
         let h1: MinimalTreeHash = result.sedimentree.minimal_hash(&CountLeadingZeroBytes);
         let h2: MinimalTreeHash = result.sedimentree.minimal_hash(&CountLeadingZeroBytes);
         assert_eq!(
@@ -790,8 +763,7 @@ fn egwalker_minimal_hash_snapshots() {
              — DETERMINISM REGRESSION",
         );
 
-        // Re-ingest and re-hash. Should match — ingest is a function of
-        // the document bytes alone.
+        // Determinism across re-ingest of the same document bytes.
         let result2 =
             automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("re-ingest");
         let h3: MinimalTreeHash = result2.sedimentree.minimal_hash(&CountLeadingZeroBytes);
@@ -802,7 +774,6 @@ fn egwalker_minimal_hash_snapshots() {
              — DETERMINISM REGRESSION",
         );
 
-        // Compare against pinned snapshot.
         let mut hex = String::with_capacity(64);
         for b in h1.as_bytes() {
             use core::fmt::Write;
@@ -816,9 +787,8 @@ fn egwalker_minimal_hash_snapshots() {
     }
 }
 
-/// Stress: minimize twice and confirm the round-trip still works.
-/// Re-minimization on already-minimized output must remain stable;
-/// regression coverage for the determinism fix at the Automerge level.
+/// Minimize twice, then round-trip. Pins idempotence at the Automerge
+/// level — regression coverage for the determinism fix.
 #[test]
 fn ingest_double_minimize_roundtrip_s1() {
     let bytes = include_bytes!("../test-vectors/S1.am");
@@ -835,7 +805,6 @@ fn ingest_double_minimize_roundtrip_s1() {
         "minimize is not idempotent on real Automerge document",
     );
 
-    // And the round-trip still works on the doubly-minimized tree.
     let blob_by_digest: Map<Digest<Blob>, &[u8]> = result
         .blobs
         .iter()

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -510,30 +510,37 @@ impl Sedimentree {
 
     /// Prune a [`Sedimentree`].
     ///
-    /// Minimize the [`Sedimentree`] by removing any fragments that are
-    /// fully supported by other fragments, and removing any loose commits
-    /// that are not needed to support the remaining fragments.
+    /// Minimize the [`Sedimentree`] by removing fragments that are
+    /// individually subsumed by some strictly-deeper kept fragment, and
+    /// removing loose commits whose data is recoverable from a kept
+    /// fragment's blob.
     ///
-    /// Uses a group-by-depth algorithm (Option B) that processes fragments
-    /// from deepest to shallowest. Deeper fragments are always kept, and
-    /// shallower fragments are discarded if their entire range (head + boundary)
-    /// is supported by already-accepted deeper fragments.
+    /// Uses a group-by-depth algorithm processing fragments from deepest
+    /// to shallowest. A fragment `F` is dropped iff some already-kept
+    /// fragment `G` with `depth(G) > depth(F)` satisfies
+    /// [`Fragment::supports`] for `F`'s summary (i.e. `F.head` and every
+    /// `F.boundary` element fall within `G`'s range). Same-depth peers
+    /// cannot dominate each other; collective coverage by multiple
+    /// deeper fragments does not count either, since each fragment's
+    /// blob contains only its own members.
     ///
-    /// Complexity: `O(|M| × avg_checkpoints)` where M = total fragments.
+    /// Complexity: `O(|M|² × avg_boundary)` worst-case for the
+    /// fragment-minimization pass (each candidate is checked against
+    /// each kept deeper fragment, and `Fragment::supports` walks the
+    /// candidate's boundary). Loose-commit pruning is `O(|C| + |F|)`
+    /// after the precomputed coverage set in `CommitDag::simplify`.
+    /// In practice `|M|` is small (depth distribution is geometric in
+    /// the metric) and the deepest-first sweep prunes early.
     #[must_use]
     pub fn minimize<M: DepthMetric>(&self, depth_metric: &M) -> Sedimentree {
-        // 1. Group fragments by depth.
-        //
         // Sort fragments by head bytes before grouping so the iteration
-        // order is independent of the underlying `Map`'s iteration order.
-        // With the `std` feature `Map = HashMap`, whose iteration order
-        // is hasher-state-dependent and so varies across processes.
-        // Without this sort, different processes can pick different
-        // representatives among equivalent fragments — producing non-equal
-        // `Sedimentree`s from identical input and violating the spec in
-        // `design/sedimentree.md` ("two trees with the same content will
-        // have identical minimal representations"). That, in turn, breaks
-        // `MinimalTreeHash` and fingerprint stability for sync.
+        // order is independent of the underlying `Map`'s. With the `std`
+        // feature `Map = HashMap`, whose iteration order is hasher-state-
+        // dependent (so per-process). Without this sort, different
+        // processes pick different representatives among equivalent
+        // fragments, violating `design/sedimentree.md`'s "two trees with
+        // the same content will have identical minimal representations"
+        // and breaking `MinimalTreeHash` / fingerprint stability for sync.
         let mut sorted_frags: Vec<&Fragment> = self.fragments.values().collect();
         sorted_frags.sort_by_key(|f| *f.head().as_bytes());
 
@@ -545,32 +552,20 @@ impl Sedimentree {
                 .push(fragment);
         }
 
-        // 2. Collect depths and sort descending (deepest first)
         let mut depths: Vec<Depth> = by_depth.keys().copied().collect();
-        depths.sort_by(|a, b| b.cmp(a)); // Descending
+        depths.sort_by(|a, b| b.cmp(a));
 
-        // 3. Process deepest first.
+        // Drop a candidate fragment iff some *strictly deeper* kept
+        // fragment individually supports it (head + boundary within its
+        // range, per `Fragment::supports`). Same-depth peers must NOT
+        // dominate each other: in merge-heavy DAGs many depth-N fragments
+        // cross-reference each other's heads in their boundaries, but
+        // each fragment's blob contains only its own members — dropping
+        // any of them silently drops change data.
         //
-        // A candidate fragment is dropped when some *strictly deeper*
-        // kept fragment supports it (per `Fragment::supports`: head +
-        // boundary fall within the deeper fragment's range).
-        //
-        // We must NOT allow a same-depth peer to dominate a candidate.
-        // In a merge-heavy DAG (typical Automerge workload), many depth-N
-        // fragments cross-reference each other's heads in their
-        // boundaries. The old check ("head + boundary in some union of
-        // checkpoints") would conclude these peers dominate each other
-        // structurally, but each fragment's *blob* contains only its own
-        // members — so dropping any of them silently drops change data.
-        //
-        // Tracking the kept fragments themselves (rather than a flat
-        // `Set<Checkpoint>` union) lets us enforce the strict-deeper rule
-        // and check `Fragment::supports` directly.
-        //
-        // We don't need an exact-equality dedup pass: `self.fragments` is
-        // a `Map<CommitId, Fragment>` keyed by head, and `Fragment`
-        // equality includes the head, so two distinct map entries cannot
-        // be equal.
+        // No exact-equality dedup needed: `self.fragments` is keyed by
+        // `Fragment::head()` and `Fragment: PartialEq` includes the head,
+        // so distinct map entries cannot be equal.
         let mut minimized_fragments = Vec::<Fragment>::new();
         let mut kept_fragments_by_depth: Map<Depth, Vec<&Fragment>> = Map::new();
 
@@ -598,10 +593,7 @@ impl Sedimentree {
             }
         }
 
-        // 4. Simplify loose commits relative to minimized fragments.
-        //
-        // `simplify` returns only the set of surviving `CommitId`s — we
-        // need membership to filter, not graph structure.
+        // Prune loose commits whose ranges are covered by kept fragments.
         let dag = commit_dag::CommitDag::from_commits(self.commits.values());
         let keepers = dag.simplify(&minimized_fragments, depth_metric);
 
@@ -827,8 +819,8 @@ impl Sedimentree {
         let minimized = self.minimize(depth_metric);
         let dag = commit_dag::CommitDag::from_commits(minimized.commits.values());
 
-        // Precompute the union of all fragment boundaries once instead of
-        // doing an `O(F²)` `any()` scan inside the fragment loop.
+        // Precompute boundary union once: O(F) instead of an O(F²)
+        // `any()` scan inside the fragment loop.
         let all_fragment_boundaries: Set<CommitId> = minimized
             .fragments
             .values()
@@ -2223,28 +2215,15 @@ mod tests {
             assert_eq!(fragments.len(), 2);
         }
 
+        /// Synthetic input where two deep fragments' checkpoints
+        /// together cover a shallow fragment but neither does
+        /// individually. Impossible from `build_fragment_store` (a real
+        /// depth-3 fragment walks every shallower ancestor as a member),
+        /// so this can only arise from malformed input. Pins safe
+        /// behaviour: shallow is kept, because each deep fragment's blob
+        /// contains only its own members.
         #[test]
         fn minimize_synthetic_collective_support_keeps_shallow() {
-            // Synthetic input: two deep fragments whose checkpoints,
-            // taken together, "cover" a shallow fragment's head and
-            // boundary, but where neither single deep fragment covers
-            // both. This configuration is *impossible* to produce from
-            // `build_fragment_store` — a real depth-3 fragment walks
-            // back through every depth<3 ancestor as a member, so any
-            // depth-3 fragment whose range spans `shallow_head` would
-            // also span `shallow_boundary` (and vice versa). Both
-            // shallow_head and shallow_boundary would be in *its own*
-            // checkpoint set, not split across two siblings.
-            //
-            // The case here can only arise from a malformed input
-            // (e.g. hand-crafted, Byzantine peer, or storage
-            // corruption). We pin the safe behavior anyway: shallow is
-            // kept, because its data is not recoverable from the union
-            // of deep1's and deep2's blobs in the general case (each
-            // deep fragment's blob contains only its own members).
-            //
-            // Pre-fix behavior dropped shallow on the (unsound)
-            // assumption that "collective coverage" preserves data.
             let shallow_head = commit_id_with_depth(2, 1);
             let shallow_boundary = commit_id_with_depth(1, 101);
 

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -522,9 +522,24 @@ impl Sedimentree {
     /// Complexity: `O(|M| × avg_checkpoints)` where M = total fragments.
     #[must_use]
     pub fn minimize<M: DepthMetric>(&self, depth_metric: &M) -> Sedimentree {
-        // 1. Group fragments by depth
+        // 1. Group fragments by depth.
+        //
+        // Sort fragments by head bytes before grouping so the iteration
+        // order is independent of the underlying `Map`'s iteration order.
+        // With the `std` feature `Map = HashMap`, whose iteration order
+        // is hasher-state-dependent and so varies across processes.
+        // Without this sort, when two same-depth fragments mutually
+        // dominate, different processes can pick different
+        // representatives — producing non-equal `Sedimentree`s from
+        // identical input and violating the spec in
+        // `design/sedimentree.md` ("two trees with the same content
+        // will have identical minimal representations"). That, in turn,
+        // breaks fingerprint stability for sync.
+        let mut sorted_frags: Vec<&Fragment> = self.fragments.values().collect();
+        sorted_frags.sort_by_key(|f| *f.head().as_bytes());
+
         let mut by_depth: Map<Depth, Vec<&Fragment>> = Map::new();
-        for fragment in self.fragments.values() {
+        for fragment in sorted_frags {
             by_depth
                 .entry(fragment.depth(depth_metric))
                 .or_default()
@@ -564,14 +579,17 @@ impl Sedimentree {
             }
         }
 
-        // 4. Simplify loose commits relative to minimized fragments
+        // 4. Simplify loose commits relative to minimized fragments.
+        //
+        // `simplify` returns only the set of surviving `CommitId`s — we
+        // need membership to filter, not graph structure.
         let dag = commit_dag::CommitDag::from_commits(self.commits.values());
-        let simplified_dag = dag.simplify(&minimized_fragments, depth_metric);
+        let keepers = dag.simplify(&minimized_fragments, depth_metric);
 
         let commits = self
             .commits
             .values()
-            .filter(|c| simplified_dag.contains_commit(&c.head()))
+            .filter(|c| keepers.contains(&c.head()))
             .cloned()
             .collect();
 
@@ -789,12 +807,18 @@ impl Sedimentree {
     pub fn heads<M: DepthMetric>(&self, depth_metric: &M) -> Vec<CommitId> {
         let minimized = self.minimize(depth_metric);
         let dag = commit_dag::CommitDag::from_commits(minimized.commits.values());
+
+        // Precompute the union of all fragment boundaries once instead of
+        // doing an `O(F²)` `any()` scan inside the fragment loop.
+        let all_fragment_boundaries: Set<CommitId> = minimized
+            .fragments
+            .values()
+            .flat_map(|f| f.boundary().iter().copied())
+            .collect();
+
         let mut heads = Vec::<CommitId>::new();
         for fragment in minimized.fragments.values() {
-            if !minimized
-                .fragments
-                .values()
-                .any(|s| s.boundary().contains(&fragment.head()))
+            if !all_fragment_boundaries.contains(&fragment.head())
                 && fragment
                     .boundary()
                     .iter()
@@ -1372,6 +1396,31 @@ mod tests {
                     let tree = Sedimentree::new(vec![], commits.clone());
                     let minimized = tree.minimize(&CountLeadingZeroBytes);
                     assert_eq!(tree, minimized);
+                });
+        }
+
+        /// `minimize` is idempotent on trees that contain fragments.
+        ///
+        /// Companion to [`minimized_loose_commit_dag_doesnt_change`]
+        /// (which only covers the no-fragments case). Exercises the
+        /// fragment-minimization step by generating arbitrary
+        /// `Sedimentree`s with fragments, minimizing once, and asserting
+        /// that a second minimize yields the same tree.
+        ///
+        /// Regression test for the cross-process determinism bug fixed
+        /// alongside `perf/minimize`: previously, re-minimizing a
+        /// freshly-minimized tree could pick a different mutual-dominance
+        /// representative due to `HashMap` iteration order, dropping a
+        /// fragment the first pass kept.
+        #[test]
+        fn minimize_with_fragments_is_idempotent() {
+            use crate::test_utils::ArbitraryDag;
+            bolero::check!()
+                .with_arbitrary::<ArbitraryDag>()
+                .for_each(|ArbitraryDag { tree }| {
+                    let once = tree.minimize(&CountLeadingZeroBytes);
+                    let twice = once.minimize(&CountLeadingZeroBytes);
+                    assert_eq!(once, twice, "minimize on tree-with-fragments is not idempotent");
                 });
         }
 

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -1446,7 +1446,10 @@ mod tests {
                 .for_each(|ArbitraryDag { tree }| {
                     let once = tree.minimize(&CountLeadingZeroBytes);
                     let twice = once.minimize(&CountLeadingZeroBytes);
-                    assert_eq!(once, twice, "minimize on tree-with-fragments is not idempotent");
+                    assert_eq!(
+                        once, twice,
+                        "minimize on tree-with-fragments is not idempotent"
+                    );
                 });
         }
 

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -528,13 +528,12 @@ impl Sedimentree {
         // order is independent of the underlying `Map`'s iteration order.
         // With the `std` feature `Map = HashMap`, whose iteration order
         // is hasher-state-dependent and so varies across processes.
-        // Without this sort, when two same-depth fragments mutually
-        // dominate, different processes can pick different
-        // representatives — producing non-equal `Sedimentree`s from
-        // identical input and violating the spec in
-        // `design/sedimentree.md` ("two trees with the same content
-        // will have identical minimal representations"). That, in turn,
-        // breaks fingerprint stability for sync.
+        // Without this sort, different processes can pick different
+        // representatives among equivalent fragments — producing non-equal
+        // `Sedimentree`s from identical input and violating the spec in
+        // `design/sedimentree.md` ("two trees with the same content will
+        // have identical minimal representations"). That, in turn, breaks
+        // `MinimalTreeHash` and fingerprint stability for sync.
         let mut sorted_frags: Vec<&Fragment> = self.fragments.values().collect();
         sorted_frags.sort_by_key(|f| *f.head().as_bytes());
 
@@ -550,31 +549,58 @@ impl Sedimentree {
         let mut depths: Vec<Depth> = by_depth.keys().copied().collect();
         depths.sort_by(|a, b| b.cmp(a)); // Descending
 
-        // 3. Process deepest first, building supported set
+        // 3. Process deepest first.
+        //
+        // A candidate fragment is dominated (and may be dropped) when:
+        // - it is *exactly equal* to some already-kept fragment
+        //   (deduplication), OR
+        // - some *strictly deeper* kept fragment supports it (per
+        //   `Fragment::supports`: head + boundary fall within the deeper
+        //   fragment's range).
+        //
+        // We must NOT allow a same-depth peer to dominate a candidate.
+        // In a merge-heavy DAG (typical Automerge workload), many depth-N
+        // fragments cross-reference each other's heads in their
+        // boundaries. The old check ("head + boundary in some union of
+        // checkpoints") would conclude these peers dominate each other
+        // structurally, but each fragment's *blob* contains only its own
+        // members — so dropping any of them silently drops change data.
+        //
+        // Tracking the kept fragments themselves (rather than a flat
+        // `Set<Checkpoint>` union) lets us enforce the strict-deeper rule
+        // and check `Fragment::supports` directly.
         let mut minimized_fragments = Vec::<Fragment>::new();
-        let mut supported: Set<Checkpoint> = Set::new();
+        let mut kept_summaries_by_depth: Map<Depth, Vec<&Fragment>> = Map::new();
 
         for depth in depths {
-            if let Some(group) = by_depth.remove(&depth) {
-                for fragment in group {
-                    // Check if this fragment is fully supported by deeper fragments
-                    let dominated = supported.contains(&Checkpoint::new(fragment.head()))
-                        && fragment
-                            .summary()
-                            .boundary()
+            let Some(group) = by_depth.remove(&depth) else {
+                continue;
+            };
+            for fragment in group {
+                // (1) Exact dedup against already-kept fragments at this depth.
+                let already_present = kept_summaries_by_depth
+                    .get(&depth)
+                    .is_some_and(|peers| peers.iter().any(|kept| *kept == fragment));
+                if already_present {
+                    continue;
+                }
+
+                // (2) Strict-deeper dominance: some kept fragment with depth > our depth supports us.
+                let dominated_by_deeper = kept_summaries_by_depth
+                    .iter()
+                    .filter(|(d, _)| **d > depth)
+                    .any(|(_, peers)| {
+                        peers
                             .iter()
-                            .all(|b| supported.contains(&Checkpoint::new(*b)));
+                            .any(|deeper| deeper.supports(fragment.summary(), depth_metric))
+                    });
 
-                    if !dominated {
-                        // Accept this fragment and add its commits to supported set
-                        supported.insert(Checkpoint::new(fragment.head()));
-                        supported.extend(fragment.checkpoints().iter().copied());
-                        for b in fragment.summary().boundary() {
-                            supported.insert(Checkpoint::new(*b));
-                        }
-
-                        minimized_fragments.push(fragment.clone());
-                    }
+                if !dominated_by_deeper {
+                    minimized_fragments.push(fragment.clone());
+                    kept_summaries_by_depth
+                        .entry(depth)
+                        .or_default()
+                        .push(fragment);
                 }
             }
         }

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -2228,8 +2228,27 @@ mod tests {
         }
 
         #[test]
-        fn minimize_collective_support() {
-            // Two deep fragments together support a shallow one
+        fn minimize_synthetic_collective_support_keeps_shallow() {
+            // Synthetic input: two deep fragments whose checkpoints,
+            // taken together, "cover" a shallow fragment's head and
+            // boundary, but where neither single deep fragment covers
+            // both. This configuration is *impossible* to produce from
+            // `build_fragment_store` — a real depth-3 fragment walks
+            // back through every depth<3 ancestor as a member, so any
+            // depth-3 fragment whose range spans `shallow_head` would
+            // also span `shallow_boundary` (and vice versa). Both
+            // shallow_head and shallow_boundary would be in *its own*
+            // checkpoint set, not split across two siblings.
+            //
+            // The case here can only arise from a malformed input
+            // (e.g. hand-crafted, Byzantine peer, or storage
+            // corruption). We pin the safe behavior anyway: shallow is
+            // kept, because its data is not recoverable from the union
+            // of deep1's and deep2's blobs in the general case (each
+            // deep fragment's blob contains only its own members).
+            //
+            // Pre-fix behavior dropped shallow on the (unsound)
+            // assumption that "collective coverage" preserves data.
             let shallow_head = commit_id_with_depth(2, 1);
             let shallow_boundary = commit_id_with_depth(1, 101);
 
@@ -2250,11 +2269,10 @@ mod tests {
             let minimized = tree.minimize(&CountLeadingZeroBytes);
             let fragments = collect_fragments(&minimized);
 
-            // Shallow should be discarded (collectively supported by deep1 + deep2)
-            assert_eq!(fragments.len(), 2);
+            assert_eq!(fragments.len(), 3);
             assert!(fragments.contains(&deep1));
             assert!(fragments.contains(&deep2));
-            assert!(!fragments.contains(&shallow));
+            assert!(fragments.contains(&shallow));
         }
 
         #[test]

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -570,7 +570,7 @@ impl Sedimentree {
         // `Set<Checkpoint>` union) lets us enforce the strict-deeper rule
         // and check `Fragment::supports` directly.
         let mut minimized_fragments = Vec::<Fragment>::new();
-        let mut kept_summaries_by_depth: Map<Depth, Vec<&Fragment>> = Map::new();
+        let mut kept_fragments_by_depth: Map<Depth, Vec<&Fragment>> = Map::new();
 
         for depth in depths {
             let Some(group) = by_depth.remove(&depth) else {
@@ -578,7 +578,7 @@ impl Sedimentree {
             };
             for fragment in group {
                 // (1) Exact dedup against already-kept fragments at this depth.
-                let already_present = kept_summaries_by_depth
+                let already_present = kept_fragments_by_depth
                     .get(&depth)
                     .is_some_and(|peers| peers.contains(&fragment));
                 if already_present {
@@ -586,7 +586,7 @@ impl Sedimentree {
                 }
 
                 // (2) Strict-deeper dominance: some kept fragment with depth > our depth supports us.
-                let dominated_by_deeper = kept_summaries_by_depth
+                let dominated_by_deeper = kept_fragments_by_depth
                     .iter()
                     .filter(|(d, _)| **d > depth)
                     .any(|(_, peers)| {
@@ -597,7 +597,7 @@ impl Sedimentree {
 
                 if !dominated_by_deeper {
                     minimized_fragments.push(fragment.clone());
-                    kept_summaries_by_depth
+                    kept_fragments_by_depth
                         .entry(depth)
                         .or_default()
                         .push(fragment);

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -551,12 +551,9 @@ impl Sedimentree {
 
         // 3. Process deepest first.
         //
-        // A candidate fragment is dominated (and may be dropped) when:
-        // - it is *exactly equal* to some already-kept fragment
-        //   (deduplication), OR
-        // - some *strictly deeper* kept fragment supports it (per
-        //   `Fragment::supports`: head + boundary fall within the deeper
-        //   fragment's range).
+        // A candidate fragment is dropped when some *strictly deeper*
+        // kept fragment supports it (per `Fragment::supports`: head +
+        // boundary fall within the deeper fragment's range).
         //
         // We must NOT allow a same-depth peer to dominate a candidate.
         // In a merge-heavy DAG (typical Automerge workload), many depth-N
@@ -569,6 +566,11 @@ impl Sedimentree {
         // Tracking the kept fragments themselves (rather than a flat
         // `Set<Checkpoint>` union) lets us enforce the strict-deeper rule
         // and check `Fragment::supports` directly.
+        //
+        // We don't need an exact-equality dedup pass: `self.fragments` is
+        // a `Map<CommitId, Fragment>` keyed by head, and `Fragment`
+        // equality includes the head, so two distinct map entries cannot
+        // be equal.
         let mut minimized_fragments = Vec::<Fragment>::new();
         let mut kept_fragments_by_depth: Map<Depth, Vec<&Fragment>> = Map::new();
 
@@ -577,15 +579,6 @@ impl Sedimentree {
                 continue;
             };
             for fragment in group {
-                // (1) Exact dedup against already-kept fragments at this depth.
-                let already_present = kept_fragments_by_depth
-                    .get(&depth)
-                    .is_some_and(|peers| peers.contains(&fragment));
-                if already_present {
-                    continue;
-                }
-
-                // (2) Strict-deeper dominance: some kept fragment with depth > our depth supports us.
                 let dominated_by_deeper = kept_fragments_by_depth
                     .iter()
                     .filter(|(d, _)| **d > depth)

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -580,7 +580,7 @@ impl Sedimentree {
                 // (1) Exact dedup against already-kept fragments at this depth.
                 let already_present = kept_summaries_by_depth
                     .get(&depth)
-                    .is_some_and(|peers| peers.iter().any(|kept| *kept == fragment));
+                    .is_some_and(|peers| peers.contains(&fragment));
                 if already_present {
                     continue;
                 }

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -596,7 +596,8 @@ mod tests {
                     let s2 = dag2.simplify(&[], &CountLeadingZeroBytes);
 
                     assert_eq!(
-                        s1, s2,
+                        s1,
+                        s2,
                         "simplify output depends on input order: {} commits",
                         commits.len()
                     );
@@ -655,18 +656,16 @@ mod tests {
         fn simplify_with_fragments_invariant_under_input_order() {
             bolero::check!()
                 .with_arbitrary::<(ArbitraryCommits, Vec<Fragment>, u64)>()
-                .for_each(
-                    |(ArbitraryCommits { commits }, fragments, shuffle_seed)| {
-                        let dag1 = CommitDag::from_commits(commits.iter());
-                        let shuffled = shuffle(commits, *shuffle_seed);
-                        let dag2 = CommitDag::from_commits(shuffled.iter());
+                .for_each(|(ArbitraryCommits { commits }, fragments, shuffle_seed)| {
+                    let dag1 = CommitDag::from_commits(commits.iter());
+                    let shuffled = shuffle(commits, *shuffle_seed);
+                    let dag2 = CommitDag::from_commits(shuffled.iter());
 
-                        let s1 = dag1.simplify(fragments, &CountLeadingZeroBytes);
-                        let s2 = dag2.simplify(fragments, &CountLeadingZeroBytes);
+                    let s1 = dag1.simplify(fragments, &CountLeadingZeroBytes);
+                    let s2 = dag2.simplify(fragments, &CountLeadingZeroBytes);
 
-                        assert_eq!(s1, s2);
-                    },
-                );
+                    assert_eq!(s1, s2);
+                });
         }
     }
 }

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -85,20 +85,12 @@ impl CommitDag {
     }
 
     fn add_edge(&mut self, source: NodeIdx, target: NodeIdx) {
-        // Both edge lists are unordered (consumers iterate without
-        // assuming any order), so prepend to the head of each list.
-        // This makes insertion O(1) instead of O(degree).
-        //
-        // The `source` field on each `Edge` is what the iterator yields:
-        // - `target_node.parents` chain yields parent NodeIdxs
-        //   (so the edge stored on the child carries `source = parent`)
-        // - `source_node.children` chain yields child NodeIdxs
-        //   (so the edge stored on the parent carries `source = child`)
-        //
-        // The two edges below have different `source` values for that
-        // reason; they are NOT duplicates.
+        // Prepend to each adjacency list (O(1) instead of O(degree)).
+        // Consumers iterate without assuming order. The two `Edge`
+        // writes below are NOT duplicates: each carries the *other*
+        // endpoint as `source` (parents-chain yields parents,
+        // children-chain yields children).
 
-        // Edge stored on the child (target) — points back to the parent.
         let parent_edge_idx = EdgeIdx(self.edges.len());
         #[allow(clippy::expect_used)]
         let target_node = self
@@ -112,7 +104,6 @@ impl CommitDag {
             next: prev_parent_head,
         });
 
-        // Edge stored on the parent (source) — points forward to the child.
         let child_edge_idx = EdgeIdx(self.edges.len());
         #[allow(clippy::expect_used)]
         let source_node = self
@@ -139,15 +130,19 @@ impl CommitDag {
         fragments: &[Fragment],
         strategy: &S,
     ) -> Set<CommitId> {
-        // The work here is to identify which parts of a commit DAG can be
-        // discarded based on the fragments we have. This is a little bit
-        // fiddly. Imagine this graph:
+        // Algorithm: walk reverse-topo from each tip, partitioning
+        // commits into fragment "ranges" (runs between boundaries — a
+        // commit is a boundary when `Depth::is_boundary()`). A commit
+        // can appear in multiple ranges (visited from multiple tips),
+        // and is dropped iff every range it belongs to is covered by
+        // some kept fragment.
+        //
+        // Example DAG (boundary commits in *bold*; fragments covering
+        // *A* and *F*):
         //
         //        ┌─┐
         //        │A│
         //   ┌────┴─┴────┐
-        //   │           │
-        //   │           │
         //  ┌▼┐         ┌▼┐          ┌─┐
         //  │B│         │C│          │D│
         //  └┬┘         └┬┘          └┬┘
@@ -157,46 +152,15 @@ impl CommitDag {
         //  │I│               ┌▼┐
         //  └─┘               │E│
         //                    └┬┘
-        //                     │
-        //                     │
         //                    ┌▼┐
         //               ┌────┤F├────┐
-        //               │    └─┘    │
-        //               │           │
-        //               │           │
-        //               │           │
         //              ┌▼┐         ┌▼┐
         //              │G│         │H│
         //              └─┘         └─┘
         //
-        // Let's say we have boundary commits at F, D, I, and A, and we
-        // have fragments covering A and F. Which commits can we discard?
-        // We can't discard G or H because they are not in any fragment
-        // range. We can't discard I or B because they are not in any
-        // fragment range that we actually have fragments for.
-        //
-        // The invariant we must maintain is that we always have a path
-        // from some commit back to the last boundary commit. How do we
-        // identify the commits that can be discarded?
-        //
-        // Walking from the tips in reverse topological order lets us
-        // identify which commits are not in any fragment range (those
-        // encountered before the first boundary commit), and which
-        // fragment ranges exist (ranges bounded by boundary commits).
-        // A commit can appear in multiple ranges.
-        //
-        // A commit can be discarded when every fragment range it belongs
-        // to is covered by at least one existing fragment.
-
-        // Identify fragment ranges (runs between boundary commits) and
-        // record which range(s) each commit belongs to. A commit is a
-        // boundary when `Depth::is_boundary` returns true (nonzero depth
-        // from the metric). Commits at depth 0 are ordinary loose commits
-        // that live inside fragment ranges.
-        //
-        // The walk is in reverse topological order (tips → roots), so the
-        // first boundary we encounter is the range's head (newest end)
-        // and subsequent non-boundary commits are its interior.
+        // We keep G and H (not in any range), and B and I (in a range
+        // not covered by any fragment we have). We drop everything in
+        // the A-covered and F-covered ranges.
         let mut commits_to_ranges = Map::new();
         let mut rangeless_commits = Set::new();
 
@@ -211,8 +175,6 @@ impl CommitDag {
             for id in self.reverse_topo(tip) {
                 let depth = strategy.to_depth(id);
                 if depth.is_boundary() {
-                    // Found a boundary — flush the current range and start a new one
-                    // keyed by this boundary commit.
                     if let Some((range_head, commits)) = range.take() {
                         for commit in commits {
                             rangeless_commits.remove(&commit);
@@ -232,8 +194,9 @@ impl CommitDag {
                     rangeless_commits.insert(id);
                 }
             }
-            // No boundary was found before reaching the root — treat the
-            // accumulated range as unbounded at its oldest end.
+            // The walk reached a root without crossing another
+            // boundary; treat the trailing range as unbounded at its
+            // oldest end.
             if let Some((end, commits)) = range.take() {
                 commits_to_ranges
                     .entry(end)
@@ -248,18 +211,10 @@ impl CommitDag {
             }
         }
 
-        // Discard commits whose ranges are all covered by existing fragments.
-        //
-        // The naive form was O(commits × ranges × fragments × supports_block):
-        //   filter(|(_, ranges)| ranges.iter().all(|r|
-        //       fragments.iter().any(|f| f.supports_block(r))))
-        //
-        // Inverted: build the set of CommitIds that ANY fragment supports,
-        // then each commit's `ranges` check is O(ranges) hash lookups.
-        // A fragment "supports" its head, all its checkpoints (truncated),
-        // and all its boundary commits — see `Fragment::supports_block`.
-        // Range heads recorded during the walk are full `CommitId`s that
-        // happen to also live as `Checkpoint`s, so we collect both forms.
+        // Build the union of `CommitId`s that any fragment supports
+        // (head, boundary, and checkpoints). Range heads recorded above
+        // are full `CommitId`s; checkpoints are truncated, so we
+        // collect both forms. See `Fragment::supports_block`.
         let mut covered_range_heads: Set<CommitId> = Set::new();
         let mut covered_checkpoints: Set<Checkpoint> = Set::new();
         for f in fragments {
@@ -584,12 +539,9 @@ mod tests {
             v
         }
 
-        /// `simplify` (with no fragments) returns the same `CommitId` set
-        /// regardless of the order commits were inserted into the DAG.
-        ///
-        /// Probes the `add_edge` prepend optimization: the per-node
-        /// adjacency-list order depends on insertion sequence, but
-        /// `simplify`'s output must not.
+        /// `simplify` output is independent of commit insertion order.
+        /// Guards against `add_edge`'s per-node adjacency-list order
+        /// leaking into observable behaviour.
         #[test]
         fn simplify_invariant_under_input_order() {
             bolero::check!()
@@ -611,12 +563,10 @@ mod tests {
                 });
         }
 
-        /// `heads` returns the same `CommitId` set regardless of the
-        /// order commits were inserted into the DAG.
-        ///
-        /// `heads` walks `node.children.is_none()`, which the prepend
-        /// change shouldn't affect — but this test guards against any
-        /// future change that introduces order-sensitivity.
+        /// `heads` is independent of commit insertion order. The
+        /// current implementation walks `node.children.is_none()` so
+        /// this is trivially true today; the test guards against future
+        /// changes.
         #[test]
         fn heads_invariant_under_input_order() {
             bolero::check!()
@@ -633,9 +583,8 @@ mod tests {
                 });
         }
 
-        /// `contains_commit` returns the same answer regardless of input
-        /// order. Trivially true (it's just a `node_map` lookup) but
-        /// included as a baseline.
+        /// `contains_commit` is independent of insertion order.
+        /// Trivially true (a `node_map` lookup), included as a baseline.
         #[test]
         fn contains_commit_invariant_under_input_order() {
             bolero::check!()
@@ -656,9 +605,9 @@ mod tests {
                 });
         }
 
-        /// `simplify` with arbitrary fragments is invariant under input
-        /// order. This exercises the inlined coverage check in
-        /// `simplify_inner` across non-empty `fragments` slices.
+        /// `simplify` with arbitrary fragments is independent of
+        /// insertion order. Exercises the precomputed-coverage path
+        /// across non-empty `fragments` slices.
         #[test]
         fn simplify_with_fragments_invariant_under_input_order() {
             bolero::check!()

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -12,7 +12,7 @@ use alloc::{vec, vec::Vec};
 use crate::{
     collections::{Map, Set},
     depth::DepthMetric,
-    fragment::Fragment,
+    fragment::{Fragment, checkpoint::Checkpoint},
     loose_commit::{LooseCommit, id::CommitId},
 };
 
@@ -85,67 +85,60 @@ impl CommitDag {
     }
 
     fn add_edge(&mut self, source: NodeIdx, target: NodeIdx) {
-        // Add an edge in the child node
-        let new_edge_idx = EdgeIdx(self.edges.len());
-        let new_edge = Edge { source, next: None };
-        self.edges.push(new_edge);
+        // Both edge lists are unordered (consumers iterate without
+        // assuming any order), so prepend to the head of each list.
+        // This makes insertion O(1) instead of O(degree).
+        //
+        // The `source` field on each `Edge` is what the iterator yields:
+        // - `target_node.parents` chain yields parent NodeIdxs
+        //   (so the edge stored on the child carries `source = parent`)
+        // - `source_node.children` chain yields child NodeIdxs
+        //   (so the edge stored on the parent carries `source = child`)
+        //
+        // The two edges below have different `source` values for that
+        // reason; they are NOT duplicates.
 
+        // Edge stored on the child (target) — points back to the parent.
+        let parent_edge_idx = EdgeIdx(self.edges.len());
         #[allow(clippy::expect_used)]
         let target_node = self
             .nodes
             .get_mut(target.0)
             .expect("NodeId not in self.nodes");
+        let prev_parent_head = target_node.parents;
+        target_node.parents = Some(parent_edge_idx);
+        self.edges.push(Edge {
+            source,
+            next: prev_parent_head,
+        });
 
-        if let Some(edge_idx) = target_node.parents {
-            #[allow(clippy::expect_used)]
-            let mut edge = self
-                .edges
-                .get_mut(edge_idx.0)
-                .expect("NodeId not in self.nodes");
-
-            #[allow(clippy::expect_used)]
-            while let Some(next) = edge.next {
-                edge = self
-                    .edges
-                    .get_mut(next.0)
-                    .expect("NodeId not in self.nodes");
-            }
-            edge.next = Some(new_edge_idx);
-        } else {
-            target_node.parents = Some(new_edge_idx);
-        }
-
-        // Now add an edge in the parent node
-        let new_edge_idx = EdgeIdx(self.edges.len());
-        let new_edge = Edge { source, next: None };
-        self.edges.push(new_edge);
-
+        // Edge stored on the parent (source) — points forward to the child.
+        let child_edge_idx = EdgeIdx(self.edges.len());
         #[allow(clippy::expect_used)]
         let source_node = self
             .nodes
             .get_mut(source.0)
             .expect("NodeId not in self.nodes");
-        if let Some(edge_idx) = source_node.children {
-            #[allow(clippy::expect_used)]
-            let mut edge = self
-                .edges
-                .get_mut(edge_idx.0)
-                .expect("NodeId not in self.nodes");
-
-            #[allow(clippy::expect_used)]
-            while let Some(next) = edge.next {
-                edge = self
-                    .edges
-                    .get_mut(next.0)
-                    .expect("next NodeId not in self.nodes");
-            }
-            edge.next = Some(new_edge_idx);
-        } else {
-            source_node.children = Some(new_edge_idx);
-        }
+        let prev_child_head = source_node.children;
+        source_node.children = Some(child_edge_idx);
+        self.edges.push(Edge {
+            source: target,
+            next: prev_child_head,
+        });
     }
 
-    pub(crate) fn simplify<S: DepthMetric>(&self, fragments: &[Fragment], strategy: &S) -> Self {
+    /// Returns the set of [`CommitId`]s that survive simplification given
+    /// `fragments`. A commit is dropped when every fragment range it
+    /// belongs to is already covered by some fragment in `fragments`.
+    ///
+    /// Returns just the membership set rather than rebuilding a fresh
+    /// [`CommitDag`]: the only caller ([`Sedimentree::minimize`]) needs
+    /// `contains` lookups, not graph structure.
+    pub(crate) fn simplify<S: DepthMetric>(
+        &self,
+        fragments: &[Fragment],
+        strategy: &S,
+    ) -> Set<CommitId> {
         // The work here is to identify which parts of a commit DAG can be
         // discarded based on the fragments we have. This is a little bit
         // fiddly. Imagine this graph:
@@ -256,49 +249,36 @@ impl CommitDag {
         }
 
         // Discard commits whose ranges are all covered by existing fragments.
-        let remaining_commits = commits_to_ranges
+        //
+        // The naive form was O(commits × ranges × fragments × supports_block):
+        //   filter(|(_, ranges)| ranges.iter().all(|r|
+        //       fragments.iter().any(|f| f.supports_block(r))))
+        //
+        // Inverted: build the set of CommitIds that ANY fragment supports,
+        // then each commit's `ranges` check is O(ranges) hash lookups.
+        // A fragment "supports" its head, all its checkpoints (truncated),
+        // and all its boundary commits — see `Fragment::supports_block`.
+        // Range heads recorded during the walk are full `CommitId`s that
+        // happen to also live as `Checkpoint`s, so we collect both forms.
+        let mut covered_range_heads: Set<CommitId> = Set::new();
+        let mut covered_checkpoints: Set<Checkpoint> = Set::new();
+        for f in fragments {
+            covered_range_heads.insert(f.head());
+            covered_range_heads.extend(f.boundary().iter().copied());
+            covered_checkpoints.extend(f.checkpoints().iter().copied());
+        }
+
+        commits_to_ranges
             .into_iter()
             .filter_map(|(commit, ranges)| {
-                if ranges
-                    .iter()
-                    .all(|&r| fragments.iter().any(|f| f.supports_block(r)))
-                {
-                    None
-                } else {
-                    Some(commit)
-                }
+                let all_covered = ranges.iter().all(|r| {
+                    covered_range_heads.contains(r)
+                        || covered_checkpoints.contains(&Checkpoint::new(*r))
+                });
+                if all_covered { None } else { Some(commit) }
             })
             .chain(rangeless_commits)
-            .collect::<Vec<_>>();
-
-        let nodes = remaining_commits
-            .iter()
-            .map(|&c| Node {
-                id: c,
-                parents: None,
-                children: None,
-            })
-            .collect::<Vec<_>>();
-        let node_map = nodes
-            .iter()
-            .enumerate()
-            .map(|(idx, node)| (node.id, NodeIdx(idx)))
-            .collect::<Map<_, _>>();
-
-        let mut dag = CommitDag {
-            nodes,
-            node_map,
-            edges: Vec::new(),
-        };
-
-        for (child_idx, commit) in remaining_commits.into_iter().enumerate() {
-            for parent in self.parents_of_id(commit) {
-                if let Some(parent) = dag.node_map.get(&parent) {
-                    dag.add_edge(*parent, NodeIdx(child_idx));
-                }
-            }
-        }
-        dag
+            .collect()
     }
 
     fn tips(&self) -> impl Iterator<Item = NodeIdx> + '_ {
@@ -315,6 +295,7 @@ impl CommitDag {
         ParentsIter::new(self, node)
     }
 
+    #[cfg(test)]
     fn parents_of_id(&self, id: CommitId) -> impl Iterator<Item = CommitId> + '_ {
         self.node_map
             .get(&id)
@@ -344,11 +325,6 @@ impl CommitDag {
                 None
             }
         })
-    }
-
-    #[cfg(test)]
-    fn commit_ids(&self) -> impl Iterator<Item = CommitId> + '_ {
-        self.nodes.iter().map(|node| node.id)
     }
 }
 
@@ -489,10 +465,7 @@ mod tests {
 
         let dag = CommitDag::from_commits([&a, &b].into_iter());
 
-        let simplified = dag
-            .simplify(&[], &depth_metric)
-            .commit_ids()
-            .collect::<Set<_>>();
+        let simplified = dag.simplify(&[], &depth_metric);
 
         // With no fragments, simplify keeps boundary commits + heads
         // Both a and b should remain (a is boundary, b would be pruned but there's no fragment)
@@ -517,10 +490,7 @@ mod tests {
 
         let dag = CommitDag::from_commits([&a, &b].into_iter());
 
-        let simplified = dag
-            .simplify(&[], &depth_metric)
-            .commit_ids()
-            .collect::<Set<_>>();
+        let simplified = dag.simplify(&[], &depth_metric);
 
         // Both are boundary commits, both remain
         assert_eq!(simplified, Set::from([a_id, b_id]));
@@ -545,5 +515,158 @@ mod tests {
             dag.parents_of_id(c_id).collect::<Set<_>>(),
             Set::from([a_id, b_id])
         );
+    }
+
+    /// Property tests for `CommitDag` invariants under input ordering.
+    ///
+    /// `add_edge` prepends to per-node adjacency lists in O(1), so the
+    /// internal edge storage order depends on the order `from_commits`
+    /// receives commits. Consumers (`simplify`, `heads`, `contains_commit`)
+    /// must be insensitive to that order.
+    mod proptests {
+        use alloc::vec::Vec;
+        use rand::{Rng, SeedableRng, rngs::SmallRng};
+
+        use super::*;
+        use crate::{commit::CountLeadingZeroBytes, fragment::Fragment};
+
+        /// A randomly-generated valid commit DAG.
+        ///
+        /// Each generated commit's `parents` reference only commits
+        /// emitted earlier in the sequence, so the result is acyclic.
+        #[derive(Debug)]
+        struct ArbitraryCommits {
+            commits: Vec<LooseCommit>,
+        }
+
+        impl<'a> arbitrary::Arbitrary<'a> for ArbitraryCommits {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+                let sedimentree_id = SedimentreeId::arbitrary(u)?;
+                let num_commits: u32 = u.int_in_range(0..=20)?;
+                let mut frontier: Vec<CommitId> = Vec::new();
+                let mut commits = Vec::with_capacity(num_commits as usize);
+                let mut rng = SmallRng::seed_from_u64(u.arbitrary()?);
+
+                for _ in 0..num_commits {
+                    let head = CommitId::new(rng.r#gen());
+                    let mut parents = BTreeSet::new();
+                    let n_parents = u.int_in_range(0..=frontier.len().min(3))?;
+                    let mut available: Vec<usize> = (0..frontier.len()).collect();
+                    for _ in 0..n_parents {
+                        if available.is_empty() {
+                            break;
+                        }
+                        let pick = u.choose_index(available.len())?;
+                        let idx = available.remove(pick);
+                        parents.insert(frontier[idx]);
+                    }
+                    let blob_meta = BlobMeta::arbitrary(u)?;
+                    commits.push(LooseCommit::new(sedimentree_id, head, parents, blob_meta));
+                    frontier.push(head);
+                }
+
+                Ok(ArbitraryCommits { commits })
+            }
+        }
+
+        fn shuffle<T: Clone>(items: &[T], seed: u64) -> Vec<T> {
+            use rand::seq::SliceRandom;
+            let mut v: Vec<T> = items.to_vec();
+            let mut rng = SmallRng::seed_from_u64(seed);
+            v.shuffle(&mut rng);
+            v
+        }
+
+        /// `simplify` (with no fragments) returns the same `CommitId` set
+        /// regardless of the order commits were inserted into the DAG.
+        ///
+        /// Probes the `add_edge` prepend optimization: the per-node
+        /// adjacency-list order depends on insertion sequence, but
+        /// `simplify`'s output must not.
+        #[test]
+        fn simplify_invariant_under_input_order() {
+            bolero::check!()
+                .with_arbitrary::<(ArbitraryCommits, u64)>()
+                .for_each(|(ArbitraryCommits { commits }, shuffle_seed)| {
+                    let dag1 = CommitDag::from_commits(commits.iter());
+                    let shuffled = shuffle(commits, *shuffle_seed);
+                    let dag2 = CommitDag::from_commits(shuffled.iter());
+
+                    let s1 = dag1.simplify(&[], &CountLeadingZeroBytes);
+                    let s2 = dag2.simplify(&[], &CountLeadingZeroBytes);
+
+                    assert_eq!(
+                        s1, s2,
+                        "simplify output depends on input order: {} commits",
+                        commits.len()
+                    );
+                });
+        }
+
+        /// `heads` returns the same `CommitId` set regardless of the
+        /// order commits were inserted into the DAG.
+        ///
+        /// `heads` walks `node.children.is_none()`, which the prepend
+        /// change shouldn't affect — but this test guards against any
+        /// future change that introduces order-sensitivity.
+        #[test]
+        fn heads_invariant_under_input_order() {
+            bolero::check!()
+                .with_arbitrary::<(ArbitraryCommits, u64)>()
+                .for_each(|(ArbitraryCommits { commits }, shuffle_seed)| {
+                    let dag1 = CommitDag::from_commits(commits.iter());
+                    let shuffled = shuffle(commits, *shuffle_seed);
+                    let dag2 = CommitDag::from_commits(shuffled.iter());
+
+                    let h1: Set<CommitId> = dag1.heads().collect();
+                    let h2: Set<CommitId> = dag2.heads().collect();
+
+                    assert_eq!(h1, h2, "heads depends on input order");
+                });
+        }
+
+        /// `contains_commit` returns the same answer regardless of input
+        /// order. Trivially true (it's just a `node_map` lookup) but
+        /// included as a baseline.
+        #[test]
+        fn contains_commit_invariant_under_input_order() {
+            bolero::check!()
+                .with_arbitrary::<(ArbitraryCommits, u64)>()
+                .for_each(|(ArbitraryCommits { commits }, shuffle_seed)| {
+                    let dag1 = CommitDag::from_commits(commits.iter());
+                    let shuffled = shuffle(commits, *shuffle_seed);
+                    let dag2 = CommitDag::from_commits(shuffled.iter());
+
+                    for c in commits {
+                        let id = c.head();
+                        assert_eq!(
+                            dag1.contains_commit(&id),
+                            dag2.contains_commit(&id),
+                            "contains_commit disagrees on {id:?}"
+                        );
+                    }
+                });
+        }
+
+        /// `simplify` with arbitrary fragments is invariant under input
+        /// order. This exercises the inlined coverage check in
+        /// `simplify_inner` across non-empty `fragments` slices.
+        #[test]
+        fn simplify_with_fragments_invariant_under_input_order() {
+            bolero::check!()
+                .with_arbitrary::<(ArbitraryCommits, Vec<Fragment>, u64)>()
+                .for_each(
+                    |(ArbitraryCommits { commits }, fragments, shuffle_seed)| {
+                        let dag1 = CommitDag::from_commits(commits.iter());
+                        let shuffled = shuffle(commits, *shuffle_seed);
+                        let dag2 = CommitDag::from_commits(shuffled.iter());
+
+                        let s1 = dag1.simplify(fragments, &CountLeadingZeroBytes);
+                        let s2 = dag2.simplify(fragments, &CountLeadingZeroBytes);
+
+                        assert_eq!(s1, s2);
+                    },
+                );
+        }
     }
 }

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -520,7 +520,12 @@ mod tests {
                         }
                         let pick = u.choose_index(available.len())?;
                         let idx = available.remove(pick);
-                        parents.insert(frontier[idx]);
+                        #[allow(clippy::expect_used)]
+                        let parent = frontier
+                            .get(idx)
+                            .copied()
+                            .expect("idx came from 0..frontier.len() and frontier doesn't shrink");
+                        parents.insert(parent);
                     }
                     let blob_meta = BlobMeta::arbitrary(u)?;
                     commits.push(LooseCommit::new(sedimentree_id, head, parents, blob_meta));

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -523,6 +523,12 @@ mod tests {
     /// internal edge storage order depends on the order `from_commits`
     /// receives commits. Consumers (`simplify`, `heads`, `contains_commit`)
     /// must be insensitive to that order.
+    ///
+    /// Gated on `bolero` because the module uses `bolero::check!`,
+    /// `arbitrary::Arbitrary` (transitively pulled in by `bolero`), and
+    /// `rand` (which is only a dependency under `test_utils`, itself
+    /// pulled in by the dev-dependency self-link with `bolero` enabled).
+    #[cfg(feature = "bolero")]
     mod proptests {
         use alloc::vec::Vec;
         use rand::{Rng, SeedableRng, rngs::SmallRng};

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -524,11 +524,12 @@ mod tests {
     /// receives commits. Consumers (`simplify`, `heads`, `contains_commit`)
     /// must be insensitive to that order.
     ///
-    /// Gated on `bolero` because the module uses `bolero::check!`,
-    /// `arbitrary::Arbitrary` (transitively pulled in by `bolero`), and
-    /// `rand` (which is only a dependency under `test_utils`, itself
-    /// pulled in by the dev-dependency self-link with `bolero` enabled).
-    #[cfg(feature = "bolero")]
+    /// Gated on both `bolero` (for `bolero::check!` and the
+    /// `arbitrary::Arbitrary` impl) and `test_utils` (which is what
+    /// enables the `rand` optional dependency this module uses).
+    /// `cargo test -p sedimentree_core --features bolero` alone is not
+    /// sufficient — `rand` would be unresolved.
+    #[cfg(all(feature = "bolero", feature = "test_utils"))]
     mod proptests {
         use alloc::vec::Vec;
         use rand::{Rng, SeedableRng, rngs::SmallRng};

--- a/sedimentree_core/tests/minimize_dag.rs
+++ b/sedimentree_core/tests/minimize_dag.rs
@@ -313,11 +313,11 @@ fn fragment_boundary_at_merge() {
 /// individually covers both.
 ///
 /// This configuration is impossible to produce from `build_fragment_store`
-/// (a real depth-3 fragment walks back through every depth<3 ancestor as
-/// a member, so the same depth-3 fragment would carry both shallow_head
-/// AND shallow_boundary in its checkpoints). It can only arise from
-/// malformed input — hand-crafted in tests, Byzantine peers, or storage
-/// corruption.
+/// (a real depth-3 fragment walks back through every `depth<3` ancestor
+/// as a member, so the same depth-3 fragment would carry both
+/// `shallow_head` AND `shallow_boundary` in its checkpoints). It can
+/// only arise from malformed input — hand-crafted in tests, Byzantine
+/// peers, or storage corruption.
 ///
 /// We pin the safe behavior: the shallow fragment is kept. Its data is
 /// not recoverable from the union of deep1's and deep2's blobs in

--- a/sedimentree_core/tests/minimize_dag.rs
+++ b/sedimentree_core/tests/minimize_dag.rs
@@ -308,9 +308,25 @@ fn fragment_boundary_at_merge() {
     );
 }
 
-/// Multiple deep fragments collectively support a shallow one.
+/// Synthetic input: two depth-3 fragments whose checkpoints together
+/// span a depth-2 fragment's head and boundary, but where neither
+/// individually covers both.
+///
+/// This configuration is impossible to produce from `build_fragment_store`
+/// (a real depth-3 fragment walks back through every depth<3 ancestor as
+/// a member, so the same depth-3 fragment would carry both shallow_head
+/// AND shallow_boundary in its checkpoints). It can only arise from
+/// malformed input — hand-crafted in tests, Byzantine peers, or storage
+/// corruption.
+///
+/// We pin the safe behavior: the shallow fragment is kept. Its data is
+/// not recoverable from the union of deep1's and deep2's blobs in
+/// general, because each deep fragment's blob contains only its own
+/// members. Pre-fix `minimize` dropped shallow on the (unsound)
+/// assumption that collective structural coverage implies recoverable
+/// content.
 #[test]
-fn collective_support_from_multiple_deep() {
+fn collective_support_from_multiple_deep_keeps_shallow() {
     let sedimentree_id = make_sedimentree_id(1);
     let shallow_head = sedimentree_core::test_utils::commit_id_with_depth(2, 1);
     let shallow_boundary = sedimentree_core::test_utils::commit_id_with_depth(1, 100);
@@ -351,13 +367,14 @@ fn collective_support_from_multiple_deep() {
         vec![],
     );
 
-    // Use CountLeadingZeroBytes since digests were created with commit_id_with_depth
     let minimized = tree.minimize(&CountLeadingZeroBytes);
     let fragments: Vec<_> = minimized.fragments().cloned().collect();
 
-    // Shallow should be pruned (collectively supported by deep1 + deep2)
-    assert_eq!(fragments.len(), 2);
+    // All three are kept: collective coverage is unsound at the blob
+    // level. Shallow's data lives only in shallow's blob; dropping
+    // shallow would lose data.
+    assert_eq!(fragments.len(), 3);
     assert!(fragments.contains(&deep1));
     assert!(fragments.contains(&deep2));
-    assert!(!fragments.contains(&shallow));
+    assert!(fragments.contains(&shallow));
 }

--- a/sedimentree_core/tests/minimize_dag.rs
+++ b/sedimentree_core/tests/minimize_dag.rs
@@ -312,19 +312,15 @@ fn fragment_boundary_at_merge() {
 /// span a depth-2 fragment's head and boundary, but where neither
 /// individually covers both.
 ///
-/// This configuration is impossible to produce from `build_fragment_store`
-/// (a real depth-3 fragment walks back through every `depth<3` ancestor
-/// as a member, so the same depth-3 fragment would carry both
-/// `shallow_head` AND `shallow_boundary` in its checkpoints). It can
-/// only arise from malformed input — hand-crafted in tests, Byzantine
-/// peers, or storage corruption.
+/// This is impossible from `build_fragment_store` — a real depth-3
+/// fragment walks every `depth<3` ancestor as a member, so a single
+/// depth-3 fragment would carry both `shallow_head` and
+/// `shallow_boundary` in its checkpoints. Only malformed input
+/// (hand-crafted, Byzantine, or corrupted) produces this shape.
 ///
-/// We pin the safe behavior: the shallow fragment is kept. Its data is
-/// not recoverable from the union of deep1's and deep2's blobs in
-/// general, because each deep fragment's blob contains only its own
-/// members. Pre-fix `minimize` dropped shallow on the (unsound)
-/// assumption that collective structural coverage implies recoverable
-/// content.
+/// We pin the safe behaviour: shallow is kept. Each deep fragment's
+/// blob contains only its own members, so dropping shallow on
+/// "collective" coverage would lose its data.
 #[test]
 fn collective_support_from_multiple_deep_keeps_shallow() {
     let sedimentree_id = make_sedimentree_id(1);
@@ -370,9 +366,6 @@ fn collective_support_from_multiple_deep_keeps_shallow() {
     let minimized = tree.minimize(&CountLeadingZeroBytes);
     let fragments: Vec<_> = minimized.fragments().cloned().collect();
 
-    // All three are kept: collective coverage is unsound at the blob
-    // level. Shallow's data lives only in shallow's blob; dropping
-    // shallow would lose data.
     assert_eq!(fragments.len(), 3);
     assert!(fragments.contains(&deep1));
     assert!(fragments.contains(&deep2));

--- a/sedimentree_core/tests/minimize_reference.rs
+++ b/sedimentree_core/tests/minimize_reference.rs
@@ -272,8 +272,7 @@ fn dropped_loose_commits_are_covered_by_kept_fragments() {
             let kept_loose: BTreeSet<CommitId> =
                 prod.loose_commits().map(LooseCommit::head).collect();
 
-            let kept_fragment_coverage: BTreeSet<Checkpoint> =
-                coverage(prod.fragments());
+            let kept_fragment_coverage: BTreeSet<Checkpoint> = coverage(prod.fragments());
 
             for c in tree.loose_commits() {
                 let id = c.head();
@@ -394,7 +393,8 @@ fn fragment_minimization_preserves_coverage() {
             let cov_after = coverage(prod.fragments());
 
             assert_eq!(
-                cov_before, cov_after,
+                cov_before,
+                cov_after,
                 "fragment minimization lost coverage: \
                  before={} entries, after={} entries",
                 cov_before.len(),
@@ -493,8 +493,7 @@ fn minimize_with_no_fragments_keeps_all_commits() {
             let minimized = stripped.minimize(&CountLeadingZeroBytes);
             let prod_set: BTreeSet<CommitId> =
                 minimized.loose_commits().map(LooseCommit::head).collect();
-            let orig_set: BTreeSet<CommitId> =
-                commits.iter().map(LooseCommit::head).collect();
+            let orig_set: BTreeSet<CommitId> = commits.iter().map(LooseCommit::head).collect();
 
             assert_eq!(prod_set, orig_set, "no fragments → all commits kept");
         });
@@ -567,8 +566,12 @@ fn fingerprint_summary_of_minimized_tree_is_stable() {
             // Use a fixed seed so the only variable is the tree.
             let seed = FingerprintSeed::new(0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210);
 
-            let s_orig = tree.minimize(&CountLeadingZeroBytes).fingerprint_summarize(&seed);
-            let s_alt = alt.minimize(&CountLeadingZeroBytes).fingerprint_summarize(&seed);
+            let s_orig = tree
+                .minimize(&CountLeadingZeroBytes)
+                .fingerprint_summarize(&seed);
+            let s_alt = alt
+                .minimize(&CountLeadingZeroBytes)
+                .fingerprint_summarize(&seed);
 
             assert_eq!(
                 s_orig, s_alt,

--- a/sedimentree_core/tests/minimize_reference.rs
+++ b/sedimentree_core/tests/minimize_reference.rs
@@ -56,8 +56,8 @@ use sedimentree_core::{
 /// For each commit `c`, walk all paths toward children, recording for each
 /// terminal path either:
 /// - "rangeless" if the path reaches a tip without crossing any boundary,
-/// - the first boundary commit `B` encountered otherwise (B is `c`'s
-///   range_head along that path).
+/// - the first boundary commit `B` encountered otherwise (`B` is `c`'s
+///   `range_head` along that path).
 ///
 /// `c` is kept iff there is at least one rangeless path, OR at least one
 /// path whose first boundary is uncovered.
@@ -234,7 +234,7 @@ fn minimize_preserves_known_commit_ids() {
         .for_each(|ArbitraryDag { tree }| {
             let prod = tree.minimize(&CountLeadingZeroBytes);
 
-            let known_before = knowable_checkpoints(&tree);
+            let known_before = knowable_checkpoints(tree);
             let known_after = knowable_checkpoints(&prod);
 
             // We require: known_before is a subset of known_after.
@@ -304,7 +304,7 @@ fn all_reachable_commit_ids_remain_knowable() {
         .for_each(|ArbitraryDag { tree }| {
             let prod = tree.minimize(&CountLeadingZeroBytes);
 
-            let reachable_before = reachable_commit_ids(&tree);
+            let reachable_before = reachable_commit_ids(tree);
             let known_after = knowable_checkpoints(&prod);
 
             for id in &reachable_before {
@@ -380,7 +380,7 @@ fn reachable_commit_ids(tree: &Sedimentree) -> BTreeSet<CommitId> {
 /// `Checkpoint`-truncated) of the kept set must equal that of the input
 /// set. Otherwise minimization would lose information.
 ///
-/// This is order-independent and so passes regardless of HashMap
+/// This is order-independent and so passes regardless of `HashMap`
 /// iteration order.
 #[test]
 fn fragment_minimization_preserves_coverage() {

--- a/sedimentree_core/tests/minimize_reference.rs
+++ b/sedimentree_core/tests/minimize_reference.rs
@@ -61,16 +61,11 @@ use sedimentree_core::{
 ///
 /// `c` is kept iff there is at least one rangeless path, OR at least one
 /// path whose first boundary is uncovered.
-///
-/// Production uses reverse-topological-order accumulation from each tip;
-/// the naive form does an independent DFS from each commit. Different
-/// algorithm, same answer.
 fn prune_loose_commits_naive<M: DepthMetric>(
     commits: &[LooseCommit],
     kept_fragments: &[Fragment],
     m: &M,
 ) -> BTreeSet<CommitId> {
-    // Coverage set built from kept fragments.
     let mut covered_range_heads: BTreeSet<CommitId> = BTreeSet::new();
     let mut covered_checkpoints: BTreeSet<Checkpoint> = BTreeSet::new();
     for f in kept_fragments {
@@ -83,9 +78,8 @@ fn prune_loose_commits_naive<M: DepthMetric>(
             || covered_checkpoints.contains(&Checkpoint::new(range_head))
     };
 
-    // Build child-direction adjacency from parent links. Only include
-    // edges between commits in our set; external parent refs are ignored
-    // (matches `CommitDag::from_commits`).
+    // Child-direction adjacency from parent links. External parents are
+    // ignored, matching `CommitDag::from_commits`.
     let commit_id_set: BTreeSet<CommitId> = commits.iter().map(LooseCommit::head).collect();
     let mut child_map: BTreeMap<CommitId, BTreeSet<CommitId>> = BTreeMap::new();
     for c in commits {
@@ -109,12 +103,11 @@ fn should_keep_naive<M: DepthMetric, F: Fn(CommitId) -> bool>(
     m: &M,
     is_covered: &F,
 ) -> bool {
-    // If c is itself a boundary, c's only range head is c itself.
+    // A boundary commit is its own range head.
     if m.to_depth(c).is_boundary() {
         return !is_covered(c);
     }
 
-    // Stack-based DFS toward children, stopping at boundaries.
     let mut visited: BTreeSet<CommitId> = BTreeSet::new();
     let mut stack: Vec<CommitId> = vec![c];
 
@@ -123,23 +116,19 @@ fn should_keep_naive<M: DepthMetric, F: Fn(CommitId) -> bool>(
             continue;
         }
 
+        // First boundary descending from c — it's one of c's range
+        // heads. Don't descend past it.
         if current != c && m.to_depth(current).is_boundary() {
-            // First boundary encountered going from c toward children:
-            // `current` is one of c's range_heads.
             if !is_covered(current) {
-                return true; // uncovered range → keep c
-            }
-            continue; // don't descend past the boundary
-        }
-
-        // Descend to children.
-        match child_map.get(&current) {
-            None => {
-                // current is a tip (no children) and not a boundary →
-                // path reached tip without crossing any boundary →
-                // c is rangeless via this path → keep c.
                 return true;
             }
+            continue;
+        }
+
+        match child_map.get(&current) {
+            // Reached a tip without crossing a boundary: c is rangeless
+            // via this path.
+            None => return true,
             Some(kids) if kids.is_empty() => return true,
             Some(kids) => {
                 for k in kids {
@@ -151,7 +140,6 @@ fn should_keep_naive<M: DepthMetric, F: Fn(CommitId) -> bool>(
         }
     }
 
-    // No path was rangeless and no first-boundary was uncovered → drop c.
     false
 }
 
@@ -177,16 +165,9 @@ fn coverage<'a, I: IntoIterator<Item = &'a Fragment>>(fragments: I) -> BTreeSet<
 
 // ─── Properties ─────────────────────────────────────────────────────────────
 
-/// Loose-commit pruning agrees with the per-commit DFS naive reference.
-///
-/// Given the same set of kept fragments (production's), production's
-/// `simplify`-based pruning and the naive DFS-based pruning must produce
-/// the same surviving commit set.
-///
-/// This is the headline correctness property for the perf change:
-/// `simplify` is what was modified, and `prune_loose_commits_naive` is
-/// algorithmically distinct (different traversal direction, different
-/// per-commit vs per-tip iteration shape).
+/// Production `simplify` and the per-commit DFS reference produce the
+/// same surviving commit set, given the same kept fragments. Headline
+/// correctness property for `simplify`.
 #[test]
 fn loose_commit_pruning_agrees_with_naive() {
     bolero::check!()
@@ -194,9 +175,9 @@ fn loose_commit_pruning_agrees_with_naive() {
         .for_each(|ArbitraryDag { tree }| {
             let prod = tree.minimize(&CountLeadingZeroBytes);
 
-            // Use production's kept fragments to feed the naive pruner —
-            // we want to test the loose-commit pruning step in isolation,
-            // not the fragment-minimization step.
+            // Feed production's kept fragments to the naive pruner so
+            // we test loose-commit pruning in isolation from
+            // fragment-minimization.
             let kept_fragments: Vec<Fragment> = prod.fragments().cloned().collect();
             let original_commits: Vec<LooseCommit> = tree.loose_commits().cloned().collect();
 
@@ -216,17 +197,13 @@ fn loose_commit_pruning_agrees_with_naive() {
 }
 
 /// **No data loss.** Every `CommitId` known to the original tree is
-/// still knowable from the minimized tree.
+/// still knowable from the minimized tree, where "knowable" means
+/// `Checkpoint::new(id)` appears in the tree's combined coverage
+/// (loose-commit heads, fragment heads/boundaries/checkpoints) — the
+/// precision `simplify` uses.
 ///
-/// "Knowable" means: the `Checkpoint::new(commit_id)` truncation appears
-/// somewhere in the tree's combined `Checkpoint`-set (loose-commit
-/// heads, fragment heads, fragment boundaries, or fragment checkpoints).
-/// This matches the precision `simplify_inner` actually uses for
-/// coverage decisions.
-///
-/// Catches the family of bugs where `minimize` drops a loose commit but
-/// no kept fragment retains evidence of its existence — i.e., genuine
-/// op-loss as opposed to redundancy elimination.
+/// Catches `minimize` dropping a loose commit when no kept fragment
+/// retains evidence of it (genuine op-loss, not redundancy elimination).
 #[test]
 fn minimize_preserves_known_commit_ids() {
     bolero::check!()
@@ -237,11 +214,9 @@ fn minimize_preserves_known_commit_ids() {
             let known_before = knowable_checkpoints(tree);
             let known_after = knowable_checkpoints(&prod);
 
-            // We require: known_before is a subset of known_after.
-            // (Equality would also be fine, but the kept fragments may
-            // legitimately re-state checkpoints from dropped fragments.
-            // What we cannot tolerate is the kept set _missing_ anything
-            // the input set knew about.)
+            // `known_after` may be a strict superset (kept fragments can
+            // re-state checkpoints from dropped peers); we only require
+            // that nothing the input knew about is missing.
             let lost: BTreeSet<&Checkpoint> = known_before.difference(&known_after).collect();
             assert!(
                 lost.is_empty(),
@@ -252,16 +227,9 @@ fn minimize_preserves_known_commit_ids() {
         });
 }
 
-/// Loose-commit pruning never drops an unknowable commit.
-///
-/// Specifically: if `minimize` drops a loose commit C from `t.loose_commits()`,
-/// then `Checkpoint::new(C.head())` must appear in the kept fragments'
-/// combined coverage (otherwise we've genuinely lost C from the tree).
-///
-/// This is the per-commit version of [`minimize_preserves_known_commit_ids`]
-/// — same invariant viewed from the loose-commit side. Strictly stronger
-/// against the failure mode "drop a commit even though no fragment
-/// covers it".
+/// Per-commit version of [`minimize_preserves_known_commit_ids`]: any
+/// loose commit `C` that `minimize` drops must have
+/// `Checkpoint::new(C.head())` in some kept fragment's coverage.
 #[test]
 fn dropped_loose_commits_are_covered_by_kept_fragments() {
     bolero::check!()
@@ -288,15 +256,13 @@ fn dropped_loose_commits_are_covered_by_kept_fragments() {
         });
 }
 
-/// All `CommitId`s reachable from the original tree's heads (via parent
-/// pointers in loose commits, plus fragment heads/boundaries) are still
-/// knowable in the minimized tree.
-///
-/// Stronger than `minimize_preserves_known_commit_ids` because it walks
-/// the full ancestor graph from heads, not just the directly-stored
-/// `CommitId`s. This is the closest property we can write to "an
-/// Automerge document re-derived from the minimized tree contains all
-/// the same change hashes" without actually pulling in Automerge.
+/// Every `CommitId` reachable from the original tree's heads (via
+/// loose-commit parent pointers and fragment heads/boundaries) is still
+/// knowable in the minimized tree. Stronger than
+/// [`minimize_preserves_known_commit_ids`] — walks the full ancestor
+/// graph, not just directly-stored `CommitId`s. The closest pure-
+/// `sedimentree_core` analogue of "Automerge round-trip preserves all
+/// change hashes".
 #[test]
 fn all_reachable_commit_ids_remain_knowable() {
     bolero::check!()
@@ -403,10 +369,8 @@ fn fragment_minimization_preserves_coverage() {
         });
 }
 
-/// Production `minimize` is deterministic *within* a process.
-///
-/// Multiple calls on the same input within one process must produce
-/// equal `Sedimentree`s.
+/// Multiple `minimize` calls on the same input within one process
+/// produce equal `Sedimentree`s.
 #[test]
 fn minimize_is_deterministic_within_process() {
     bolero::check!()
@@ -418,22 +382,11 @@ fn minimize_is_deterministic_within_process() {
         });
 }
 
-/// Production `minimize` is deterministic *across constructions*.
-///
-/// Building the same logical `Sedimentree` from two different orderings
-/// of input fragments and commits must produce equal `minimize` outputs.
-///
-/// This is the regression test for the cross-process non-determinism
-/// bug. Different `Sedimentree::new` calls produce internal `Map`s with
-/// different (hasher-state-dependent) iteration orders. Before the fix,
-/// `minimize` leaked that order into its output by iterating
-/// `self.fragments.values()` to populate a per-depth `Vec`, so two
-/// `Sedimentree`s constructed differently could yield different
-/// `minimize` outputs even with identical input fragments and commits.
-///
-/// Two `Sedimentree::new` invocations within one process can in
-/// principle still hash identically, so to be sure we shuffle the
-/// inputs deterministically and assert agreement.
+/// Building the same logical `Sedimentree` from differently-ordered
+/// inputs produces equal `minimize` outputs. Regression test for the
+/// cross-process non-determinism bug: pre-fix, `minimize` iterated
+/// `self.fragments.values()` to populate a per-depth `Vec`, leaking the
+/// `HashMap`'s hasher-state-dependent order into its output.
 #[test]
 fn minimize_is_deterministic_across_constructions() {
     use rand::{SeedableRng, rngs::SmallRng, seq::SliceRandom};
@@ -459,17 +412,10 @@ fn minimize_is_deterministic_across_constructions() {
         });
 }
 
-/// `minimize` is idempotent: minimizing twice yields the same tree.
-///
-/// Regression test for the determinism fix. Before the fix, this
-/// failed because `tree.minimize()` produced N fragments, but
-/// re-minimizing produced N-1 — the first pass did not reach a fixed
-/// point because `Map<CommitId, Fragment>` iteration order varies
-/// across `Sedimentree::new` invocations, so re-minimization picked a
-/// different mutual-dominance representative.
-///
-/// The fix sorts fragments by head bytes before processing, making
-/// the per-depth iteration order independent of `HashMap` hasher state.
+/// `tree.minimize().minimize() == tree.minimize()`. Pre-fix this could
+/// fail: `Sedimentree::new` produced a fresh `HashMap` whose iteration
+/// order differed from the input's, so re-minimize picked a different
+/// mutual-dominance representative.
 #[test]
 fn minimize_is_idempotent() {
     bolero::check!()
@@ -502,17 +448,10 @@ fn minimize_with_no_fragments_keeps_all_commits() {
 // ─── Downstream stability ───────────────────────────────────────────────────
 
 /// `MinimalTreeHash` is stable across `Sedimentree` constructions.
-///
-/// This is the headline user-facing property. Two peers with identical
-/// content must compute identical `minimal_hash` values, regardless of
-/// how they constructed their local `Sedimentree` (which depends on
-/// `HashMap` iteration order — a per-process random thing).
-///
-/// `minimal_hash` calls `self.minimize(m)` internally, so this property
-/// is the direct downstream consequence of the determinism fix. Before
-/// the fix, two peers with identical state could compute different
-/// hashes and (depending on consumer logic) believe they were out of
-/// sync, repeatedly trigger redundant resync, or fail equality checks.
+/// Headline user-facing consequence of the determinism fix:
+/// `minimal_hash` calls `minimize` internally, so two peers with
+/// identical content must compute identical hashes regardless of local
+/// `HashMap` ordering.
 #[test]
 fn minimal_hash_is_stable_across_constructions() {
     use rand::{SeedableRng, rngs::SmallRng, seq::SliceRandom};
@@ -539,14 +478,10 @@ fn minimal_hash_is_stable_across_constructions() {
         });
 }
 
-/// `fingerprint_summarize` of a minimized tree is stable across
-/// constructions.
-///
-/// `fingerprint_summarize` itself is order-independent (uses `BTreeSet`
-/// internally), but the typical sync flow is `tree.minimize().fingerprint_summarize()`,
-/// where `minimize` was the source of non-determinism. This property
-/// pins the composed behaviour: two peers with identical content
-/// produce identical wire summaries.
+/// `tree.minimize().fingerprint_summarize(seed)` is stable across
+/// constructions. `fingerprint_summarize` is itself order-independent;
+/// this pins the composed sync-flow behaviour against `minimize`'s
+/// pre-fix non-determinism.
 #[test]
 fn fingerprint_summary_of_minimized_tree_is_stable() {
     use rand::{SeedableRng, rngs::SmallRng, seq::SliceRandom};

--- a/sedimentree_core/tests/minimize_reference.rs
+++ b/sedimentree_core/tests/minimize_reference.rs
@@ -1,0 +1,578 @@
+//! Naive-reference equivalence tests for [`Sedimentree::minimize`].
+//!
+//! Tests the production minimize algorithm against an independent naive
+//! reference, plus a battery of structural-correctness properties.
+//!
+//! ## Properties at a glance
+//!
+//! - **Equivalence to naive reference**
+//!   ([`loose_commit_pruning_agrees_with_naive`]): the naive impl computes
+//!   the surviving commit set via per-commit DFS toward children
+//!   (production uses reverse-topo accumulation from tips). Different
+//!   algorithm, same answer.
+//!
+//! - **Coverage preservation** ([`fragment_minimization_preserves_coverage`]):
+//!   the combined `head ∪ boundary ∪ checkpoints` `Checkpoint`-set of
+//!   kept fragments equals that of the input fragments. Minimization
+//!   doesn't lose data via the fragment side.
+//!
+//! - **No data loss via reachability**
+//!   ([`minimize_preserves_known_commit_ids`]): every `CommitId` known
+//!   to the original tree (as commit head, fragment head, fragment
+//!   boundary, or fragment checkpoint) is still known to the minimized
+//!   tree. The Checkpoint-truncation precision is honoured.
+//!
+//! - **Determinism** ([`minimize_is_deterministic_within_process`],
+//!   [`minimize_is_deterministic_across_constructions`],
+//!   [`minimize_is_idempotent`]): same content → same output, regardless
+//!   of construction order or call count.
+//!
+//! - **Downstream stability**
+//!   ([`minimal_hash_is_stable_across_constructions`],
+//!   [`fingerprint_summary_of_minimized_tree_is_stable`]): the
+//!   user-visible derived values are stable.
+//!
+//! Requires the `test_utils` and `bolero` features.
+
+#![cfg(all(feature = "test_utils", feature = "bolero"))]
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use sedimentree_core::{
+    commit::CountLeadingZeroBytes,
+    crypto::fingerprint::FingerprintSeed,
+    depth::DepthMetric,
+    fragment::{Fragment, checkpoint::Checkpoint},
+    loose_commit::{LooseCommit, id::CommitId},
+    sedimentree::Sedimentree,
+    test_utils::ArbitraryDag,
+};
+
+// ─── Naive loose-commit pruning ─────────────────────────────────────────────
+
+/// Per-commit DFS reference for loose-commit pruning.
+///
+/// For each commit `c`, walk all paths toward children, recording for each
+/// terminal path either:
+/// - "rangeless" if the path reaches a tip without crossing any boundary,
+/// - the first boundary commit `B` encountered otherwise (B is `c`'s
+///   range_head along that path).
+///
+/// `c` is kept iff there is at least one rangeless path, OR at least one
+/// path whose first boundary is uncovered.
+///
+/// Production uses reverse-topological-order accumulation from each tip;
+/// the naive form does an independent DFS from each commit. Different
+/// algorithm, same answer.
+fn prune_loose_commits_naive<M: DepthMetric>(
+    commits: &[LooseCommit],
+    kept_fragments: &[Fragment],
+    m: &M,
+) -> BTreeSet<CommitId> {
+    // Coverage set built from kept fragments.
+    let mut covered_range_heads: BTreeSet<CommitId> = BTreeSet::new();
+    let mut covered_checkpoints: BTreeSet<Checkpoint> = BTreeSet::new();
+    for f in kept_fragments {
+        covered_range_heads.insert(f.head());
+        covered_range_heads.extend(f.boundary().iter().copied());
+        covered_checkpoints.extend(f.checkpoints().iter().copied());
+    }
+    let is_covered = |range_head: CommitId| -> bool {
+        covered_range_heads.contains(&range_head)
+            || covered_checkpoints.contains(&Checkpoint::new(range_head))
+    };
+
+    // Build child-direction adjacency from parent links. Only include
+    // edges between commits in our set; external parent refs are ignored
+    // (matches `CommitDag::from_commits`).
+    let commit_id_set: BTreeSet<CommitId> = commits.iter().map(LooseCommit::head).collect();
+    let mut child_map: BTreeMap<CommitId, BTreeSet<CommitId>> = BTreeMap::new();
+    for c in commits {
+        for parent in c.parents() {
+            if commit_id_set.contains(parent) {
+                child_map.entry(*parent).or_default().insert(c.head());
+            }
+        }
+    }
+
+    commits
+        .iter()
+        .filter(|c| should_keep_naive(c.head(), &child_map, m, &is_covered))
+        .map(LooseCommit::head)
+        .collect()
+}
+
+fn should_keep_naive<M: DepthMetric, F: Fn(CommitId) -> bool>(
+    c: CommitId,
+    child_map: &BTreeMap<CommitId, BTreeSet<CommitId>>,
+    m: &M,
+    is_covered: &F,
+) -> bool {
+    // If c is itself a boundary, c's only range head is c itself.
+    if m.to_depth(c).is_boundary() {
+        return !is_covered(c);
+    }
+
+    // Stack-based DFS toward children, stopping at boundaries.
+    let mut visited: BTreeSet<CommitId> = BTreeSet::new();
+    let mut stack: Vec<CommitId> = vec![c];
+
+    while let Some(current) = stack.pop() {
+        if !visited.insert(current) {
+            continue;
+        }
+
+        if current != c && m.to_depth(current).is_boundary() {
+            // First boundary encountered going from c toward children:
+            // `current` is one of c's range_heads.
+            if !is_covered(current) {
+                return true; // uncovered range → keep c
+            }
+            continue; // don't descend past the boundary
+        }
+
+        // Descend to children.
+        match child_map.get(&current) {
+            None => {
+                // current is a tip (no children) and not a boundary →
+                // path reached tip without crossing any boundary →
+                // c is rangeless via this path → keep c.
+                return true;
+            }
+            Some(kids) if kids.is_empty() => return true,
+            Some(kids) => {
+                for k in kids {
+                    if !visited.contains(k) {
+                        stack.push(*k);
+                    }
+                }
+            }
+        }
+    }
+
+    // No path was rangeless and no first-boundary was uncovered → drop c.
+    false
+}
+
+// ─── Coverage helpers ───────────────────────────────────────────────────────
+
+/// The "coverage" of a fragment set: the union of every fragment's head,
+/// boundary commits, and checkpoints (each as `Checkpoint`-truncated values).
+///
+/// Two fragment sets with equal coverage are functionally equivalent for
+/// the purposes of [`Sedimentree::minimize`]'s loose-commit pruning: any
+/// loose commit dropped under one is also dropped under the other.
+fn coverage<'a, I: IntoIterator<Item = &'a Fragment>>(fragments: I) -> BTreeSet<Checkpoint> {
+    let mut cov: BTreeSet<Checkpoint> = BTreeSet::new();
+    for f in fragments {
+        cov.insert(Checkpoint::new(f.head()));
+        for b in f.boundary() {
+            cov.insert(Checkpoint::new(*b));
+        }
+        cov.extend(f.checkpoints().iter().copied());
+    }
+    cov
+}
+
+// ─── Properties ─────────────────────────────────────────────────────────────
+
+/// Loose-commit pruning agrees with the per-commit DFS naive reference.
+///
+/// Given the same set of kept fragments (production's), production's
+/// `simplify`-based pruning and the naive DFS-based pruning must produce
+/// the same surviving commit set.
+///
+/// This is the headline correctness property for the perf change:
+/// `simplify` is what was modified, and `prune_loose_commits_naive` is
+/// algorithmically distinct (different traversal direction, different
+/// per-commit vs per-tip iteration shape).
+#[test]
+fn loose_commit_pruning_agrees_with_naive() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let prod = tree.minimize(&CountLeadingZeroBytes);
+
+            // Use production's kept fragments to feed the naive pruner —
+            // we want to test the loose-commit pruning step in isolation,
+            // not the fragment-minimization step.
+            let kept_fragments: Vec<Fragment> = prod.fragments().cloned().collect();
+            let original_commits: Vec<LooseCommit> = tree.loose_commits().cloned().collect();
+
+            let prod_commits: BTreeSet<CommitId> =
+                prod.loose_commits().map(LooseCommit::head).collect();
+            let naive_commits = prune_loose_commits_naive(
+                &original_commits,
+                &kept_fragments,
+                &CountLeadingZeroBytes,
+            );
+
+            assert_eq!(
+                prod_commits, naive_commits,
+                "loose-commit pruning diverges between production simplify and naive DFS"
+            );
+        });
+}
+
+/// **No data loss.** Every `CommitId` known to the original tree is
+/// still knowable from the minimized tree.
+///
+/// "Knowable" means: the `Checkpoint::new(commit_id)` truncation appears
+/// somewhere in the tree's combined `Checkpoint`-set (loose-commit
+/// heads, fragment heads, fragment boundaries, or fragment checkpoints).
+/// This matches the precision `simplify_inner` actually uses for
+/// coverage decisions.
+///
+/// Catches the family of bugs where `minimize` drops a loose commit but
+/// no kept fragment retains evidence of its existence — i.e., genuine
+/// op-loss as opposed to redundancy elimination.
+#[test]
+fn minimize_preserves_known_commit_ids() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let prod = tree.minimize(&CountLeadingZeroBytes);
+
+            let known_before = knowable_checkpoints(&tree);
+            let known_after = knowable_checkpoints(&prod);
+
+            // We require: known_before is a subset of known_after.
+            // (Equality would also be fine, but the kept fragments may
+            // legitimately re-state checkpoints from dropped fragments.
+            // What we cannot tolerate is the kept set _missing_ anything
+            // the input set knew about.)
+            let lost: BTreeSet<&Checkpoint> = known_before.difference(&known_after).collect();
+            assert!(
+                lost.is_empty(),
+                "minimize lost knowledge of {} commit(s); first few: {:?}",
+                lost.len(),
+                lost.iter().take(5).collect::<Vec<_>>(),
+            );
+        });
+}
+
+/// Loose-commit pruning never drops an unknowable commit.
+///
+/// Specifically: if `minimize` drops a loose commit C from `t.loose_commits()`,
+/// then `Checkpoint::new(C.head())` must appear in the kept fragments'
+/// combined coverage (otherwise we've genuinely lost C from the tree).
+///
+/// This is the per-commit version of [`minimize_preserves_known_commit_ids`]
+/// — same invariant viewed from the loose-commit side. Strictly stronger
+/// against the failure mode "drop a commit even though no fragment
+/// covers it".
+#[test]
+fn dropped_loose_commits_are_covered_by_kept_fragments() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let prod = tree.minimize(&CountLeadingZeroBytes);
+
+            let kept_loose: BTreeSet<CommitId> =
+                prod.loose_commits().map(LooseCommit::head).collect();
+
+            let kept_fragment_coverage: BTreeSet<Checkpoint> =
+                coverage(prod.fragments());
+
+            for c in tree.loose_commits() {
+                let id = c.head();
+                if !kept_loose.contains(&id) {
+                    let cp = Checkpoint::new(id);
+                    assert!(
+                        kept_fragment_coverage.contains(&cp),
+                        "loose commit {id:?} was dropped but its checkpoint \
+                         is not in any kept fragment"
+                    );
+                }
+            }
+        });
+}
+
+/// All `CommitId`s reachable from the original tree's heads (via parent
+/// pointers in loose commits, plus fragment heads/boundaries) are still
+/// knowable in the minimized tree.
+///
+/// Stronger than `minimize_preserves_known_commit_ids` because it walks
+/// the full ancestor graph from heads, not just the directly-stored
+/// `CommitId`s. This is the closest property we can write to "an
+/// Automerge document re-derived from the minimized tree contains all
+/// the same change hashes" without actually pulling in Automerge.
+#[test]
+fn all_reachable_commit_ids_remain_knowable() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let prod = tree.minimize(&CountLeadingZeroBytes);
+
+            let reachable_before = reachable_commit_ids(&tree);
+            let known_after = knowable_checkpoints(&prod);
+
+            for id in &reachable_before {
+                let cp = Checkpoint::new(*id);
+                assert!(
+                    known_after.contains(&cp),
+                    "commit {id:?} reachable from input tree's heads but \
+                     not knowable from minimized tree"
+                );
+            }
+        });
+}
+
+/// All `Checkpoint`s a tree carries, considering loose commits AND
+/// fragments at the truncation precision actually used by `simplify`.
+fn knowable_checkpoints(tree: &Sedimentree) -> BTreeSet<Checkpoint> {
+    let mut s: BTreeSet<Checkpoint> = BTreeSet::new();
+    for c in tree.loose_commits() {
+        s.insert(Checkpoint::new(c.head()));
+    }
+    for f in tree.fragments() {
+        s.insert(Checkpoint::new(f.head()));
+        for b in f.boundary() {
+            s.insert(Checkpoint::new(*b));
+        }
+        s.extend(f.checkpoints().iter().copied());
+    }
+    s
+}
+
+/// Every `CommitId` reachable by walking `LooseCommit::parents()` backward
+/// from any commit in the tree, plus every `Fragment` head and boundary.
+fn reachable_commit_ids(tree: &Sedimentree) -> BTreeSet<CommitId> {
+    let mut all: BTreeSet<CommitId> = BTreeSet::new();
+    let mut stack: Vec<CommitId> = Vec::new();
+
+    for c in tree.loose_commits() {
+        all.insert(c.head());
+        stack.push(c.head());
+    }
+    for f in tree.fragments() {
+        all.insert(f.head());
+        stack.push(f.head());
+        for b in f.boundary() {
+            all.insert(*b);
+            stack.push(*b);
+        }
+    }
+
+    // Walk parent pointers transitively.
+    let parents_of: BTreeMap<CommitId, BTreeSet<CommitId>> = tree
+        .loose_commits()
+        .map(|c| (c.head(), c.parents().iter().copied().collect()))
+        .collect();
+
+    while let Some(id) = stack.pop() {
+        if let Some(parents) = parents_of.get(&id) {
+            for p in parents {
+                if all.insert(*p) {
+                    stack.push(*p);
+                }
+            }
+        }
+    }
+
+    all
+}
+
+/// Fragment minimization preserves total coverage.
+///
+/// Whichever fragments production picks among mutual-dominance
+/// alternatives, the combined coverage (head ∪ boundary ∪ checkpoints,
+/// `Checkpoint`-truncated) of the kept set must equal that of the input
+/// set. Otherwise minimization would lose information.
+///
+/// This is order-independent and so passes regardless of HashMap
+/// iteration order.
+#[test]
+fn fragment_minimization_preserves_coverage() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let prod = tree.minimize(&CountLeadingZeroBytes);
+
+            let cov_before = coverage(tree.fragments());
+            let cov_after = coverage(prod.fragments());
+
+            assert_eq!(
+                cov_before, cov_after,
+                "fragment minimization lost coverage: \
+                 before={} entries, after={} entries",
+                cov_before.len(),
+                cov_after.len()
+            );
+        });
+}
+
+/// Production `minimize` is deterministic *within* a process.
+///
+/// Multiple calls on the same input within one process must produce
+/// equal `Sedimentree`s.
+#[test]
+fn minimize_is_deterministic_within_process() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let m1 = tree.minimize(&CountLeadingZeroBytes);
+            let m2 = tree.minimize(&CountLeadingZeroBytes);
+            assert_eq!(m1, m2, "minimize not deterministic within a process");
+        });
+}
+
+/// Production `minimize` is deterministic *across constructions*.
+///
+/// Building the same logical `Sedimentree` from two different orderings
+/// of input fragments and commits must produce equal `minimize` outputs.
+///
+/// This is the regression test for the cross-process non-determinism
+/// bug. Different `Sedimentree::new` calls produce internal `Map`s with
+/// different (hasher-state-dependent) iteration orders. Before the fix,
+/// `minimize` leaked that order into its output by iterating
+/// `self.fragments.values()` to populate a per-depth `Vec`, so two
+/// `Sedimentree`s constructed differently could yield different
+/// `minimize` outputs even with identical input fragments and commits.
+///
+/// Two `Sedimentree::new` invocations within one process can in
+/// principle still hash identically, so to be sure we shuffle the
+/// inputs deterministically and assert agreement.
+#[test]
+fn minimize_is_deterministic_across_constructions() {
+    use rand::{SeedableRng, rngs::SmallRng, seq::SliceRandom};
+
+    bolero::check!()
+        .with_arbitrary::<(ArbitraryDag, u64)>()
+        .for_each(|(ArbitraryDag { tree }, shuffle_seed)| {
+            let mut frags: Vec<Fragment> = tree.fragments().cloned().collect();
+            let mut commits: Vec<LooseCommit> = tree.loose_commits().cloned().collect();
+
+            let mut rng = SmallRng::seed_from_u64(*shuffle_seed);
+            frags.shuffle(&mut rng);
+            commits.shuffle(&mut rng);
+
+            let alt = Sedimentree::new(frags, commits);
+            let m_orig = tree.minimize(&CountLeadingZeroBytes);
+            let m_alt = alt.minimize(&CountLeadingZeroBytes);
+
+            assert_eq!(
+                m_orig, m_alt,
+                "minimize output depends on Sedimentree construction order"
+            );
+        });
+}
+
+/// `minimize` is idempotent: minimizing twice yields the same tree.
+///
+/// Regression test for the determinism fix. Before the fix, this
+/// failed because `tree.minimize()` produced N fragments, but
+/// re-minimizing produced N-1 — the first pass did not reach a fixed
+/// point because `Map<CommitId, Fragment>` iteration order varies
+/// across `Sedimentree::new` invocations, so re-minimization picked a
+/// different mutual-dominance representative.
+///
+/// The fix sorts fragments by head bytes before processing, making
+/// the per-depth iteration order independent of `HashMap` hasher state.
+#[test]
+fn minimize_is_idempotent() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let once = tree.minimize(&CountLeadingZeroBytes);
+            let twice = once.minimize(&CountLeadingZeroBytes);
+            assert_eq!(once, twice, "minimize is not idempotent");
+        });
+}
+
+/// With no fragments, `minimize` keeps every commit.
+#[test]
+fn minimize_with_no_fragments_keeps_all_commits() {
+    bolero::check!()
+        .with_arbitrary::<ArbitraryDag>()
+        .for_each(|ArbitraryDag { tree }| {
+            let commits: Vec<LooseCommit> = tree.loose_commits().cloned().collect();
+            let stripped = Sedimentree::new(vec![], commits.clone());
+
+            let minimized = stripped.minimize(&CountLeadingZeroBytes);
+            let prod_set: BTreeSet<CommitId> =
+                minimized.loose_commits().map(LooseCommit::head).collect();
+            let orig_set: BTreeSet<CommitId> =
+                commits.iter().map(LooseCommit::head).collect();
+
+            assert_eq!(prod_set, orig_set, "no fragments → all commits kept");
+        });
+}
+
+// ─── Downstream stability ───────────────────────────────────────────────────
+
+/// `MinimalTreeHash` is stable across `Sedimentree` constructions.
+///
+/// This is the headline user-facing property. Two peers with identical
+/// content must compute identical `minimal_hash` values, regardless of
+/// how they constructed their local `Sedimentree` (which depends on
+/// `HashMap` iteration order — a per-process random thing).
+///
+/// `minimal_hash` calls `self.minimize(m)` internally, so this property
+/// is the direct downstream consequence of the determinism fix. Before
+/// the fix, two peers with identical state could compute different
+/// hashes and (depending on consumer logic) believe they were out of
+/// sync, repeatedly trigger redundant resync, or fail equality checks.
+#[test]
+fn minimal_hash_is_stable_across_constructions() {
+    use rand::{SeedableRng, rngs::SmallRng, seq::SliceRandom};
+
+    bolero::check!()
+        .with_arbitrary::<(ArbitraryDag, u64)>()
+        .for_each(|(ArbitraryDag { tree }, shuffle_seed)| {
+            let mut frags: Vec<Fragment> = tree.fragments().cloned().collect();
+            let mut commits: Vec<LooseCommit> = tree.loose_commits().cloned().collect();
+
+            let mut rng = SmallRng::seed_from_u64(*shuffle_seed);
+            frags.shuffle(&mut rng);
+            commits.shuffle(&mut rng);
+
+            let alt = Sedimentree::new(frags, commits);
+            let h_orig = tree.minimal_hash(&CountLeadingZeroBytes);
+            let h_alt = alt.minimal_hash(&CountLeadingZeroBytes);
+
+            assert_eq!(
+                h_orig.as_bytes(),
+                h_alt.as_bytes(),
+                "minimal_hash differs for Sedimentrees with identical content but different construction order"
+            );
+        });
+}
+
+/// `fingerprint_summarize` of a minimized tree is stable across
+/// constructions.
+///
+/// `fingerprint_summarize` itself is order-independent (uses `BTreeSet`
+/// internally), but the typical sync flow is `tree.minimize().fingerprint_summarize()`,
+/// where `minimize` was the source of non-determinism. This property
+/// pins the composed behaviour: two peers with identical content
+/// produce identical wire summaries.
+#[test]
+fn fingerprint_summary_of_minimized_tree_is_stable() {
+    use rand::{SeedableRng, rngs::SmallRng, seq::SliceRandom};
+
+    bolero::check!()
+        .with_arbitrary::<(ArbitraryDag, u64)>()
+        .for_each(|(ArbitraryDag { tree }, shuffle_seed)| {
+            let mut frags: Vec<Fragment> = tree.fragments().cloned().collect();
+            let mut commits: Vec<LooseCommit> = tree.loose_commits().cloned().collect();
+
+            let mut rng = SmallRng::seed_from_u64(*shuffle_seed);
+            frags.shuffle(&mut rng);
+            commits.shuffle(&mut rng);
+
+            let alt = Sedimentree::new(frags, commits);
+
+            // Use a fixed seed so the only variable is the tree.
+            let seed = FingerprintSeed::new(0x0123_4567_89ab_cdef, 0xfedc_ba98_7654_3210);
+
+            let s_orig = tree.minimize(&CountLeadingZeroBytes).fingerprint_summarize(&seed);
+            let s_alt = alt.minimize(&CountLeadingZeroBytes).fingerprint_summarize(&seed);
+
+            assert_eq!(
+                s_orig, s_alt,
+                "fingerprint summary of minimized tree differs across constructions"
+            );
+        });
+}


### PR DESCRIPTION
### Perf

| Bench                         | Baseline | After    | Speedup |
|-------------------------------|----------|----------|---------|
| `heads/linear_dag/5000`       | 523 ms   | 13.7 ms  | **38×** |
| `minimize/linear_dag/5000`    | 195 ms   | 10.2 ms  | **20×** |
| `heads/linear_dag/1000`       | 16.5 ms  | 1.36 ms  | 12×     |
| `minimize/linear_dag/1000`    | 7.4 ms   | 1.12 ms  | 6.6×    |

How:
- `CommitDag::add_edge`: O(degree) → O(1) prepend.
- `simplify` returns `Set<CommitId>` instead of rebuilding a `CommitDag`.
- `simplify` coverage check inverted: O(commits×ranges×fragments) →
  O(fragments) precompute + O(ranges) lookups.
- `heads()`: precompute fragment-boundary union (O(F²) → O(F)).

Minor regressions on tiny inputs (10-element DAGs, +10–32%) where
set-construction overhead dominates. Real workloads are firmly in the
asymptotic regime.

### Two correctness fixes that fell out

While validating the perf change with property tests, found and fixed:
1. **Cross-process determinism.** `minimize` iterated `HashMap` order
   to populate per-depth groups, producing different output across
   processes for identical content. Two peers could compute different
   `MinimalTreeHash` values for the same data. Fix: sort fragments by
   head bytes before grouping.
2. **Data loss on minimize.** Same-depth fragments could "dominate"
   each other structurally even though their blobs were disjoint —
   silently losing change data on real Automerge workloads. A1
   ingested to 7 fragments, minimize kept 2, round-trip recovered 0
   of 1 heads (70% of changes lost). Fix: dominance now requires a
   *strictly deeper* kept fragment that individually subsumes the
   candidate.

### Tests
- 11 new bolero properties inclusing naive DFS reference, determinism,
  idempotency, `MinimalTreeHash` stability.
- All 7 egwalker vectors (S1–S3, A1, A2, C1, C2) round-trip through
  ingest → minimize → reassemble; canonical hashes pinned.
- `cargo test --workspace`: all green.