### PR TITLE
Fix fingerprinting arch bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,6 +3013,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,6 +3171,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -3558,6 +3574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4787,7 +4804,7 @@ dependencies = [
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures 0.4.68",
- "wasm-bindgen-test",
+ "wasm-bindgen-test 0.3.68",
  "wasm_refgen",
  "web-sys",
 ]
@@ -5390,7 +5407,7 @@ dependencies = [
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures 0.4.68",
- "wasm-bindgen-test",
+ "wasm-bindgen-test 0.2.50",
  "wasm_refgen",
  "web-sys",
 ]
@@ -6334,7 +6351,29 @@ dependencies = [
  "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures 0.3.27",
- "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-macro 0.2.50",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures 0.4.68",
+ "wasm-bindgen-test-macro 0.3.68",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
@@ -6346,6 +6385,23 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
 ]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,9 +2333,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -4046,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",
@@ -5130,9 +5130,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "str_stack"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"
@@ -7050,9 +7050,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/sedimentree_core/src/crypto/fingerprint.rs
+++ b/sedimentree_core/src/crypto/fingerprint.rs
@@ -148,34 +148,25 @@ pub struct Fingerprint<T> {
     _marker: PhantomData<T>,
 }
 
-/// A type whose bytes can be fed into a fingerprint hasher in a
-/// **cross-architecture-stable** way.
+/// A type whose bytes can be fed into a fingerprint hasher portably.
 ///
-/// The standard library's [`Hash`](core::hash::Hash) trait is *not*
-/// suitable for cross-platform sync: `<[u8; N] as Hash>::hash` (and
-/// `<[T] as Hash>::hash`) prefix the data with `state.write_usize(N)`,
-/// whose byte width differs between 32-bit (e.g. wasm32) and 64-bit
-/// (e.g. x86_64) targets. A browser and a native peer hashing the
-/// same `CommitId` therefore produce different fingerprints, breaking
-/// set reconciliation entirely.
+/// We bypass [`core::hash::Hash`] because `<[u8; N] as Hash>::hash` writes
+/// a `state.write_usize(N)` length prefix whose byte width differs on
+/// 32-bit (e.g. wasm32) vs 64-bit (e.g. x86_64) targets, so a browser
+/// and a native peer would compute different fingerprints for the same
+/// `CommitId`.
 ///
-/// Implementors of this trait return the raw bytes to hash directly,
-/// bypassing `Hash`'s architecture-dependent length-prefix machinery.
+/// Implementations must return bytes of a fixed length for all values
+/// of `Self` (or otherwise self-delimit). `fingerprint_bytes` is fed to
+/// SipHash without a length prefix, so variable-length encodings could
+/// collide.
 pub trait FingerprintInput {
     /// Raw bytes to feed into the fingerprint hasher.
-    ///
-    /// Implementations must return identical bytes on every target
-    /// for the same logical value.
     fn fingerprint_bytes(&self) -> &[u8];
 }
 
 impl<T: FingerprintInput> Fingerprint<T> {
-    /// Compute a fingerprint of a [`FingerprintInput`] value using the
-    /// given seed.
-    ///
-    /// Writes the value's [`fingerprint_bytes`](FingerprintInput::fingerprint_bytes)
-    /// directly into SipHash-2-4 — no length prefix, no architecture
-    /// dependence.
+    /// Compute a fingerprint of `value` under `seed`.
     ///
     /// ```
     /// use sedimentree_core::{

--- a/sedimentree_core/src/crypto/fingerprint.rs
+++ b/sedimentree_core/src/crypto/fingerprint.rs
@@ -4,7 +4,7 @@
 //! compact (`u64`) [`Fingerprint<T>`] values. This is especially
 //! useful for bandwidth-efficient sync.
 
-use core::{hash::Hasher, marker::PhantomData};
+use core::marker::PhantomData;
 
 use siphasher::sip::SipHasher24;
 
@@ -148,22 +148,51 @@ pub struct Fingerprint<T> {
     _marker: PhantomData<T>,
 }
 
-impl<T: core::hash::Hash> Fingerprint<T> {
-    /// Compute a fingerprint of a hashable value using the given seed.
+/// A type whose bytes can be fed into a fingerprint hasher in a
+/// **cross-architecture-stable** way.
+///
+/// The standard library's [`Hash`](core::hash::Hash) trait is *not*
+/// suitable for cross-platform sync: `<[u8; N] as Hash>::hash` (and
+/// `<[T] as Hash>::hash`) prefix the data with `state.write_usize(N)`,
+/// whose byte width differs between 32-bit (e.g. wasm32) and 64-bit
+/// (e.g. x86_64) targets. A browser and a native peer hashing the
+/// same `CommitId` therefore produce different fingerprints, breaking
+/// set reconciliation entirely.
+///
+/// Implementors of this trait return the raw bytes to hash directly,
+/// bypassing `Hash`'s architecture-dependent length-prefix machinery.
+pub trait FingerprintInput {
+    /// Raw bytes to feed into the fingerprint hasher.
     ///
-    /// Feeds the value into SipHash-2-4 via its [`Hash`] implementation.
+    /// Implementations must return identical bytes on every target
+    /// for the same logical value.
+    fn fingerprint_bytes(&self) -> &[u8];
+}
+
+impl<T: FingerprintInput> Fingerprint<T> {
+    /// Compute a fingerprint of a [`FingerprintInput`] value using the
+    /// given seed.
+    ///
+    /// Writes the value's [`fingerprint_bytes`](FingerprintInput::fingerprint_bytes)
+    /// directly into SipHash-2-4 — no length prefix, no architecture
+    /// dependence.
     ///
     /// ```
-    /// use sedimentree_core::crypto::fingerprint::{Fingerprint, FingerprintSeed};
+    /// use sedimentree_core::{
+    ///     crypto::fingerprint::{Fingerprint, FingerprintSeed},
+    ///     loose_commit::id::CommitId,
+    /// };
     ///
     /// let seed = FingerprintSeed::new(42, 99);
-    /// let fp: Fingerprint<u64> = Fingerprint::new(&seed, &12345u64);
-    /// assert_eq!(fp, Fingerprint::new(&seed, &12345u64));
+    /// let id = CommitId::new([7u8; 32]);
+    /// let fp: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
+    /// assert_eq!(fp, Fingerprint::new(&seed, &id));
     /// ```
     #[must_use]
     pub fn new(seed: &FingerprintSeed, value: &T) -> Self {
+        use core::hash::Hasher;
         let mut hasher = seed.hasher();
-        value.hash(&mut hasher);
+        hasher.write(value.fingerprint_bytes());
         Self::from_u64(hasher.finish())
     }
 }

--- a/sedimentree_core/src/crypto/fingerprint.rs
+++ b/sedimentree_core/src/crypto/fingerprint.rs
@@ -130,9 +130,12 @@ impl<'a> arbitrary::Arbitrary<'a> for FingerprintSeed {
 
 /// A short keyed hash for set reconciliation.
 ///
-/// Computed via SipHash-2-4 with a per-request [`FingerprintSeed`].
-/// The phantom type `T` tracks what was fingerprinted:
-/// - [`Fingerprint<CommitId>`][crate::loose_commit::id::CommitId] — fingerprint of a commit or fragment identity
+/// Computed via SipHash-2-4 with a per-request [`FingerprintSeed`]. The
+/// phantom `T` tags what was fingerprinted so different fingerprint
+/// universes (e.g. `Fingerprint<CommitId>` vs a hypothetical
+/// `Fingerprint<Foo>`) don't get accidentally mixed. Per-type
+/// constructors live alongside the type they fingerprint — see
+/// [`Fingerprint<CommitId>::new`][crate::loose_commit::id::CommitId].
 ///
 /// # Collision Probability
 ///
@@ -146,46 +149,6 @@ impl<'a> arbitrary::Arbitrary<'a> for FingerprintSeed {
 pub struct Fingerprint<T> {
     hash: u64,
     _marker: PhantomData<T>,
-}
-
-/// A type whose bytes can be fed into a fingerprint hasher portably.
-///
-/// We bypass [`core::hash::Hash`] because `<[u8; N] as Hash>::hash` writes
-/// a `state.write_usize(N)` length prefix whose byte width differs on
-/// 32-bit (e.g. wasm32) vs 64-bit (e.g. x86_64) targets, so a browser
-/// and a native peer would compute different fingerprints for the same
-/// `CommitId`.
-///
-/// Implementations must return bytes of a fixed length for all values
-/// of `Self` (or otherwise self-delimit). `fingerprint_bytes` is fed to
-/// SipHash without a length prefix, so variable-length encodings could
-/// collide.
-pub trait FingerprintInput {
-    /// Raw bytes to feed into the fingerprint hasher.
-    fn fingerprint_bytes(&self) -> &[u8];
-}
-
-impl<T: FingerprintInput> Fingerprint<T> {
-    /// Compute a fingerprint of `value` under `seed`.
-    ///
-    /// ```
-    /// use sedimentree_core::{
-    ///     crypto::fingerprint::{Fingerprint, FingerprintSeed},
-    ///     loose_commit::id::CommitId,
-    /// };
-    ///
-    /// let seed = FingerprintSeed::new(42, 99);
-    /// let id = CommitId::new([7u8; 32]);
-    /// let fp: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
-    /// assert_eq!(fp, Fingerprint::new(&seed, &id));
-    /// ```
-    #[must_use]
-    pub fn new(seed: &FingerprintSeed, value: &T) -> Self {
-        use core::hash::Hasher;
-        let mut hasher = seed.hasher();
-        hasher.write(value.fingerprint_bytes());
-        Self::from_u64(hasher.finish())
-    }
 }
 
 impl<T> Fingerprint<T> {

--- a/sedimentree_core/src/crypto/fingerprint.rs
+++ b/sedimentree_core/src/crypto/fingerprint.rs
@@ -131,11 +131,9 @@ impl<'a> arbitrary::Arbitrary<'a> for FingerprintSeed {
 /// A short keyed hash for set reconciliation.
 ///
 /// Computed via SipHash-2-4 with a per-request [`FingerprintSeed`]. The
-/// phantom `T` tags what was fingerprinted so different fingerprint
-/// universes (e.g. `Fingerprint<CommitId>` vs a hypothetical
-/// `Fingerprint<Foo>`) don't get accidentally mixed. Per-type
-/// constructors live alongside the type they fingerprint — see
-/// [`Fingerprint<CommitId>::new`][crate::loose_commit::id::CommitId].
+/// phantom `T` tags what was fingerprinted to prevent mixing fingerprints
+/// of different types. Per-type constructors live alongside the type they
+/// fingerprint — see [`Fingerprint<CommitId>::new`][crate::loose_commit::id::CommitId].
 ///
 /// # Collision Probability
 ///

--- a/sedimentree_core/src/loose_commit/id.rs
+++ b/sedimentree_core/src/loose_commit/id.rs
@@ -1,5 +1,7 @@
 //! Causal identity for loose commits.
 
+use crate::crypto::fingerprint::FingerprintInput;
+
 /// A user-supplied opaque identifier for a loose commit.
 ///
 /// Unlike [`Digest`](crate::crypto::digest::Digest), which is a content hash
@@ -34,7 +36,7 @@ impl From<[u8; 32]> for CommitId {
     }
 }
 
-impl crate::crypto::fingerprint::FingerprintInput for CommitId {
+impl FingerprintInput for CommitId {
     fn fingerprint_bytes(&self) -> &[u8] {
         &self.0
     }

--- a/sedimentree_core/src/loose_commit/id.rs
+++ b/sedimentree_core/src/loose_commit/id.rs
@@ -1,6 +1,7 @@
 //! Causal identity for loose commits.
 
 use crate::crypto::fingerprint::{Fingerprint, FingerprintSeed};
+use core::hash::Hasher;
 
 /// A user-supplied opaque identifier for a loose commit.
 ///
@@ -59,7 +60,6 @@ impl Fingerprint<CommitId> {
     /// ```
     #[must_use]
     pub fn new(seed: &FingerprintSeed, id: &CommitId) -> Self {
-        use core::hash::Hasher;
         let mut hasher = seed.hasher();
         hasher.write(&id.0);
         Self::from_u64(hasher.finish())

--- a/sedimentree_core/src/loose_commit/id.rs
+++ b/sedimentree_core/src/loose_commit/id.rs
@@ -1,6 +1,6 @@
 //! Causal identity for loose commits.
 
-use crate::crypto::fingerprint::FingerprintInput;
+use crate::crypto::fingerprint::{Fingerprint, FingerprintSeed};
 
 /// A user-supplied opaque identifier for a loose commit.
 ///
@@ -36,9 +36,33 @@ impl From<[u8; 32]> for CommitId {
     }
 }
 
-impl FingerprintInput for CommitId {
-    fn fingerprint_bytes(&self) -> &[u8] {
-        &self.0
+impl Fingerprint<CommitId> {
+    /// Compute a `CommitId` fingerprint under `seed`.
+    ///
+    /// Hashes the `CommitId`'s 32 raw bytes directly via SipHash-2-4,
+    /// bypassing [`core::hash::Hash`] (whose `<[u8; N] as Hash>::hash`
+    /// impl prefixes the data with `write_usize(N)` — `usize` differs
+    /// in width between 32-bit and 64-bit targets, so a browser and a
+    /// native peer would otherwise compute different fingerprints for
+    /// the same `CommitId`).
+    ///
+    /// ```
+    /// use sedimentree_core::{
+    ///     crypto::fingerprint::{Fingerprint, FingerprintSeed},
+    ///     loose_commit::id::CommitId,
+    /// };
+    ///
+    /// let seed = FingerprintSeed::new(42, 99);
+    /// let id = CommitId::new([7u8; 32]);
+    /// let fp = Fingerprint::<CommitId>::new(&seed, &id);
+    /// assert_eq!(fp, Fingerprint::<CommitId>::new(&seed, &id));
+    /// ```
+    #[must_use]
+    pub fn new(seed: &FingerprintSeed, id: &CommitId) -> Self {
+        use core::hash::Hasher;
+        let mut hasher = seed.hasher();
+        hasher.write(&id.0);
+        Self::from_u64(hasher.finish())
     }
 }
 

--- a/sedimentree_core/src/loose_commit/id.rs
+++ b/sedimentree_core/src/loose_commit/id.rs
@@ -34,6 +34,12 @@ impl From<[u8; 32]> for CommitId {
     }
 }
 
+impl crate::crypto::fingerprint::FingerprintInput for CommitId {
+    fn fingerprint_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl From<CommitId> for [u8; 32] {
     fn from(id: CommitId) -> Self {
         id.0

--- a/sedimentree_core/tests/diff_diverging_histories.rs
+++ b/sedimentree_core/tests/diff_diverging_histories.rs
@@ -33,7 +33,7 @@ fn commit(seed: u8, parents: &[CommitId]) -> LooseCommit {
     )
 }
 
-fn head(seed: u8) -> CommitId {
+const fn head(seed: u8) -> CommitId {
     CommitId::new([seed; 32])
 }
 

--- a/sedimentree_core/tests/diff_diverging_histories.rs
+++ b/sedimentree_core/tests/diff_diverging_histories.rs
@@ -82,8 +82,7 @@ fn full_local_empty_remote_sends_all() {
 }
 
 /// Disjoint sets produce `local_only.len() == |local|` and
-/// `remote_only.len() == |remote|` — matches the "N missing, requesting N"
-/// log pattern when peers genuinely have nothing in common.
+/// `remote_only.len() == |remote|`.
 #[test]
 fn disjoint_histories_send_full_sets_in_both_directions() {
     let local = tree(vec![
@@ -289,125 +288,8 @@ fn many_parallel_chains_pruning() {
     assert_eq!(diff.local_only_commits.len(), 12);
 }
 
-/// After both sides ingest the other's `local_only_commits`, a fresh-seed
-/// round-2 diff is empty in both directions. The diff layer converges in
-/// one round given correct ingestion.
-#[test]
-fn convergence_after_one_round_when_both_sides_ingest() {
-    let local_initial = tree(vec![
-        commit(10, &[]),
-        commit(11, &[head(10)]),
-        commit(12, &[head(11)]),
-    ]);
-    let remote_initial = tree(vec![
-        commit(20, &[]),
-        commit(21, &[head(20)]),
-        commit(22, &[head(21)]),
-    ]);
-
-    let local_summary = local_initial.fingerprint_summarize(&SEED);
-    let remote_summary = remote_initial.fingerprint_summarize(&SEED);
-
-    let from_remote_to_local: Vec<LooseCommit> = {
-        let diff = remote_initial.diff_remote_fingerprints(&local_summary);
-        assert_eq!(diff.local_only_commits.len(), 3);
-        assert_eq!(diff.remote_only_commit_fingerprints.len(), 3);
-        diff.local_only_commits
-            .into_iter()
-            .map(|(_, c)| c.clone())
-            .collect()
-    };
-
-    let from_local_to_remote: Vec<LooseCommit> = {
-        let diff = local_initial.diff_remote_fingerprints(&remote_summary);
-        assert_eq!(diff.local_only_commits.len(), 3);
-        assert_eq!(diff.remote_only_commit_fingerprints.len(), 3);
-        diff.local_only_commits
-            .into_iter()
-            .map(|(_, c)| c.clone())
-            .collect()
-    };
-
-    let mut local_after = local_initial;
-    for commit in from_remote_to_local {
-        local_after.add_commit(commit);
-    }
-    let mut remote_after = remote_initial;
-    for commit in from_local_to_remote {
-        remote_after.add_commit(commit);
-    }
-
-    assert_eq!(local_after.loose_commits().count(), 6);
-    assert_eq!(remote_after.loose_commits().count(), 6);
-
-    let seed2 = FingerprintSeed::new(0xFEED_FACE, 0xCAFE_BABE);
-    let local_summary2 = local_after.fingerprint_summarize(&seed2);
-    let remote_summary2 = remote_after.fingerprint_summarize(&seed2);
-
-    let round2_at_local = local_after.diff_remote_fingerprints(&remote_summary2);
-    let round2_at_remote = remote_after.diff_remote_fingerprints(&local_summary2);
-
-    assert!(round2_at_local.local_only_commits.is_empty());
-    assert!(round2_at_local.remote_only_commit_fingerprints.is_empty());
-    assert!(round2_at_remote.local_only_commits.is_empty());
-    assert!(round2_at_remote.remote_only_commit_fingerprints.is_empty());
-}
-
-#[test]
-fn loose_commit_only_sync_converges_in_one_round_arbitrary_overlap() {
-    // Shared: A, B, C. Local-only: D, E. Remote-only: X, Y, Z (X forks off B).
-    let a = commit(1, &[]);
-    let b = commit(2, &[head(1)]);
-    let c = commit(3, &[head(2)]);
-    let d = commit(4, &[head(3)]);
-    let e = commit(5, &[head(4)]);
-    let x = commit(11, &[head(2)]);
-    let y = commit(12, &[head(11)]);
-    let z = commit(13, &[head(12)]);
-
-    let local_initial = tree(vec![a.clone(), b.clone(), c.clone(), d, e]);
-    let remote_initial = tree(vec![a, b, c, x, y, z]);
-
-    let local_summary = local_initial.fingerprint_summarize(&SEED);
-    let remote_summary = remote_initial.fingerprint_summarize(&SEED);
-
-    let from_remote_to_local: Vec<LooseCommit> = {
-        let diff = remote_initial.diff_remote_fingerprints(&local_summary);
-        assert_eq!(diff.local_only_commits.len(), 3);
-        diff.local_only_commits
-            .into_iter()
-            .map(|(_, c)| c.clone())
-            .collect()
-    };
-
-    let from_local_to_remote: Vec<LooseCommit> = {
-        let diff = local_initial.diff_remote_fingerprints(&remote_summary);
-        assert_eq!(diff.local_only_commits.len(), 2);
-        diff.local_only_commits
-            .into_iter()
-            .map(|(_, c)| c.clone())
-            .collect()
-    };
-
-    let mut local_after = local_initial;
-    for commit in from_remote_to_local {
-        local_after.add_commit(commit);
-    }
-    let mut remote_after = remote_initial;
-    for commit in from_local_to_remote {
-        remote_after.add_commit(commit);
-    }
-
-    assert_eq!(local_after.loose_commits().count(), 8);
-    assert_eq!(remote_after.loose_commits().count(), 8);
-
-    let seed2 = FingerprintSeed::new(7, 11);
-    let remote_summary2 = remote_after.fingerprint_summarize(&seed2);
-    let round2 = local_after.diff_remote_fingerprints(&remote_summary2);
-
-    assert!(round2.local_only_commits.is_empty());
-    assert!(round2.remote_only_commit_fingerprints.is_empty());
-}
+// One-round-convergence-after-mutual-ingest is covered as a property in
+// `tests/sync_convergence_props.rs::prop_mutual_ingest_converges_in_one_round`.
 
 /// Minimize on a fragment-less tree must not change the fingerprint set.
 #[test]

--- a/sedimentree_core/tests/diff_diverging_histories.rs
+++ b/sedimentree_core/tests/diff_diverging_histories.rs
@@ -1,0 +1,729 @@
+//! Tests for `Sedimentree::diff_remote_fingerprints` with **diverging
+//! loose-commit-only histories**.
+//!
+//! The existing tests in `sedimentree.rs::tests` focus on fragment
+//! scenarios (fragments dominating commits, fragment-coverage pruning,
+//! etc.). The user-observed bug from the React-todo workflow involves
+//! **zero fragments** and a stream of loose-commit-only updates, so this
+//! file exercises that regime specifically.
+//!
+//! Key invariants we want to lock down:
+//!
+//! 1. **No overlap → both sides report their full disjoint sets.**
+//!    Disjoint chains should produce `local_only_commits.len() == |local|`
+//!    and `remote_only_commit_fingerprints.len() == |remote|`.
+//!
+//! 2. **Full overlap → empty diff.** Identical trees produce empty diffs.
+//!
+//! 3. **Partial overlap → only the delta.** Two chains sharing a common
+//!    prefix should send only the divergent suffix.
+//!
+//! 4. **DAG-ancestry pruning is correct.** When the responder has commit
+//!    X and X is in the requester's fingerprint set, the responder should
+//!    skip sending X's ancestors. We test this is sound (doesn't drop
+//!    commits the requester actually needs) and complete (does drop
+//!    redundant ancestor sends).
+//!
+//! 5. **Forked histories.** Two chains diverging after a shared root
+//!    should each send their post-divergence tail, not the shared prefix.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
+
+use std::collections::BTreeSet;
+
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    commit::CountLeadingZeroBytes,
+    crypto::fingerprint::FingerprintSeed,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+    sedimentree::Sedimentree,
+};
+
+const SED_ID: SedimentreeId = SedimentreeId::new([42u8; 32]);
+const SEED: FingerprintSeed = FingerprintSeed::new(0x1234_5678, 0xDEAD_BEEF);
+
+/// Build a loose commit whose head is `[seed; 32]` and whose blob bytes
+/// are also a function of `seed` (so different seeds → different blob
+/// digests, avoiding accidental collisions).
+fn commit(seed: u8, parents: &[CommitId]) -> LooseCommit {
+    let blob = Blob::new(vec![seed; 64]);
+    let blob_meta = BlobMeta::new(&blob);
+    let head = CommitId::new([seed; 32]);
+    LooseCommit::new(
+        SED_ID,
+        head,
+        parents.iter().copied().collect::<BTreeSet<_>>(),
+        blob_meta,
+    )
+}
+
+fn head(seed: u8) -> CommitId {
+    CommitId::new([seed; 32])
+}
+
+fn tree(commits: Vec<LooseCommit>) -> Sedimentree {
+    Sedimentree::new(vec![], commits)
+}
+
+// ===========================================================================
+// Section 1: Identity & emptiness invariants
+// ===========================================================================
+
+/// Two identical trees should produce an empty diff in both directions.
+#[test]
+fn identical_trees_have_empty_diff() {
+    let a = commit(1, &[]);
+    let b = commit(2, &[head(1)]);
+    let c = commit(3, &[head(2)]);
+
+    let local = tree(vec![a.clone(), b.clone(), c.clone()]);
+    let remote = tree(vec![a, b, c]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    assert!(
+        diff.local_only_commits.is_empty(),
+        "identical trees: local_only_commits should be empty, got {}",
+        diff.local_only_commits.len(),
+    );
+    assert!(
+        diff.remote_only_commit_fingerprints.is_empty(),
+        "identical trees: remote_only_commit_fingerprints should be empty, got {}",
+        diff.remote_only_commit_fingerprints.len(),
+    );
+}
+
+/// Local empty, remote non-empty. Local should request everything remote
+/// has, send nothing.
+#[test]
+fn empty_local_full_remote_requests_all() {
+    let local = tree(vec![]);
+    let remote = tree(vec![commit(1, &[]), commit(2, &[head(1)])]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    assert_eq!(
+        diff.local_only_commits.len(),
+        0,
+        "empty local sends nothing"
+    );
+    assert_eq!(
+        diff.remote_only_commit_fingerprints.len(),
+        2,
+        "empty local requests all 2 commits from remote"
+    );
+}
+
+/// Local non-empty, remote empty. Local should send everything, request
+/// nothing.
+#[test]
+fn full_local_empty_remote_sends_all() {
+    let local = tree(vec![commit(1, &[]), commit(2, &[head(1)])]);
+    let remote = tree(vec![]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    assert_eq!(
+        diff.local_only_commits.len(),
+        2,
+        "full local sends all 2 commits"
+    );
+    assert!(
+        diff.remote_only_commit_fingerprints.is_empty(),
+        "empty remote: nothing to request, got {} fps",
+        diff.remote_only_commit_fingerprints.len(),
+    );
+}
+
+// ===========================================================================
+// Section 2: Disjoint histories — the user's bug shape
+// ===========================================================================
+
+/// **The user's bug shape.** Two peers with completely disjoint commit
+/// sets should produce `local_only.len() == |local|` and
+/// `remote_only.len() == |remote|` — this exactly matches the
+/// "19 missing, requesting 19" pattern from the logs IF the two browsers
+/// genuinely had disjoint commits at sync time.
+///
+/// We assert the math here to confirm that *this specific symptom is
+/// expected* given disjoint inputs — which means the user's bug is
+/// **either** about the data being genuinely disjoint when it shouldn't
+/// be, **or** about the system failing to converge after the disjoint
+/// diff round.
+#[test]
+fn disjoint_histories_send_full_sets_in_both_directions() {
+    // Local has chain A → B → C (seeds 10, 11, 12)
+    let local = tree(vec![
+        commit(10, &[]),
+        commit(11, &[head(10)]),
+        commit(12, &[head(11)]),
+    ]);
+
+    // Remote has chain X → Y → Z (seeds 20, 21, 22) — fully disjoint
+    let remote = tree(vec![
+        commit(20, &[]),
+        commit(21, &[head(20)]),
+        commit(22, &[head(21)]),
+    ]);
+
+    let remote_summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&remote_summary);
+
+    // Local has 3 commits that remote doesn't have.
+    assert_eq!(
+        diff.local_only_commits.len(),
+        3,
+        "disjoint: local should report all 3 of its commits as local_only"
+    );
+    // Remote has 3 commits that local doesn't have.
+    assert_eq!(
+        diff.remote_only_commit_fingerprints.len(),
+        3,
+        "disjoint: remote_only_commit_fingerprints should be all 3 of remote's"
+    );
+}
+
+/// Disjoint histories with **unequal sizes** — e.g. local has 19, remote
+/// has 20. Confirms the "M missing, requesting N" pattern matches the
+/// inputs exactly when there's zero overlap.
+#[test]
+fn disjoint_histories_unequal_sizes() {
+    // Local: chain of 19 commits starting at seed 10.
+    let mut local_commits = vec![commit(10, &[])];
+    for i in 1..19u8 {
+        local_commits.push(commit(10 + i, &[head(10 + i - 1)]));
+    }
+    assert_eq!(local_commits.len(), 19);
+    let local = tree(local_commits);
+
+    // Remote: chain of 20 commits starting at seed 100 (disjoint).
+    let mut remote_commits = vec![commit(100, &[])];
+    for i in 1..20u8 {
+        remote_commits.push(commit(100 + i, &[head(100 + i - 1)]));
+    }
+    assert_eq!(remote_commits.len(), 20);
+    let remote = tree(remote_commits);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // 19 missing (local-only, what local will send to remote)
+    assert_eq!(
+        diff.local_only_commits.len(),
+        19,
+        "local has 19 disjoint → local_only_commits is 19"
+    );
+    // 20 requesting (remote-only, fingerprints local will echo back)
+    assert_eq!(
+        diff.remote_only_commit_fingerprints.len(),
+        20,
+        "remote has 20 disjoint → remote_only_commit_fingerprints is 20"
+    );
+}
+
+// ===========================================================================
+// Section 3: Overlapping histories (the convergence case)
+// ===========================================================================
+
+/// Local and remote share commits A, B; local has additional C; remote
+/// has additional D. After sync, both should converge.
+#[test]
+fn forked_after_shared_prefix() {
+    // Shared prefix
+    let a = commit(1, &[]);
+    let b = commit(2, &[head(1)]);
+
+    // Local-only continuation
+    let c = commit(3, &[head(2)]);
+    // Remote-only continuation
+    let d = commit(4, &[head(2)]);
+
+    let local = tree(vec![a.clone(), b.clone(), c]);
+    let remote = tree(vec![a, b, d]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // A and B are shared, ancestors_of({A, B}) = {A, B}. Local's commits
+    // are {A, B, C}. local_only_commits before pruning = [C]. After
+    // ancestor pruning: C is not an ancestor of shared, keep. = [C].
+    assert_eq!(
+        diff.local_only_commits.len(),
+        1,
+        "forked: local should only send its divergent suffix (1 commit)"
+    );
+    let sent_id = *diff.local_only_commits[0].0;
+    assert_eq!(sent_id, head(3), "should send C, not A or B");
+
+    // Remote-only: D is not in local's fp set. A and B are in both.
+    assert_eq!(
+        diff.remote_only_commit_fingerprints.len(),
+        1,
+        "forked: should request 1 commit (D)"
+    );
+}
+
+/// Linear history, remote is a strict prefix of local. Local sends only
+/// the tail; the shared prefix is pruned by DAG-ancestry analysis.
+#[test]
+fn remote_is_prefix_of_local() {
+    // Local: A → B → C → D
+    let a = commit(1, &[]);
+    let b = commit(2, &[head(1)]);
+    let c = commit(3, &[head(2)]);
+    let d = commit(4, &[head(3)]);
+
+    let local = tree(vec![a.clone(), b.clone(), c.clone(), d]);
+    // Remote: A → B only
+    let remote = tree(vec![a, b]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // Pre-pruning local_only = [C, D]. ancestors_of({A, B}) = {A, B}.
+    // Neither C nor D is in there, so both survive.
+    assert_eq!(
+        diff.local_only_commits.len(),
+        2,
+        "prefix: local sends C and D"
+    );
+    let sent_ids: BTreeSet<CommitId> = diff
+        .local_only_commits
+        .iter()
+        .map(|(id, _)| **id)
+        .collect();
+    assert!(sent_ids.contains(&head(3)) && sent_ids.contains(&head(4)));
+    assert!(
+        !sent_ids.contains(&head(1)) && !sent_ids.contains(&head(2)),
+        "shared prefix must not be re-sent"
+    );
+
+    assert!(
+        diff.remote_only_commit_fingerprints.is_empty(),
+        "prefix: nothing to request"
+    );
+}
+
+/// Local is a strict prefix of remote. Local requests the tail.
+#[test]
+fn local_is_prefix_of_remote() {
+    let a = commit(1, &[]);
+    let b = commit(2, &[head(1)]);
+    let c = commit(3, &[head(2)]);
+    let d = commit(4, &[head(3)]);
+
+    let local = tree(vec![a.clone(), b.clone()]);
+    let remote = tree(vec![a, b, c, d]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    assert!(
+        diff.local_only_commits.is_empty(),
+        "local prefix has nothing to send"
+    );
+    assert_eq!(
+        diff.remote_only_commit_fingerprints.len(),
+        2,
+        "local prefix requests C and D"
+    );
+}
+
+// ===========================================================================
+// Section 4: DAG-ancestry pruning correctness
+// ===========================================================================
+
+/// The pruning step removes commits from `local_only_commits` when they're
+/// ancestors of a commit the remote has. This test pins down that
+/// behavior: if remote has the tip C, local doesn't re-send A and B
+/// (C's ancestors).
+#[test]
+fn ancestry_pruning_drops_ancestors_of_shared_tip() {
+    // Local: A → B → C → D (D is local-only, A,B,C shared)
+    let a = commit(1, &[]);
+    let b = commit(2, &[head(1)]);
+    let c = commit(3, &[head(2)]);
+    let d = commit(4, &[head(3)]);
+
+    let local = tree(vec![a.clone(), b.clone(), c.clone(), d.clone()]);
+
+    // Remote claims to have A, B, C (but not D)
+    let remote = tree(vec![a, b, c]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // Pre-pruning local_only = [D]. ancestors_of({A,B,C}) = {A,B,C}.
+    // D is not in ancestors → keep.
+    assert_eq!(
+        diff.local_only_commits.len(),
+        1,
+        "ancestry: send only D (the divergent tip)"
+    );
+    assert_eq!(*diff.local_only_commits[0].0, head(4));
+}
+
+/// **Sound-vs-complete edge case.** If remote claims to have B but does
+/// not actually have B's parent A, ancestry pruning drops A from
+/// `local_only_commits`. Convergence depends on the protocol invariant
+/// that "if you have a commit, you have its ancestors." This test
+/// confirms our pruning DOES drop A in this case — documenting the
+/// invariant and the cost of violating it.
+///
+/// (If a future change wants to be defensive against protocol violations,
+/// this test will need updating.)
+#[test]
+fn ancestry_pruning_trusts_remote_has_advertised_commits_ancestors() {
+    let a = commit(1, &[]);
+    let b = commit(2, &[head(1)]);
+
+    let local = tree(vec![a.clone(), b.clone()]);
+
+    // Remote claims to have only B (NOT A). This is "ill-formed" in the
+    // sense that a peer should never advertise B without having A, but
+    // the protocol can't enforce that.
+    let remote = tree(vec![b]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // shared = {B}. ancestors_of({B}) = {B, A}. local_only pre-prune = [A].
+    // After pruning: A is in ancestors → drop. Result: send nothing.
+    assert!(
+        diff.local_only_commits.is_empty(),
+        "ancestry pruning DOES trust the remote's advertisement; A is not re-sent. \
+         This is documented behavior — a peer that has B without A will not get A \
+         from this responder. Result was: {} commits",
+        diff.local_only_commits.len(),
+    );
+}
+
+/// Multi-tip DAG: local has two parallel chains rooted at the same point.
+/// Remote has only chain 1's tip. Pruning should drop chain 1's
+/// ancestors but keep all of chain 2.
+#[test]
+fn ancestry_pruning_preserves_disjoint_branches() {
+    let root = commit(1, &[]);
+
+    // Branch 1: root → b1 → c1
+    let b1 = commit(10, &[head(1)]);
+    let c1 = commit(11, &[head(10)]);
+
+    // Branch 2: root → b2 → c2
+    let b2 = commit(20, &[head(1)]);
+    let c2 = commit(21, &[head(20)]);
+
+    let local = tree(vec![root.clone(), b1.clone(), c1.clone(), b2.clone(), c2.clone()]);
+
+    // Remote has only c1's chain: root, b1, c1
+    let remote = tree(vec![root, b1, c1]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // shared = {root, b1, c1}. ancestors_of(those) = {root, b1, c1}.
+    // local_only pre-prune = [b2, c2]. After: both kept (neither is an
+    // ancestor of shared).
+    assert_eq!(
+        diff.local_only_commits.len(),
+        2,
+        "should send branch 2 (b2 + c2) but not the shared chain"
+    );
+    let sent_ids: BTreeSet<CommitId> = diff
+        .local_only_commits
+        .iter()
+        .map(|(id, _)| **id)
+        .collect();
+    assert!(
+        sent_ids.contains(&head(20)) && sent_ids.contains(&head(21)),
+        "sent set should be exactly {{b2, c2}}, got: {:?}",
+        sent_ids
+    );
+}
+
+/// Diamond DAG: shared root with two parallel branches that re-merge.
+///
+/// ```text
+///       root
+///      /    \
+///     b1     b2
+///      \    /
+///       merge
+/// ```
+///
+/// Remote has the merge commit. Pruning should drop all of root, b1, b2.
+#[test]
+fn ancestry_pruning_handles_diamond_dag() {
+    let root = commit(1, &[]);
+    let b1 = commit(2, &[head(1)]);
+    let b2 = commit(3, &[head(1)]);
+    let merge = commit(4, &[head(2), head(3)]);
+
+    let local = tree(vec![root, b1, b2, merge.clone()]);
+
+    // Remote has only the merge commit
+    let remote = tree(vec![merge]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // shared = {merge}. ancestors_of({merge}) walks both parents:
+    //   merge → b1 → root (added)
+    //   merge → b2 → root (already visited)
+    // Result: {merge, b1, b2, root}.
+    // local_only pre-prune = [root, b1, b2]. All in ancestors → all dropped.
+    assert!(
+        diff.local_only_commits.is_empty(),
+        "diamond DAG: nothing should be sent (remote has the merge tip)"
+    );
+}
+
+/// Many parallel small chains, remote has only the latest commit of one.
+/// Verifies pruning scales correctly with many disjoint branches.
+#[test]
+fn many_parallel_chains_pruning() {
+    // 5 independent chains of length 3 each
+    let mut all_commits = Vec::new();
+    let mut chain_tips: Vec<CommitId> = Vec::new();
+    for chain_idx in 0..5u8 {
+        let base = 10 + chain_idx * 10;
+        let c0 = commit(base, &[]);
+        let c1 = commit(base + 1, &[head(base)]);
+        let c2 = commit(base + 2, &[head(base + 1)]);
+        chain_tips.push(head(base + 2));
+        all_commits.push(c0);
+        all_commits.push(c1);
+        all_commits.push(c2);
+    }
+    let local = tree(all_commits);
+    assert_eq!(
+        local.loose_commits().count(),
+        15,
+        "5 chains × 3 commits = 15"
+    );
+
+    // Remote has just the last commit of the first chain (seed 12)
+    let remote = tree(vec![commit(12, &[head(11)])]);
+
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
+
+    // Chain 0: shared = {c2}. ancestors_of({c2}) = {c2, c1, c0}.
+    //   Local's c0, c1, c2 all in ancestors → all dropped.
+    // Chains 1-4: nothing shared, all 12 commits sent.
+    assert_eq!(
+        diff.local_only_commits.len(),
+        12,
+        "4 chains × 3 commits = 12 sent; chain 0 fully pruned"
+    );
+}
+
+// ===========================================================================
+// Section 5: The "growing forever" failure mode
+// ===========================================================================
+
+/// **Models the user's compute-grows-on-each-update symptom.** If two
+/// peers keep authoring independent commits and never converge, each
+/// successive sync produces a larger disjoint set. This is correct
+/// behavior at the diff layer — but if the FOLLOW-UP step (ingesting
+/// `missing_commits`) is broken, the next round still sees the same
+/// disjointness.
+///
+/// We verify the math layer: round-2 of a disjoint sync should produce
+/// 0 missing and 0 requesting **assuming both sides ingested correctly**.
+#[test]
+fn convergence_after_one_round_when_both_sides_ingest() {
+    // Round 0: local has chain A, remote has chain B (disjoint).
+    let local_initial = tree(vec![
+        commit(10, &[]),
+        commit(11, &[head(10)]),
+        commit(12, &[head(11)]),
+    ]);
+    let remote_initial = tree(vec![
+        commit(20, &[]),
+        commit(21, &[head(20)]),
+        commit(22, &[head(21)]),
+    ]);
+
+    // Simulate round 1: each side observes the other's diff
+    let local_summary = local_initial.fingerprint_summarize(&SEED);
+    let remote_summary = remote_initial.fingerprint_summarize(&SEED);
+
+    // Materialize owned commit sets from the diffs before moving the trees.
+    let from_remote_to_local: Vec<LooseCommit> = {
+        let diff_at_remote = remote_initial.diff_remote_fingerprints(&local_summary);
+        assert_eq!(diff_at_remote.local_only_commits.len(), 3);
+        assert_eq!(diff_at_remote.remote_only_commit_fingerprints.len(), 3);
+        diff_at_remote
+            .local_only_commits
+            .into_iter()
+            .map(|(_, c)| c.clone())
+            .collect()
+    };
+
+    let from_local_to_remote: Vec<LooseCommit> = {
+        let diff_at_local = local_initial.diff_remote_fingerprints(&remote_summary);
+        assert_eq!(diff_at_local.local_only_commits.len(), 3);
+        assert_eq!(diff_at_local.remote_only_commit_fingerprints.len(), 3);
+        diff_at_local
+            .local_only_commits
+            .into_iter()
+            .map(|(_, c)| c.clone())
+            .collect()
+    };
+
+    // Each side ingests the OTHER side's local_only_commits.
+    let mut local_after = local_initial;
+    for commit in from_remote_to_local {
+        local_after.add_commit(commit);
+    }
+    let mut remote_after = remote_initial;
+    for commit in from_local_to_remote {
+        remote_after.add_commit(commit);
+    }
+
+    // After ingestion both should have all 6 commits.
+    assert_eq!(local_after.loose_commits().count(), 6);
+    assert_eq!(remote_after.loose_commits().count(), 6);
+
+    // Round 2: with a fresh seed, the diff should be empty in both
+    // directions. This proves the diff layer converges in ONE round
+    // when both sides ingest the response correctly.
+    let seed2 = FingerprintSeed::new(0xFEED_FACE, 0xCAFE_BABE);
+    let local_summary2 = local_after.fingerprint_summarize(&seed2);
+    let remote_summary2 = remote_after.fingerprint_summarize(&seed2);
+
+    let round2_at_local = local_after.diff_remote_fingerprints(&remote_summary2);
+    let round2_at_remote = remote_after.diff_remote_fingerprints(&local_summary2);
+
+    assert!(
+        round2_at_local.local_only_commits.is_empty()
+            && round2_at_local.remote_only_commit_fingerprints.is_empty(),
+        "round 2 at local should be empty (received={}, sent_back={})",
+        round2_at_local.remote_only_commit_fingerprints.len(),
+        round2_at_local.local_only_commits.len(),
+    );
+    assert!(
+        round2_at_remote.local_only_commits.is_empty()
+            && round2_at_remote.remote_only_commit_fingerprints.is_empty(),
+        "round 2 at remote should be empty (received={}, sent_back={})",
+        round2_at_remote.remote_only_commit_fingerprints.len(),
+        round2_at_remote.local_only_commits.len(),
+    );
+}
+
+/// **The most direct test of the user's bug-pattern as a pure math
+/// property.** If sync convergence works at the diff layer, then for
+/// any pair of trees `(A, B)`, after we add `A.local_only` to `B` and
+/// `B.local_only` to `A`, a follow-up diff with a fresh seed is empty.
+///
+/// This is just an explicit, deterministic version of what the property
+/// tests in `sedimentree.rs::tests::proptests` should cover for the
+/// loose-commit-only case.
+#[test]
+fn loose_commit_only_sync_converges_in_one_round_arbitrary_overlap() {
+    // Shared: A, B, C
+    // Local-only: D, E
+    // Remote-only: X, Y, Z (with X having parent B from the shared set)
+    let a = commit(1, &[]);
+    let b = commit(2, &[head(1)]);
+    let c = commit(3, &[head(2)]);
+
+    let d = commit(4, &[head(3)]);
+    let e = commit(5, &[head(4)]);
+
+    let x = commit(11, &[head(2)]); // forks off B
+    let y = commit(12, &[head(11)]);
+    let z = commit(13, &[head(12)]);
+
+    let local_initial = tree(vec![a.clone(), b.clone(), c.clone(), d, e]);
+    let remote_initial = tree(vec![a, b, c, x, y, z]);
+
+    let local_summary = local_initial.fingerprint_summarize(&SEED);
+    let remote_summary = remote_initial.fingerprint_summarize(&SEED);
+
+    let from_remote_to_local: Vec<LooseCommit> = {
+        let diff_at_remote = remote_initial.diff_remote_fingerprints(&local_summary);
+        assert_eq!(
+            diff_at_remote.local_only_commits.len(),
+            3,
+            "remote sends X, Y, Z (post-shared)"
+        );
+        diff_at_remote
+            .local_only_commits
+            .into_iter()
+            .map(|(_, c)| c.clone())
+            .collect()
+    };
+
+    let from_local_to_remote: Vec<LooseCommit> = {
+        let diff_at_local = local_initial.diff_remote_fingerprints(&remote_summary);
+        assert_eq!(
+            diff_at_local.local_only_commits.len(),
+            2,
+            "local sends D, E (post-shared)"
+        );
+        diff_at_local
+            .local_only_commits
+            .into_iter()
+            .map(|(_, c)| c.clone())
+            .collect()
+    };
+
+    let mut local_after = local_initial;
+    for commit in from_remote_to_local {
+        local_after.add_commit(commit);
+    }
+    let mut remote_after = remote_initial;
+    for commit in from_local_to_remote {
+        remote_after.add_commit(commit);
+    }
+
+    assert_eq!(local_after.loose_commits().count(), 8);
+    assert_eq!(remote_after.loose_commits().count(), 8);
+
+    // Round 2 with fresh seed
+    let seed2 = FingerprintSeed::new(7, 11);
+    let remote_summary2 = remote_after.fingerprint_summarize(&seed2);
+    let round2 = local_after.diff_remote_fingerprints(&remote_summary2);
+
+    assert!(round2.local_only_commits.is_empty());
+    assert!(round2.remote_only_commit_fingerprints.is_empty());
+}
+
+// ===========================================================================
+// Section 6: Minimize interaction (loose-only side)
+// ===========================================================================
+
+/// Verifies that minimize on a loose-only tree (no fragments) doesn't
+/// change the fingerprint set, so a tree minimized before fingerprinting
+/// is interchangeable with the unminimized version.
+#[test]
+fn minimize_loose_only_preserves_fingerprints() {
+    let local = tree(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+
+    let depth_metric = CountLeadingZeroBytes;
+    let minimized = local.minimize(&depth_metric);
+
+    let summary_raw = local.fingerprint_summarize(&SEED);
+    let summary_min = minimized.fingerprint_summarize(&SEED);
+
+    assert_eq!(
+        summary_raw.commit_fingerprints(),
+        summary_min.commit_fingerprints(),
+        "minimize on loose-only tree must not change commit fingerprints"
+    );
+    assert_eq!(
+        summary_raw.fragment_fingerprints(),
+        summary_min.fragment_fingerprints(),
+        "fragment set should be empty in both"
+    );
+}

--- a/sedimentree_core/tests/diff_diverging_histories.rs
+++ b/sedimentree_core/tests/diff_diverging_histories.rs
@@ -1,31 +1,7 @@
-//! Tests for `Sedimentree::diff_remote_fingerprints` with **diverging
-//! loose-commit-only histories**.
-//!
-//! The existing tests in `sedimentree.rs::tests` focus on fragment
-//! scenarios (fragments dominating commits, fragment-coverage pruning,
-//! etc.). The user-observed bug from the React-todo workflow involves
-//! **zero fragments** and a stream of loose-commit-only updates, so this
-//! file exercises that regime specifically.
-//!
-//! Key invariants we want to lock down:
-//!
-//! 1. **No overlap → both sides report their full disjoint sets.**
-//!    Disjoint chains should produce `local_only_commits.len() == |local|`
-//!    and `remote_only_commit_fingerprints.len() == |remote|`.
-//!
-//! 2. **Full overlap → empty diff.** Identical trees produce empty diffs.
-//!
-//! 3. **Partial overlap → only the delta.** Two chains sharing a common
-//!    prefix should send only the divergent suffix.
-//!
-//! 4. **DAG-ancestry pruning is correct.** When the responder has commit
-//!    X and X is in the requester's fingerprint set, the responder should
-//!    skip sending X's ancestors. We test this is sound (doesn't drop
-//!    commits the requester actually needs) and complete (does drop
-//!    redundant ancestor sends).
-//!
-//! 5. **Forked histories.** Two chains diverging after a shared root
-//!    should each send their post-divergence tail, not the shared prefix.
+//! `Sedimentree::diff_remote_fingerprints` on loose-commit-only histories
+//! (no fragments). Covers identity/emptiness, disjoint chains, partial
+//! overlap with prefix/fork shapes, DAG-ancestry pruning, and
+//! one-round-convergence after mutual ingestion.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
 
@@ -43,9 +19,8 @@ use sedimentree_core::{
 const SED_ID: SedimentreeId = SedimentreeId::new([42u8; 32]);
 const SEED: FingerprintSeed = FingerprintSeed::new(0x1234_5678, 0xDEAD_BEEF);
 
-/// Build a loose commit whose head is `[seed; 32]` and whose blob bytes
-/// are also a function of `seed` (so different seeds → different blob
-/// digests, avoiding accidental collisions).
+/// Commit whose head is `[seed; 32]` and whose blob bytes are also a
+/// function of `seed`, so different seeds give different blob digests.
 fn commit(seed: u8, parents: &[CommitId]) -> LooseCommit {
     let blob = Blob::new(vec![seed; 64]);
     let blob_meta = BlobMeta::new(&blob);
@@ -66,11 +41,6 @@ fn tree(commits: Vec<LooseCommit>) -> Sedimentree {
     Sedimentree::new(vec![], commits)
 }
 
-// ===========================================================================
-// Section 1: Identity & emptiness invariants
-// ===========================================================================
-
-/// Two identical trees should produce an empty diff in both directions.
 #[test]
 fn identical_trees_have_empty_diff() {
     let a = commit(1, &[]);
@@ -83,20 +53,10 @@ fn identical_trees_have_empty_diff() {
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    assert!(
-        diff.local_only_commits.is_empty(),
-        "identical trees: local_only_commits should be empty, got {}",
-        diff.local_only_commits.len(),
-    );
-    assert!(
-        diff.remote_only_commit_fingerprints.is_empty(),
-        "identical trees: remote_only_commit_fingerprints should be empty, got {}",
-        diff.remote_only_commit_fingerprints.len(),
-    );
+    assert!(diff.local_only_commits.is_empty());
+    assert!(diff.remote_only_commit_fingerprints.is_empty());
 }
 
-/// Local empty, remote non-empty. Local should request everything remote
-/// has, send nothing.
 #[test]
 fn empty_local_full_remote_requests_all() {
     let local = tree(vec![]);
@@ -105,20 +65,10 @@ fn empty_local_full_remote_requests_all() {
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    assert_eq!(
-        diff.local_only_commits.len(),
-        0,
-        "empty local sends nothing"
-    );
-    assert_eq!(
-        diff.remote_only_commit_fingerprints.len(),
-        2,
-        "empty local requests all 2 commits from remote"
-    );
+    assert_eq!(diff.local_only_commits.len(), 0);
+    assert_eq!(diff.remote_only_commit_fingerprints.len(), 2);
 }
 
-/// Local non-empty, remote empty. Local should send everything, request
-/// nothing.
 #[test]
 fn full_local_empty_remote_sends_all() {
     let local = tree(vec![commit(1, &[]), commit(2, &[head(1)])]);
@@ -127,72 +77,35 @@ fn full_local_empty_remote_sends_all() {
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    assert_eq!(
-        diff.local_only_commits.len(),
-        2,
-        "full local sends all 2 commits"
-    );
-    assert!(
-        diff.remote_only_commit_fingerprints.is_empty(),
-        "empty remote: nothing to request, got {} fps",
-        diff.remote_only_commit_fingerprints.len(),
-    );
+    assert_eq!(diff.local_only_commits.len(), 2);
+    assert!(diff.remote_only_commit_fingerprints.is_empty());
 }
 
-// ===========================================================================
-// Section 2: Disjoint histories — the user's bug shape
-// ===========================================================================
-
-/// **The user's bug shape.** Two peers with completely disjoint commit
-/// sets should produce `local_only.len() == |local|` and
-/// `remote_only.len() == |remote|` — this exactly matches the
-/// "19 missing, requesting 19" pattern from the logs IF the two browsers
-/// genuinely had disjoint commits at sync time.
-///
-/// We assert the math here to confirm that *this specific symptom is
-/// expected* given disjoint inputs — which means the user's bug is
-/// **either** about the data being genuinely disjoint when it shouldn't
-/// be, **or** about the system failing to converge after the disjoint
-/// diff round.
+/// Disjoint sets produce `local_only.len() == |local|` and
+/// `remote_only.len() == |remote|` — matches the "N missing, requesting N"
+/// log pattern when peers genuinely have nothing in common.
 #[test]
 fn disjoint_histories_send_full_sets_in_both_directions() {
-    // Local has chain A → B → C (seeds 10, 11, 12)
     let local = tree(vec![
         commit(10, &[]),
         commit(11, &[head(10)]),
         commit(12, &[head(11)]),
     ]);
-
-    // Remote has chain X → Y → Z (seeds 20, 21, 22) — fully disjoint
     let remote = tree(vec![
         commit(20, &[]),
         commit(21, &[head(20)]),
         commit(22, &[head(21)]),
     ]);
 
-    let remote_summary = remote.fingerprint_summarize(&SEED);
-    let diff = local.diff_remote_fingerprints(&remote_summary);
+    let summary = remote.fingerprint_summarize(&SEED);
+    let diff = local.diff_remote_fingerprints(&summary);
 
-    // Local has 3 commits that remote doesn't have.
-    assert_eq!(
-        diff.local_only_commits.len(),
-        3,
-        "disjoint: local should report all 3 of its commits as local_only"
-    );
-    // Remote has 3 commits that local doesn't have.
-    assert_eq!(
-        diff.remote_only_commit_fingerprints.len(),
-        3,
-        "disjoint: remote_only_commit_fingerprints should be all 3 of remote's"
-    );
+    assert_eq!(diff.local_only_commits.len(), 3);
+    assert_eq!(diff.remote_only_commit_fingerprints.len(), 3);
 }
 
-/// Disjoint histories with **unequal sizes** — e.g. local has 19, remote
-/// has 20. Confirms the "M missing, requesting N" pattern matches the
-/// inputs exactly when there's zero overlap.
 #[test]
 fn disjoint_histories_unequal_sizes() {
-    // Local: chain of 19 commits starting at seed 10.
     let mut local_commits = vec![commit(10, &[])];
     for i in 1..19u8 {
         local_commits.push(commit(10 + i, &[head(10 + i - 1)]));
@@ -200,7 +113,6 @@ fn disjoint_histories_unequal_sizes() {
     assert_eq!(local_commits.len(), 19);
     let local = tree(local_commits);
 
-    // Remote: chain of 20 commits starting at seed 100 (disjoint).
     let mut remote_commits = vec![commit(100, &[])];
     for i in 1..20u8 {
         remote_commits.push(commit(100 + i, &[head(100 + i - 1)]));
@@ -211,35 +123,17 @@ fn disjoint_histories_unequal_sizes() {
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // 19 missing (local-only, what local will send to remote)
-    assert_eq!(
-        diff.local_only_commits.len(),
-        19,
-        "local has 19 disjoint → local_only_commits is 19"
-    );
-    // 20 requesting (remote-only, fingerprints local will echo back)
-    assert_eq!(
-        diff.remote_only_commit_fingerprints.len(),
-        20,
-        "remote has 20 disjoint → remote_only_commit_fingerprints is 20"
-    );
+    assert_eq!(diff.local_only_commits.len(), 19);
+    assert_eq!(diff.remote_only_commit_fingerprints.len(), 20);
 }
 
-// ===========================================================================
-// Section 3: Overlapping histories (the convergence case)
-// ===========================================================================
-
-/// Local and remote share commits A, B; local has additional C; remote
-/// has additional D. After sync, both should converge.
+/// Shared prefix A→B; local adds C, remote adds D. Each side sends its
+/// divergent suffix only.
 #[test]
 fn forked_after_shared_prefix() {
-    // Shared prefix
     let a = commit(1, &[]);
     let b = commit(2, &[head(1)]);
-
-    // Local-only continuation
     let c = commit(3, &[head(2)]);
-    // Remote-only continuation
     let d = commit(4, &[head(2)]);
 
     let local = tree(vec![a.clone(), b.clone(), c]);
@@ -248,67 +142,35 @@ fn forked_after_shared_prefix() {
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // A and B are shared, ancestors_of({A, B}) = {A, B}. Local's commits
-    // are {A, B, C}. local_only_commits before pruning = [C]. After
-    // ancestor pruning: C is not an ancestor of shared, keep. = [C].
-    assert_eq!(
-        diff.local_only_commits.len(),
-        1,
-        "forked: local should only send its divergent suffix (1 commit)"
-    );
-    let sent_id = *diff.local_only_commits[0].0;
-    assert_eq!(sent_id, head(3), "should send C, not A or B");
-
-    // Remote-only: D is not in local's fp set. A and B are in both.
-    assert_eq!(
-        diff.remote_only_commit_fingerprints.len(),
-        1,
-        "forked: should request 1 commit (D)"
-    );
+    assert_eq!(diff.local_only_commits.len(), 1);
+    assert_eq!(*diff.local_only_commits[0].0, head(3));
+    assert_eq!(diff.remote_only_commit_fingerprints.len(), 1);
 }
 
-/// Linear history, remote is a strict prefix of local. Local sends only
-/// the tail; the shared prefix is pruned by DAG-ancestry analysis.
 #[test]
 fn remote_is_prefix_of_local() {
-    // Local: A → B → C → D
     let a = commit(1, &[]);
     let b = commit(2, &[head(1)]);
     let c = commit(3, &[head(2)]);
     let d = commit(4, &[head(3)]);
 
     let local = tree(vec![a.clone(), b.clone(), c.clone(), d]);
-    // Remote: A → B only
     let remote = tree(vec![a, b]);
 
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // Pre-pruning local_only = [C, D]. ancestors_of({A, B}) = {A, B}.
-    // Neither C nor D is in there, so both survive.
-    assert_eq!(
-        diff.local_only_commits.len(),
-        2,
-        "prefix: local sends C and D"
-    );
+    assert_eq!(diff.local_only_commits.len(), 2);
     let sent_ids: BTreeSet<CommitId> = diff
         .local_only_commits
         .iter()
         .map(|(id, _)| **id)
         .collect();
     assert!(sent_ids.contains(&head(3)) && sent_ids.contains(&head(4)));
-    assert!(
-        !sent_ids.contains(&head(1)) && !sent_ids.contains(&head(2)),
-        "shared prefix must not be re-sent"
-    );
-
-    assert!(
-        diff.remote_only_commit_fingerprints.is_empty(),
-        "prefix: nothing to request"
-    );
+    assert!(!sent_ids.contains(&head(1)) && !sent_ids.contains(&head(2)));
+    assert!(diff.remote_only_commit_fingerprints.is_empty());
 }
 
-/// Local is a strict prefix of remote. Local requests the tail.
 #[test]
 fn local_is_prefix_of_remote() {
     let a = commit(1, &[]);
@@ -322,140 +184,72 @@ fn local_is_prefix_of_remote() {
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    assert!(
-        diff.local_only_commits.is_empty(),
-        "local prefix has nothing to send"
-    );
-    assert_eq!(
-        diff.remote_only_commit_fingerprints.len(),
-        2,
-        "local prefix requests C and D"
-    );
+    assert!(diff.local_only_commits.is_empty());
+    assert_eq!(diff.remote_only_commit_fingerprints.len(), 2);
 }
 
-// ===========================================================================
-// Section 4: DAG-ancestry pruning correctness
-// ===========================================================================
-
-/// The pruning step removes commits from `local_only_commits` when they're
-/// ancestors of a commit the remote has. This test pins down that
-/// behavior: if remote has the tip C, local doesn't re-send A and B
-/// (C's ancestors).
+/// If remote has C, local should not re-send C's ancestors A and B.
 #[test]
 fn ancestry_pruning_drops_ancestors_of_shared_tip() {
-    // Local: A → B → C → D (D is local-only, A,B,C shared)
     let a = commit(1, &[]);
     let b = commit(2, &[head(1)]);
     let c = commit(3, &[head(2)]);
     let d = commit(4, &[head(3)]);
 
     let local = tree(vec![a.clone(), b.clone(), c.clone(), d.clone()]);
-
-    // Remote claims to have A, B, C (but not D)
     let remote = tree(vec![a, b, c]);
 
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // Pre-pruning local_only = [D]. ancestors_of({A,B,C}) = {A,B,C}.
-    // D is not in ancestors → keep.
-    assert_eq!(
-        diff.local_only_commits.len(),
-        1,
-        "ancestry: send only D (the divergent tip)"
-    );
+    assert_eq!(diff.local_only_commits.len(), 1);
     assert_eq!(*diff.local_only_commits[0].0, head(4));
 }
 
-/// **Sound-vs-complete edge case.** If remote claims to have B but does
-/// not actually have B's parent A, ancestry pruning drops A from
-/// `local_only_commits`. Convergence depends on the protocol invariant
-/// that "if you have a commit, you have its ancestors." This test
-/// confirms our pruning DOES drop A in this case — documenting the
-/// invariant and the cost of violating it.
-///
-/// (If a future change wants to be defensive against protocol violations,
-/// this test will need updating.)
+/// Pruning trusts the responder-claimed set's ancestors. If remote claims
+/// B without A, local does not re-send A — documenting the protocol
+/// invariant "if you have a commit, you have its ancestors."
 #[test]
 fn ancestry_pruning_trusts_remote_has_advertised_commits_ancestors() {
     let a = commit(1, &[]);
     let b = commit(2, &[head(1)]);
 
     let local = tree(vec![a.clone(), b.clone()]);
-
-    // Remote claims to have only B (NOT A). This is "ill-formed" in the
-    // sense that a peer should never advertise B without having A, but
-    // the protocol can't enforce that.
     let remote = tree(vec![b]);
 
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // shared = {B}. ancestors_of({B}) = {B, A}. local_only pre-prune = [A].
-    // After pruning: A is in ancestors → drop. Result: send nothing.
-    assert!(
-        diff.local_only_commits.is_empty(),
-        "ancestry pruning DOES trust the remote's advertisement; A is not re-sent. \
-         This is documented behavior — a peer that has B without A will not get A \
-         from this responder. Result was: {} commits",
-        diff.local_only_commits.len(),
-    );
+    assert!(diff.local_only_commits.is_empty());
 }
 
-/// Multi-tip DAG: local has two parallel chains rooted at the same point.
-/// Remote has only chain 1's tip. Pruning should drop chain 1's
-/// ancestors but keep all of chain 2.
+/// Two parallel chains rooted at the same point; remote has only chain
+/// 1's tip. Pruning drops chain 1, keeps chain 2.
 #[test]
 fn ancestry_pruning_preserves_disjoint_branches() {
     let root = commit(1, &[]);
-
-    // Branch 1: root → b1 → c1
     let b1 = commit(10, &[head(1)]);
     let c1 = commit(11, &[head(10)]);
-
-    // Branch 2: root → b2 → c2
     let b2 = commit(20, &[head(1)]);
     let c2 = commit(21, &[head(20)]);
 
     let local = tree(vec![root.clone(), b1.clone(), c1.clone(), b2.clone(), c2.clone()]);
-
-    // Remote has only c1's chain: root, b1, c1
     let remote = tree(vec![root, b1, c1]);
 
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // shared = {root, b1, c1}. ancestors_of(those) = {root, b1, c1}.
-    // local_only pre-prune = [b2, c2]. After: both kept (neither is an
-    // ancestor of shared).
-    assert_eq!(
-        diff.local_only_commits.len(),
-        2,
-        "should send branch 2 (b2 + c2) but not the shared chain"
-    );
+    assert_eq!(diff.local_only_commits.len(), 2);
     let sent_ids: BTreeSet<CommitId> = diff
         .local_only_commits
         .iter()
         .map(|(id, _)| **id)
         .collect();
-    assert!(
-        sent_ids.contains(&head(20)) && sent_ids.contains(&head(21)),
-        "sent set should be exactly {{b2, c2}}, got: {:?}",
-        sent_ids
-    );
+    assert!(sent_ids.contains(&head(20)) && sent_ids.contains(&head(21)));
 }
 
-/// Diamond DAG: shared root with two parallel branches that re-merge.
-///
-/// ```text
-///       root
-///      /    \
-///     b1     b2
-///      \    /
-///       merge
-/// ```
-///
-/// Remote has the merge commit. Pruning should drop all of root, b1, b2.
+/// Diamond: `root → {b1, b2} → merge`. Remote has only `merge`. Pruning
+/// drops root, b1, b2 (all ancestors of merge via both parents).
 #[test]
 fn ancestry_pruning_handles_diamond_dag() {
     let root = commit(1, &[]);
@@ -464,80 +258,42 @@ fn ancestry_pruning_handles_diamond_dag() {
     let merge = commit(4, &[head(2), head(3)]);
 
     let local = tree(vec![root, b1, b2, merge.clone()]);
-
-    // Remote has only the merge commit
     let remote = tree(vec![merge]);
 
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // shared = {merge}. ancestors_of({merge}) walks both parents:
-    //   merge → b1 → root (added)
-    //   merge → b2 → root (already visited)
-    // Result: {merge, b1, b2, root}.
-    // local_only pre-prune = [root, b1, b2]. All in ancestors → all dropped.
-    assert!(
-        diff.local_only_commits.is_empty(),
-        "diamond DAG: nothing should be sent (remote has the merge tip)"
-    );
+    assert!(diff.local_only_commits.is_empty());
 }
 
-/// Many parallel small chains, remote has only the latest commit of one.
-/// Verifies pruning scales correctly with many disjoint branches.
 #[test]
 fn many_parallel_chains_pruning() {
-    // 5 independent chains of length 3 each
     let mut all_commits = Vec::new();
-    let mut chain_tips: Vec<CommitId> = Vec::new();
     for chain_idx in 0..5u8 {
         let base = 10 + chain_idx * 10;
-        let c0 = commit(base, &[]);
-        let c1 = commit(base + 1, &[head(base)]);
-        let c2 = commit(base + 2, &[head(base + 1)]);
-        chain_tips.push(head(base + 2));
-        all_commits.push(c0);
-        all_commits.push(c1);
-        all_commits.push(c2);
+        all_commits.push(commit(base, &[]));
+        all_commits.push(commit(base + 1, &[head(base)]));
+        all_commits.push(commit(base + 2, &[head(base + 1)]));
     }
     let local = tree(all_commits);
-    assert_eq!(
-        local.loose_commits().count(),
-        15,
-        "5 chains × 3 commits = 15"
-    );
+    assert_eq!(local.loose_commits().count(), 15);
 
-    // Remote has just the last commit of the first chain (seed 12)
+    // Remote has only the last commit of the first chain.
     let remote = tree(vec![commit(12, &[head(11)])]);
 
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
-    // Chain 0: shared = {c2}. ancestors_of({c2}) = {c2, c1, c0}.
-    //   Local's c0, c1, c2 all in ancestors → all dropped.
-    // Chains 1-4: nothing shared, all 12 commits sent.
-    assert_eq!(
-        diff.local_only_commits.len(),
-        12,
-        "4 chains × 3 commits = 12 sent; chain 0 fully pruned"
-    );
+    // Chain 0 is fully pruned (3 ancestors of the shared tip); 4 chains
+    // × 3 commits = 12 remain.
+    assert_eq!(diff.local_only_commits.len(), 12);
 }
 
-// ===========================================================================
-// Section 5: The "growing forever" failure mode
-// ===========================================================================
-
-/// **Models the user's compute-grows-on-each-update symptom.** If two
-/// peers keep authoring independent commits and never converge, each
-/// successive sync produces a larger disjoint set. This is correct
-/// behavior at the diff layer — but if the FOLLOW-UP step (ingesting
-/// `missing_commits`) is broken, the next round still sees the same
-/// disjointness.
-///
-/// We verify the math layer: round-2 of a disjoint sync should produce
-/// 0 missing and 0 requesting **assuming both sides ingested correctly**.
+/// After both sides ingest the other's `local_only_commits`, a fresh-seed
+/// round-2 diff is empty in both directions. The diff layer converges in
+/// one round given correct ingestion.
 #[test]
 fn convergence_after_one_round_when_both_sides_ingest() {
-    // Round 0: local has chain A, remote has chain B (disjoint).
     let local_initial = tree(vec![
         commit(10, &[]),
         commit(11, &[head(10)]),
@@ -549,34 +305,29 @@ fn convergence_after_one_round_when_both_sides_ingest() {
         commit(22, &[head(21)]),
     ]);
 
-    // Simulate round 1: each side observes the other's diff
     let local_summary = local_initial.fingerprint_summarize(&SEED);
     let remote_summary = remote_initial.fingerprint_summarize(&SEED);
 
-    // Materialize owned commit sets from the diffs before moving the trees.
     let from_remote_to_local: Vec<LooseCommit> = {
-        let diff_at_remote = remote_initial.diff_remote_fingerprints(&local_summary);
-        assert_eq!(diff_at_remote.local_only_commits.len(), 3);
-        assert_eq!(diff_at_remote.remote_only_commit_fingerprints.len(), 3);
-        diff_at_remote
-            .local_only_commits
+        let diff = remote_initial.diff_remote_fingerprints(&local_summary);
+        assert_eq!(diff.local_only_commits.len(), 3);
+        assert_eq!(diff.remote_only_commit_fingerprints.len(), 3);
+        diff.local_only_commits
             .into_iter()
             .map(|(_, c)| c.clone())
             .collect()
     };
 
     let from_local_to_remote: Vec<LooseCommit> = {
-        let diff_at_local = local_initial.diff_remote_fingerprints(&remote_summary);
-        assert_eq!(diff_at_local.local_only_commits.len(), 3);
-        assert_eq!(diff_at_local.remote_only_commit_fingerprints.len(), 3);
-        diff_at_local
-            .local_only_commits
+        let diff = local_initial.diff_remote_fingerprints(&remote_summary);
+        assert_eq!(diff.local_only_commits.len(), 3);
+        assert_eq!(diff.remote_only_commit_fingerprints.len(), 3);
+        diff.local_only_commits
             .into_iter()
             .map(|(_, c)| c.clone())
             .collect()
     };
 
-    // Each side ingests the OTHER side's local_only_commits.
     let mut local_after = local_initial;
     for commit in from_remote_to_local {
         local_after.add_commit(commit);
@@ -586,13 +337,9 @@ fn convergence_after_one_round_when_both_sides_ingest() {
         remote_after.add_commit(commit);
     }
 
-    // After ingestion both should have all 6 commits.
     assert_eq!(local_after.loose_commits().count(), 6);
     assert_eq!(remote_after.loose_commits().count(), 6);
 
-    // Round 2: with a fresh seed, the diff should be empty in both
-    // directions. This proves the diff layer converges in ONE round
-    // when both sides ingest the response correctly.
     let seed2 = FingerprintSeed::new(0xFEED_FACE, 0xCAFE_BABE);
     let local_summary2 = local_after.fingerprint_summarize(&seed2);
     let remote_summary2 = remote_after.fingerprint_summarize(&seed2);
@@ -600,43 +347,21 @@ fn convergence_after_one_round_when_both_sides_ingest() {
     let round2_at_local = local_after.diff_remote_fingerprints(&remote_summary2);
     let round2_at_remote = remote_after.diff_remote_fingerprints(&local_summary2);
 
-    assert!(
-        round2_at_local.local_only_commits.is_empty()
-            && round2_at_local.remote_only_commit_fingerprints.is_empty(),
-        "round 2 at local should be empty (received={}, sent_back={})",
-        round2_at_local.remote_only_commit_fingerprints.len(),
-        round2_at_local.local_only_commits.len(),
-    );
-    assert!(
-        round2_at_remote.local_only_commits.is_empty()
-            && round2_at_remote.remote_only_commit_fingerprints.is_empty(),
-        "round 2 at remote should be empty (received={}, sent_back={})",
-        round2_at_remote.remote_only_commit_fingerprints.len(),
-        round2_at_remote.local_only_commits.len(),
-    );
+    assert!(round2_at_local.local_only_commits.is_empty());
+    assert!(round2_at_local.remote_only_commit_fingerprints.is_empty());
+    assert!(round2_at_remote.local_only_commits.is_empty());
+    assert!(round2_at_remote.remote_only_commit_fingerprints.is_empty());
 }
 
-/// **The most direct test of the user's bug-pattern as a pure math
-/// property.** If sync convergence works at the diff layer, then for
-/// any pair of trees `(A, B)`, after we add `A.local_only` to `B` and
-/// `B.local_only` to `A`, a follow-up diff with a fresh seed is empty.
-///
-/// This is just an explicit, deterministic version of what the property
-/// tests in `sedimentree.rs::tests::proptests` should cover for the
-/// loose-commit-only case.
 #[test]
 fn loose_commit_only_sync_converges_in_one_round_arbitrary_overlap() {
-    // Shared: A, B, C
-    // Local-only: D, E
-    // Remote-only: X, Y, Z (with X having parent B from the shared set)
+    // Shared: A, B, C. Local-only: D, E. Remote-only: X, Y, Z (X forks off B).
     let a = commit(1, &[]);
     let b = commit(2, &[head(1)]);
     let c = commit(3, &[head(2)]);
-
     let d = commit(4, &[head(3)]);
     let e = commit(5, &[head(4)]);
-
-    let x = commit(11, &[head(2)]); // forks off B
+    let x = commit(11, &[head(2)]);
     let y = commit(12, &[head(11)]);
     let z = commit(13, &[head(12)]);
 
@@ -647,28 +372,18 @@ fn loose_commit_only_sync_converges_in_one_round_arbitrary_overlap() {
     let remote_summary = remote_initial.fingerprint_summarize(&SEED);
 
     let from_remote_to_local: Vec<LooseCommit> = {
-        let diff_at_remote = remote_initial.diff_remote_fingerprints(&local_summary);
-        assert_eq!(
-            diff_at_remote.local_only_commits.len(),
-            3,
-            "remote sends X, Y, Z (post-shared)"
-        );
-        diff_at_remote
-            .local_only_commits
+        let diff = remote_initial.diff_remote_fingerprints(&local_summary);
+        assert_eq!(diff.local_only_commits.len(), 3);
+        diff.local_only_commits
             .into_iter()
             .map(|(_, c)| c.clone())
             .collect()
     };
 
     let from_local_to_remote: Vec<LooseCommit> = {
-        let diff_at_local = local_initial.diff_remote_fingerprints(&remote_summary);
-        assert_eq!(
-            diff_at_local.local_only_commits.len(),
-            2,
-            "local sends D, E (post-shared)"
-        );
-        diff_at_local
-            .local_only_commits
+        let diff = local_initial.diff_remote_fingerprints(&remote_summary);
+        assert_eq!(diff.local_only_commits.len(), 2);
+        diff.local_only_commits
             .into_iter()
             .map(|(_, c)| c.clone())
             .collect()
@@ -686,7 +401,6 @@ fn loose_commit_only_sync_converges_in_one_round_arbitrary_overlap() {
     assert_eq!(local_after.loose_commits().count(), 8);
     assert_eq!(remote_after.loose_commits().count(), 8);
 
-    // Round 2 with fresh seed
     let seed2 = FingerprintSeed::new(7, 11);
     let remote_summary2 = remote_after.fingerprint_summarize(&seed2);
     let round2 = local_after.diff_remote_fingerprints(&remote_summary2);
@@ -695,13 +409,7 @@ fn loose_commit_only_sync_converges_in_one_round_arbitrary_overlap() {
     assert!(round2.remote_only_commit_fingerprints.is_empty());
 }
 
-// ===========================================================================
-// Section 6: Minimize interaction (loose-only side)
-// ===========================================================================
-
-/// Verifies that minimize on a loose-only tree (no fragments) doesn't
-/// change the fingerprint set, so a tree minimized before fingerprinting
-/// is interchangeable with the unminimized version.
+/// Minimize on a fragment-less tree must not change the fingerprint set.
 #[test]
 fn minimize_loose_only_preserves_fingerprints() {
     let local = tree(vec![
@@ -719,11 +427,9 @@ fn minimize_loose_only_preserves_fingerprints() {
     assert_eq!(
         summary_raw.commit_fingerprints(),
         summary_min.commit_fingerprints(),
-        "minimize on loose-only tree must not change commit fingerprints"
     );
     assert_eq!(
         summary_raw.fragment_fingerprints(),
         summary_min.fragment_fingerprints(),
-        "fragment set should be empty in both"
     );
 }

--- a/sedimentree_core/tests/diff_diverging_histories.rs
+++ b/sedimentree_core/tests/diff_diverging_histories.rs
@@ -160,11 +160,7 @@ fn remote_is_prefix_of_local() {
     let diff = local.diff_remote_fingerprints(&summary);
 
     assert_eq!(diff.local_only_commits.len(), 2);
-    let sent_ids: BTreeSet<CommitId> = diff
-        .local_only_commits
-        .iter()
-        .map(|(id, _)| **id)
-        .collect();
+    let sent_ids: BTreeSet<CommitId> = diff.local_only_commits.iter().map(|(id, _)| **id).collect();
     assert!(sent_ids.contains(&head(3)) && sent_ids.contains(&head(4)));
     assert!(!sent_ids.contains(&head(1)) && !sent_ids.contains(&head(2)));
     assert!(diff.remote_only_commit_fingerprints.is_empty());
@@ -232,18 +228,20 @@ fn ancestry_pruning_preserves_disjoint_branches() {
     let b2 = commit(20, &[head(1)]);
     let c2 = commit(21, &[head(20)]);
 
-    let local = tree(vec![root.clone(), b1.clone(), c1.clone(), b2.clone(), c2.clone()]);
+    let local = tree(vec![
+        root.clone(),
+        b1.clone(),
+        c1.clone(),
+        b2.clone(),
+        c2.clone(),
+    ]);
     let remote = tree(vec![root, b1, c1]);
 
     let summary = remote.fingerprint_summarize(&SEED);
     let diff = local.diff_remote_fingerprints(&summary);
 
     assert_eq!(diff.local_only_commits.len(), 2);
-    let sent_ids: BTreeSet<CommitId> = diff
-        .local_only_commits
-        .iter()
-        .map(|(id, _)| **id)
-        .collect();
+    let sent_ids: BTreeSet<CommitId> = diff.local_only_commits.iter().map(|(id, _)| **id).collect();
     assert!(sent_ids.contains(&head(20)) && sent_ids.contains(&head(21)));
 }
 

--- a/sedimentree_core/tests/fingerprint_stability.rs
+++ b/sedimentree_core/tests/fingerprint_stability.rs
@@ -32,27 +32,30 @@ pub const EXPECTED_FP_ONES: u64 = 13_743_385_435_344_457_055;
 pub const EXPECTED_FP_SEQUENTIAL: u64 = 10_722_668_375_651_339_477;
 pub const EXPECTED_FP_REPEATING: u64 = 16_398_704_403_767_843_780;
 
-fn test_seed() -> FingerprintSeed {
+const fn test_seed() -> FingerprintSeed {
     FingerprintSeed::new(TEST_SEED_KEY0, TEST_SEED_KEY1)
 }
 
-fn id_zeroes() -> CommitId {
+const fn id_zeroes() -> CommitId {
     CommitId::new([0u8; 32])
 }
 
-fn id_ones() -> CommitId {
+const fn id_ones() -> CommitId {
     CommitId::new([0xFF; 32])
 }
 
 fn id_sequential() -> CommitId {
     let mut bytes = [0u8; 32];
     for (i, b) in bytes.iter_mut().enumerate() {
-        *b = (i + 1) as u8;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            *b = (i + 1) as u8;
+        }
     }
     CommitId::new(bytes)
 }
 
-fn id_repeating() -> CommitId {
+const fn id_repeating() -> CommitId {
     CommitId::new([42u8; 32])
 }
 
@@ -90,8 +93,7 @@ fn print_fingerprint_baselines() {
     let fp_r: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_repeating());
 
     eprintln!(
-        "Fingerprint baselines (seed key0=0x{:016X}, key1=0x{:016X}):",
-        TEST_SEED_KEY0, TEST_SEED_KEY1,
+        "Fingerprint baselines (seed key0=0x{TEST_SEED_KEY0:016X}, key1=0x{TEST_SEED_KEY1:016X}):",
     );
     eprintln!("  zeroes     = {}", fp_z.as_u64());
     eprintln!("  ones       = {}", fp_o.as_u64());

--- a/sedimentree_core/tests/fingerprint_stability.rs
+++ b/sedimentree_core/tests/fingerprint_stability.rs
@@ -1,51 +1,35 @@
-//! **Cross-platform fingerprint stability tests.**
-//!
-//! The user's bug shows two peers (one Wasm browser, one native server)
-//! producing "N missing, requesting N" diffs even when they should share
-//! commits. One uncaught failure mode is: `Fingerprint::new(seed, value)`
-//! producing different `u64`s on `wasm32-unknown-unknown` vs `x86_64-*`.
-//!
-//! This file hardcodes the expected `u64` for fixed inputs, asserted on
-//! whatever target this test runs on. The companion test in
+//! Asserts that `Fingerprint::new` produces fixed expected `u64`s for a
+//! handful of inputs. The companion test
 //! `sedimentree_wasm/tests/fingerprint_stability_wasm.rs` asserts the
-//! same hardcoded outputs from the wasm32 target. If either side
-//! disagrees with the hardcoded values, the platforms hash differently
-//! — and the bug is in the std-library or hasher chain, not in the
-//! Subduction protocol.
+//! same values from wasm32; if the two ever disagree, the protocol
+//! cannot interop between targets.
 //!
-//! To regenerate the hardcoded constants (e.g. after a `siphasher`
-//! upgrade), uncomment the `regenerate_baselines` test and run with
-//! `cargo test regenerate_baselines -- --nocapture`. Copy the printed
-//! values back into the `const`s. Then verify the same printed values
-//! match what `wasm-pack test --node sedimentree_wasm` prints.
+//! To regenerate after a `siphasher` upgrade, run the `#[ignore]`'d
+//! helper:
+//!
+//! ```sh
+//! cargo test --test fingerprint_stability print_fingerprint_baselines \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! Copy the printed values into both this file's `EXPECTED_FP_*` constants
+//! and the matching constants in the wasm-side companion. Then run
+//! `wasm-pack test --node sedimentree_wasm --test fingerprint_stability_wasm`
+//! to confirm both targets agree.
 
-#![allow(clippy::expect_used, clippy::unreadable_literal)]
+#![allow(clippy::expect_used, clippy::unreadable_literal, missing_docs)]
 
 use sedimentree_core::{
     crypto::fingerprint::{Fingerprint, FingerprintSeed},
     loose_commit::id::CommitId,
 };
 
-// ============================================================================
-// Hardcoded expected u64 outputs for fixed inputs
-// ============================================================================
-//
-// Generated on x86_64-unknown-linux-gnu with siphasher 1.0.x.
-// If you change the inputs, regenerate via the test below.
-
 const TEST_SEED_KEY0: u64 = 0x1234_5678_9ABC_DEF0;
 const TEST_SEED_KEY1: u64 = 0xFEDC_BA98_7654_3210;
 
-/// `Fingerprint::new(seed, CommitId([0u8; 32]))`
 pub const EXPECTED_FP_ZEROES: u64 = 6_748_340_123_268_596_282;
-
-/// `Fingerprint::new(seed, CommitId([0xFFu8; 32]))`
 pub const EXPECTED_FP_ONES: u64 = 13_743_385_435_344_457_055;
-
-/// `Fingerprint::new(seed, CommitId([1, 2, 3, ..., 32]))` (1..=32 as bytes)
 pub const EXPECTED_FP_SEQUENTIAL: u64 = 10_722_668_375_651_339_477;
-
-/// `Fingerprint::new(seed, CommitId([42; 32]))`
 pub const EXPECTED_FP_REPEATING: u64 = 16_398_704_403_767_843_780;
 
 fn test_seed() -> FingerprintSeed {
@@ -72,24 +56,10 @@ fn id_repeating() -> CommitId {
     CommitId::new([42u8; 32])
 }
 
-// ============================================================================
-// Tests
-// ============================================================================
-
 #[test]
 fn fingerprint_of_all_zero_commit_id_matches_baseline() {
     let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &id_zeroes());
-    assert_eq!(
-        fp.as_u64(),
-        EXPECTED_FP_ZEROES,
-        "Fingerprint output for (seed={{0x{:016X}, 0x{:016X}}}, all-zero CommitId) \
-         differs from the cross-platform baseline. This means SipHash or the \
-         underlying Hash impl produces different bytes on this target than on \
-         x86_64. The Subduction sync protocol cannot work across peers whose \
-         hashes disagree.",
-        TEST_SEED_KEY0,
-        TEST_SEED_KEY1,
-    );
+    assert_eq!(fp.as_u64(), EXPECTED_FP_ZEROES);
 }
 
 #[test]
@@ -110,16 +80,8 @@ fn fingerprint_of_repeating_byte_commit_id_matches_baseline() {
     assert_eq!(fp.as_u64(), EXPECTED_FP_REPEATING);
 }
 
-/// Helper test that prints the actual `u64`s for the four fixed inputs.
-/// Used to (re)generate the `EXPECTED_FP_*` constants above.
-///
-/// **This test always passes** — its purpose is to print the values to
-/// stdout so they can be copied into the constants. Run it on the host
-/// AND on wasm32; if the printed values differ across platforms, the
-/// bug is confirmed.
-///
-/// Run with `cargo test print_fingerprint_baselines -- --nocapture`.
 #[test]
+#[ignore = "diagnostic helper; run with --ignored --nocapture to regenerate baselines"]
 fn print_fingerprint_baselines() {
     let seed = test_seed();
     let fp_z: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_zeroes());

--- a/sedimentree_core/tests/fingerprint_stability.rs
+++ b/sedimentree_core/tests/fingerprint_stability.rs
@@ -1,0 +1,138 @@
+//! **Cross-platform fingerprint stability tests.**
+//!
+//! The user's bug shows two peers (one Wasm browser, one native server)
+//! producing "N missing, requesting N" diffs even when they should share
+//! commits. One uncaught failure mode is: `Fingerprint::new(seed, value)`
+//! producing different `u64`s on `wasm32-unknown-unknown` vs `x86_64-*`.
+//!
+//! This file hardcodes the expected `u64` for fixed inputs, asserted on
+//! whatever target this test runs on. The companion test in
+//! `sedimentree_wasm/tests/fingerprint_stability_wasm.rs` asserts the
+//! same hardcoded outputs from the wasm32 target. If either side
+//! disagrees with the hardcoded values, the platforms hash differently
+//! — and the bug is in the std-library or hasher chain, not in the
+//! Subduction protocol.
+//!
+//! To regenerate the hardcoded constants (e.g. after a `siphasher`
+//! upgrade), uncomment the `regenerate_baselines` test and run with
+//! `cargo test regenerate_baselines -- --nocapture`. Copy the printed
+//! values back into the `const`s. Then verify the same printed values
+//! match what `wasm-pack test --node sedimentree_wasm` prints.
+
+#![allow(clippy::expect_used, clippy::unreadable_literal)]
+
+use sedimentree_core::{
+    crypto::fingerprint::{Fingerprint, FingerprintSeed},
+    loose_commit::id::CommitId,
+};
+
+// ============================================================================
+// Hardcoded expected u64 outputs for fixed inputs
+// ============================================================================
+//
+// Generated on x86_64-unknown-linux-gnu with siphasher 1.0.x.
+// If you change the inputs, regenerate via the test below.
+
+const TEST_SEED_KEY0: u64 = 0x1234_5678_9ABC_DEF0;
+const TEST_SEED_KEY1: u64 = 0xFEDC_BA98_7654_3210;
+
+/// `Fingerprint::new(seed, CommitId([0u8; 32]))`
+pub const EXPECTED_FP_ZEROES: u64 = 6_748_340_123_268_596_282;
+
+/// `Fingerprint::new(seed, CommitId([0xFFu8; 32]))`
+pub const EXPECTED_FP_ONES: u64 = 13_743_385_435_344_457_055;
+
+/// `Fingerprint::new(seed, CommitId([1, 2, 3, ..., 32]))` (1..=32 as bytes)
+pub const EXPECTED_FP_SEQUENTIAL: u64 = 10_722_668_375_651_339_477;
+
+/// `Fingerprint::new(seed, CommitId([42; 32]))`
+pub const EXPECTED_FP_REPEATING: u64 = 16_398_704_403_767_843_780;
+
+fn test_seed() -> FingerprintSeed {
+    FingerprintSeed::new(TEST_SEED_KEY0, TEST_SEED_KEY1)
+}
+
+fn id_zeroes() -> CommitId {
+    CommitId::new([0u8; 32])
+}
+
+fn id_ones() -> CommitId {
+    CommitId::new([0xFF; 32])
+}
+
+fn id_sequential() -> CommitId {
+    let mut bytes = [0u8; 32];
+    for (i, b) in bytes.iter_mut().enumerate() {
+        *b = (i + 1) as u8;
+    }
+    CommitId::new(bytes)
+}
+
+fn id_repeating() -> CommitId {
+    CommitId::new([42u8; 32])
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn fingerprint_of_all_zero_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &id_zeroes());
+    assert_eq!(
+        fp.as_u64(),
+        EXPECTED_FP_ZEROES,
+        "Fingerprint output for (seed={{0x{:016X}, 0x{:016X}}}, all-zero CommitId) \
+         differs from the cross-platform baseline. This means SipHash or the \
+         underlying Hash impl produces different bytes on this target than on \
+         x86_64. The Subduction sync protocol cannot work across peers whose \
+         hashes disagree.",
+        TEST_SEED_KEY0,
+        TEST_SEED_KEY1,
+    );
+}
+
+#[test]
+fn fingerprint_of_all_ones_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &id_ones());
+    assert_eq!(fp.as_u64(), EXPECTED_FP_ONES);
+}
+
+#[test]
+fn fingerprint_of_sequential_bytes_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &id_sequential());
+    assert_eq!(fp.as_u64(), EXPECTED_FP_SEQUENTIAL);
+}
+
+#[test]
+fn fingerprint_of_repeating_byte_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &id_repeating());
+    assert_eq!(fp.as_u64(), EXPECTED_FP_REPEATING);
+}
+
+/// Helper test that prints the actual `u64`s for the four fixed inputs.
+/// Used to (re)generate the `EXPECTED_FP_*` constants above.
+///
+/// **This test always passes** — its purpose is to print the values to
+/// stdout so they can be copied into the constants. Run it on the host
+/// AND on wasm32; if the printed values differ across platforms, the
+/// bug is confirmed.
+///
+/// Run with `cargo test print_fingerprint_baselines -- --nocapture`.
+#[test]
+fn print_fingerprint_baselines() {
+    let seed = test_seed();
+    let fp_z: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_zeroes());
+    let fp_o: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_ones());
+    let fp_s: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_sequential());
+    let fp_r: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_repeating());
+
+    eprintln!(
+        "Fingerprint baselines (seed key0=0x{:016X}, key1=0x{:016X}):",
+        TEST_SEED_KEY0, TEST_SEED_KEY1,
+    );
+    eprintln!("  zeroes     = {}", fp_z.as_u64());
+    eprintln!("  ones       = {}", fp_o.as_u64());
+    eprintln!("  sequential = {}", fp_s.as_u64());
+    eprintln!("  repeating  = {}", fp_r.as_u64());
+}

--- a/sedimentree_core/tests/sync_convergence_props.rs
+++ b/sedimentree_core/tests/sync_convergence_props.rs
@@ -1,0 +1,263 @@
+//! Property tests for `Sedimentree::diff_remote_fingerprints` and
+//! `fingerprint_summarize`. The canonical "after mutual ingest, a fresh
+//! diff is empty" property is the single most important sync-correctness
+//! invariant — if it ever fails, sync diverges forever.
+
+#![cfg(feature = "bolero")]
+#![allow(clippy::expect_used)]
+
+use std::collections::BTreeSet;
+
+use sedimentree_core::{
+    collections::Set,
+    crypto::fingerprint::{Fingerprint, FingerprintSeed},
+    loose_commit::{LooseCommit, id::CommitId},
+    sedimentree::{FingerprintSummary, Sedimentree},
+};
+
+/// Rebuild `commits` dropping any parent reference whose target isn't
+/// also in the list. The diff layer's ancestry-pruning step assumes
+/// "if you have a commit, you have its ancestors" — peers that violate
+/// this can't be expected to converge in one round.
+fn close_ancestry(commits: &[LooseCommit]) -> Vec<LooseCommit> {
+    let ids: BTreeSet<CommitId> = commits.iter().map(LooseCommit::head).collect();
+    commits
+        .iter()
+        .map(|c| {
+            let pruned_parents: BTreeSet<CommitId> = c
+                .parents()
+                .iter()
+                .copied()
+                .filter(|p| ids.contains(p))
+                .collect();
+            LooseCommit::new(c.sedimentree_id(), c.head(), pruned_parents, *c.blob_meta())
+        })
+        .collect()
+}
+
+/// Topo-sort an already ancestry-closed list of commits so that every
+/// commit appears after all its parents. Drops members of any cycle.
+fn topo_sort(commits: Vec<LooseCommit>) -> Vec<LooseCommit> {
+    let mut placed = BTreeSet::new();
+    let mut result = Vec::new();
+    let mut remaining = commits;
+
+    loop {
+        let before = remaining.len();
+        let mut next_remaining = Vec::new();
+        for c in remaining {
+            if c.parents().iter().all(|p| placed.contains(p)) {
+                placed.insert(c.head());
+                result.push(c);
+            } else {
+                next_remaining.push(c);
+            }
+        }
+        if next_remaining.len() == before {
+            // No progress — remaining commits are in a cycle. Drop them.
+            return result;
+        }
+        if next_remaining.is_empty() {
+            return result;
+        }
+        remaining = next_remaining;
+    }
+}
+
+/// Partition a topo-sorted universe into two ancestry-closed subsets
+/// using element-wise boolean masks. A commit is admitted to a subset
+/// only if its mask bit is set *and* all its parents are already in
+/// that subset. Produces overlapping, disjoint, or empty sets depending
+/// on the masks.
+fn partition(
+    universe: &[LooseCommit],
+    a_mask: &[bool],
+    b_mask: &[bool],
+) -> (Vec<LooseCommit>, Vec<LooseCommit>) {
+    let mut a_commits = Vec::new();
+    let mut b_commits = Vec::new();
+    let mut a_ids: BTreeSet<CommitId> = BTreeSet::new();
+    let mut b_ids: BTreeSet<CommitId> = BTreeSet::new();
+
+    for (i, c) in universe.iter().enumerate() {
+        let in_a = a_mask.get(i).copied().unwrap_or(false);
+        let in_b = b_mask.get(i).copied().unwrap_or(false);
+
+        if in_a && c.parents().iter().all(|p| a_ids.contains(p)) {
+            a_commits.push(c.clone());
+            a_ids.insert(c.head());
+        }
+        if in_b && c.parents().iter().all(|p| b_ids.contains(p)) {
+            b_commits.push(c.clone());
+            b_ids.insert(c.head());
+        }
+    }
+
+    (a_commits, b_commits)
+}
+
+/// **The canonical sync-correctness property.** For any two
+/// ancestry-closed loose-commit trees drawn from a shared universe
+/// (so they may overlap, fork, or be disjoint) and any pair of seeds,
+/// after each side ingests the other's `local_only_commits` (computed
+/// under the first seed), a fresh diff under the second seed is empty
+/// in both directions.
+#[test]
+fn prop_mutual_ingest_converges_in_one_round() {
+    bolero::check!()
+        .with_arbitrary::<(
+            Vec<LooseCommit>,
+            Vec<bool>,
+            Vec<bool>,
+            FingerprintSeed,
+            FingerprintSeed,
+        )>()
+        .for_each(|(universe, a_mask, b_mask, seed1, seed2)| {
+            let universe = topo_sort(close_ancestry(universe));
+            let (a_commits, b_commits) = partition(&universe, a_mask, b_mask);
+
+            let a_initial = Sedimentree::new(vec![], a_commits);
+            let b_initial = Sedimentree::new(vec![], b_commits);
+
+            let a_summary1 = a_initial.fingerprint_summarize(seed1);
+            let b_summary1 = b_initial.fingerprint_summarize(seed1);
+
+            let to_a: Vec<LooseCommit> = b_initial
+                .diff_remote_fingerprints(&a_summary1)
+                .local_only_commits
+                .into_iter()
+                .map(|(_, c)| c.clone())
+                .collect();
+            let to_b: Vec<LooseCommit> = a_initial
+                .diff_remote_fingerprints(&b_summary1)
+                .local_only_commits
+                .into_iter()
+                .map(|(_, c)| c.clone())
+                .collect();
+
+            let mut a_after = a_initial;
+            for c in to_a {
+                a_after.add_commit(c);
+            }
+            let mut b_after = b_initial;
+            for c in to_b {
+                b_after.add_commit(c);
+            }
+
+            let a_summary2 = a_after.fingerprint_summarize(seed2);
+            let b_summary2 = b_after.fingerprint_summarize(seed2);
+
+            let round2_at_a = a_after.diff_remote_fingerprints(&b_summary2);
+            let round2_at_b = b_after.diff_remote_fingerprints(&a_summary2);
+
+            assert!(
+                round2_at_a.local_only_commits.is_empty()
+                    && round2_at_a.remote_only_commit_fingerprints.is_empty(),
+                "round 2 at A non-empty: {} local-only, {} requested",
+                round2_at_a.local_only_commits.len(),
+                round2_at_a.remote_only_commit_fingerprints.len(),
+            );
+            assert!(
+                round2_at_b.local_only_commits.is_empty()
+                    && round2_at_b.remote_only_commit_fingerprints.is_empty(),
+                "round 2 at B non-empty: {} local-only, {} requested",
+                round2_at_b.local_only_commits.len(),
+                round2_at_b.remote_only_commit_fingerprints.len(),
+            );
+        });
+}
+
+/// Every commit in a tree appears in its own fingerprint summary.
+#[test]
+fn prop_summary_contains_every_commits_fingerprint() {
+    bolero::check!()
+        .with_arbitrary::<(Vec<LooseCommit>, FingerprintSeed)>()
+        .for_each(|(commits, seed)| {
+            let tree = Sedimentree::new(vec![], close_ancestry(commits));
+            let summary = tree.fingerprint_summarize(seed);
+
+            for commit in tree.loose_commits() {
+                let fp = Fingerprint::new(seed, &commit.head());
+                assert!(
+                    summary.commit_fingerprints().contains(&fp),
+                    "summary missing fp of commit {:?}",
+                    commit.head(),
+                );
+            }
+        });
+}
+
+/// `diff(T, T.summarize(s))` is empty for any tree and seed.
+#[test]
+fn prop_self_diff_is_empty() {
+    bolero::check!()
+        .with_arbitrary::<(Vec<LooseCommit>, FingerprintSeed)>()
+        .for_each(|(commits, seed)| {
+            let tree = Sedimentree::new(vec![], close_ancestry(commits));
+            let diff = tree.diff_remote_fingerprints(&tree.fingerprint_summarize(seed));
+
+            assert!(diff.local_only_commits.is_empty());
+            assert!(diff.remote_only_commit_fingerprints.is_empty());
+        });
+}
+
+/// **Ancestry-pruning soundness.** The `local_only_commits` returned
+/// by `diff_remote_fingerprints` is exactly
+/// `(local ∖ remote_fingerprints) ∖ ancestors_of(local ∩ remote_fingerprints)`.
+///
+/// A commit is dropped iff it would have been in `local_only` *and* it
+/// is an ancestor of some shared commit. Anything else is a bug —
+/// either pruning is too aggressive (drops a commit the remote needs)
+/// or too lax (re-sends a commit the remote already has via ancestry).
+#[test]
+fn prop_ancestry_pruning_drops_exactly_ancestors_of_shared() {
+    bolero::check!()
+        .with_arbitrary::<(Vec<LooseCommit>, FingerprintSummary)>()
+        .for_each(|(local_commits, remote_summary)| {
+            let local = Sedimentree::new(vec![], close_ancestry(local_commits));
+            let seed = remote_summary.seed();
+
+            let pre_pruning_local_only: Set<CommitId> = local
+                .loose_commits()
+                .filter(|c| {
+                    !remote_summary
+                        .commit_fingerprints()
+                        .contains(&Fingerprint::new(seed, &c.head()))
+                })
+                .map(LooseCommit::head)
+                .collect();
+
+            let shared_ids: Set<CommitId> = local
+                .loose_commits()
+                .filter(|c| {
+                    remote_summary
+                        .commit_fingerprints()
+                        .contains(&Fingerprint::new(seed, &c.head()))
+                })
+                .map(LooseCommit::head)
+                .collect();
+
+            let ancestors = local.ancestors_of(&shared_ids);
+
+            let diff = local.diff_remote_fingerprints(remote_summary);
+            let post_pruning_local_only: Set<CommitId> = diff
+                .local_only_commits
+                .iter()
+                .map(|(id, _)| **id)
+                .collect();
+
+            let actual_dropped: Set<CommitId> = pre_pruning_local_only
+                .difference(&post_pruning_local_only)
+                .copied()
+                .collect();
+            let expected_dropped: Set<CommitId> = pre_pruning_local_only
+                .intersection(&ancestors)
+                .copied()
+                .collect();
+
+            assert_eq!(
+                actual_dropped, expected_dropped,
+                "pruning rule mismatch: actual={actual_dropped:?} expected={expected_dropped:?}",
+            );
+        });
+}

--- a/sedimentree_core/tests/sync_convergence_props.rs
+++ b/sedimentree_core/tests/sync_convergence_props.rs
@@ -240,11 +240,8 @@ fn prop_ancestry_pruning_drops_exactly_ancestors_of_shared() {
             let ancestors = local.ancestors_of(&shared_ids);
 
             let diff = local.diff_remote_fingerprints(remote_summary);
-            let post_pruning_local_only: Set<CommitId> = diff
-                .local_only_commits
-                .iter()
-                .map(|(id, _)| **id)
-                .collect();
+            let post_pruning_local_only: Set<CommitId> =
+                diff.local_only_commits.iter().map(|(id, _)| **id).collect();
 
             let actual_dropped: Set<CommitId> = pre_pruning_local_only
                 .difference(&post_pruning_local_only)

--- a/sedimentree_fs_storage/Cargo.toml
+++ b/sedimentree_fs_storage/Cargo.toml
@@ -25,10 +25,12 @@ tokio = { workspace = true, features = ["fs", "io-util"] }
 tracing = { workspace = true, default-features = true }
 
 [dev-dependencies]
+future_form = { workspace = true }
+subduction_core = { workspace = true, features = ["std", "test_utils"] }
 subduction_crypto = { workspace = true, features = ["std"] }
 tempfile = { workspace = true }
 testresult = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/sedimentree_fs_storage/tests/relay_topology_fs.rs
+++ b/sedimentree_fs_storage/tests/relay_topology_fs.rs
@@ -1,8 +1,7 @@
 //! Relay-topology sync over `FsStorage` (vs. the `MemoryStorage`
-//! version in `subduction_core/tests/relay_topology_sync.rs`). The
-//! user-reported bug only reproduces against the CLI server which uses
-//! `MetricsStorage<FsStorage>`; if these fail while the in-memory tests
-//! pass, the issue is in `FsStorage`'s concurrency model.
+//! version in `subduction_core/tests/relay_topology_sync.rs`). If
+//! these fail while the in-memory tests pass, the issue is in
+//! `FsStorage`'s concurrency model rather than the sync protocol.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing)]
 
@@ -174,9 +173,9 @@ async fn fs_relay_single_client_repeated_add_built_batch_converges() -> TestResu
     Ok(())
 }
 
-/// Closest analogue to the user's two-browser workflow: A and B each
-/// `add_built_batch` repeatedly through a relay; final state must agree
-/// and a follow-up sync must be empty.
+/// Two clients writing through a single relay: A and B each
+/// `add_built_batch` repeatedly; final state must agree and a follow-up
+/// sync must be empty.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fs_relay_two_clients_add_built_batch_converge_via_relay() -> TestResult {
     let h = setup_relay().await?;
@@ -281,7 +280,12 @@ async fn fs_relay_concurrent_add_built_batch_calls_converge() -> TestResult {
         handle.await??;
     }
 
-    tokio::time::sleep(Duration::from_millis(400)).await;
+    // Give in-flight broadcasts and embedded syncs a moment to drain,
+    // then drive an explicit sync to deterministically flush any state
+    // still pending on the relay (FsStorage I/O can outlast the burst).
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let (_, stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
 
     assert_eq!(
         h.a.get_commits(sed_id).await.map(|c| c.len()),
@@ -290,10 +294,12 @@ async fn fs_relay_concurrent_add_built_batch_calls_converge() -> TestResult {
     assert_eq!(
         h.r.get_commits(sed_id).await.map(|c| c.len()),
         Some(n as usize),
+        "drive sync stats: {stats:?}",
     );
 
-    let (_, stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(stats.is_empty(), "{stats:?}");
+    // Re-converged: a follow-up sync must be empty.
+    let (_, stats2, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(stats2.is_empty(), "follow-up sync: {stats2:?}");
 
     Ok(())
 }

--- a/sedimentree_fs_storage/tests/relay_topology_fs.rs
+++ b/sedimentree_fs_storage/tests/relay_topology_fs.rs
@@ -1,11 +1,8 @@
-//! Relay-topology sync test using **`FsStorage`** instead of `MemoryStorage`.
-//!
-//! The equivalent test in `subduction_core/tests/relay_topology_sync.rs`
-//! passes with `MemoryStorage`. The user-observed bug only reproduces with
-//! the `subduction_cli` server, which uses `MetricsStorage<FsStorage>`.
-//! If this test fails while the `MemoryStorage` version passes, the bug
-//! is in `FsStorage` (most likely a concurrency / load-vs-save race that
-//! the synchronous in-memory map doesn't have).
+//! Relay-topology sync over `FsStorage` (vs. the `MemoryStorage`
+//! version in `subduction_core/tests/relay_topology_sync.rs`). The
+//! user-reported bug only reproduces against the CLI server which uses
+//! `MetricsStorage<FsStorage>`; if these fail while the in-memory tests
+//! pass, the issue is in `FsStorage`'s concurrency model.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing)]
 
@@ -75,7 +72,6 @@ fn make_commit_pair(sed_id: SedimentreeId, seed: u8) -> (LooseCommit, Blob) {
     (commit, blob)
 }
 
-/// Build a Subduction backed by `FsStorage` rooted at `tempdir`.
 fn make_node(signer: MemorySigner, tempdir: &TempDir) -> TestResult<TestSubduction> {
     let storage = FsStorage::new(tempdir.path().to_path_buf())?;
 
@@ -118,7 +114,7 @@ struct RelayHarness {
     a: TestSubduction,
     r: TestSubduction,
     b: TestSubduction,
-    // Held to keep storage dirs alive for the duration of the test.
+    /// Held to keep storage dirs alive for the duration of the test.
     _dirs: [TempDir; 3],
 }
 
@@ -148,10 +144,6 @@ async fn setup_relay() -> TestResult<RelayHarness> {
     })
 }
 
-/// Single-client: repeatedly `add_built_batch` (the wasm `addBatch` path)
-/// against a relay backed by `FsStorage`. Each call inserts one commit,
-/// then internally syncs with the relay. After all calls, both sides must
-/// have all commits and a follow-up sync must be empty.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fs_relay_single_client_repeated_add_built_batch_converges() -> TestResult {
     let h = setup_relay().await?;
@@ -170,36 +162,27 @@ async fn fs_relay_single_client_repeated_add_built_batch_converges() -> TestResu
     assert_eq!(
         h.a.get_commits(sed_id).await.map(|c| c.len()),
         Some(total as usize),
-        "A: all commits present"
     );
     assert_eq!(
         h.r.get_commits(sed_id).await.map(|c| c.len()),
         Some(total as usize),
-        "R: all commits propagated"
     );
 
     let (_, stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        stats.is_empty(),
-        "follow-up sync should be empty, got received={}, sent={}",
-        stats.total_received(),
-        stats.total_sent(),
-    );
+    assert!(stats.is_empty(), "{stats:?}");
 
     Ok(())
 }
 
-/// Two clients writing through a relay, each calling `add_built_batch`
-/// repeatedly. This is the closest analogue to the user's two-browser
-/// todo-app workflow.
+/// Closest analogue to the user's two-browser workflow: A and B each
+/// `add_built_batch` repeatedly through a relay; final state must agree
+/// and a follow-up sync must be empty.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fs_relay_two_clients_add_built_batch_converge_via_relay() -> TestResult {
     let h = setup_relay().await?;
     let sed_id = SedimentreeId::new([0xA2; 32]);
 
     let r_peer = PeerId::from(make_signer(20).verifying_key());
-
-    // Subscribe each client to the relay for this sed_id.
     h.a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
         .await?;
     h.b.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
@@ -221,43 +204,25 @@ async fn fs_relay_two_clients_add_built_batch_converge_via_relay() -> TestResult
     let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let b_count = h.b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!(
-        (a_count, r_count, b_count),
-        (total_pairs, total_pairs, total_pairs),
-        "after interleaved add_built_batch from both ends, all three should hold \
-         {total_pairs} commits each (got A={a_count}, R={r_count}, B={b_count})"
-    );
+    assert_eq!((a_count, r_count, b_count), (total_pairs, total_pairs, total_pairs));
 
     let (_, a_stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        a_stats.is_empty(),
-        "A's follow-up sync should be empty, got received={}, sent={}",
-        a_stats.total_received(),
-        a_stats.total_sent(),
-    );
-    assert!(
-        b_stats.is_empty(),
-        "B's follow-up sync should be empty, got received={}, sent={}",
-        b_stats.total_received(),
-        b_stats.total_sent(),
-    );
+    assert!(a_stats.is_empty(), "A: {a_stats:?}");
+    assert!(b_stats.is_empty(), "B: {b_stats:?}");
 
     Ok(())
 }
 
-/// **Rapid-fire stress.** Two clients fire commits as fast as possible,
-/// with no waits between calls. Each commit involves disk I/O via
-/// `FsStorage`. With concurrent `BatchSyncRequest`s arriving while writes
-/// are still in flight, this is the most plausible setup for a
-/// load-vs-save race on the responder.
+/// Rapid-fire from both clients, no inter-call pause. Concurrent
+/// `BatchSyncRequest`s arrive while writes are still in flight — the
+/// load-vs-save race window is widest here.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
     let h = setup_relay().await?;
     let sed_id = SedimentreeId::new([0xA3; 32]);
 
     let r_peer = PeerId::from(make_signer(20).verifying_key());
-
     h.a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
         .await?;
     h.b.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
@@ -265,9 +230,6 @@ async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
     let total = 16usize;
-    // Each side authors `total / 2` commits in rapid succession. The
-    // `await` is required at each step (single-task issuance), but no
-    // PROPAGATION_PAUSE between them.
     for i in 0..total {
         if i % 2 == 0 {
             let pair = make_commit_pair(sed_id, (i as u8) + 1);
@@ -278,10 +240,8 @@ async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
         }
     }
 
-    // Give I/O + propagation a generous chance to settle.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    // Drive convergence explicitly.
     h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
@@ -289,37 +249,16 @@ async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
     let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let b_count = h.b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!(
-        (a_count, r_count, b_count),
-        (total, total, total),
-        "rapid-fire: all three should hold {total} commits each \
-         (got A={a_count}, R={r_count}, B={b_count})"
-    );
+    assert_eq!((a_count, r_count, b_count), (total, total, total));
 
     let (_, a_stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        a_stats.is_empty(),
-        "A's follow-up sync after rapid-fire should be empty, got received={}, sent={}",
-        a_stats.total_received(),
-        a_stats.total_sent(),
-    );
-    assert!(
-        b_stats.is_empty(),
-        "B's follow-up sync after rapid-fire should be empty, got received={}, sent={}",
-        b_stats.total_received(),
-        b_stats.total_sent(),
-    );
+    assert!(a_stats.is_empty(), "A: {a_stats:?}");
+    assert!(b_stats.is_empty(), "B: {b_stats:?}");
 
     Ok(())
 }
 
-/// **Concurrent add_built_batch from a single client.** Spawns multiple
-/// tasks that each call `add_built_batch` simultaneously against the
-/// relay. Each `add_built_batch` internally issues a `BatchSyncRequest`,
-/// so the relay sees a burst of concurrent requests interleaved with
-/// `LooseCommit` fire-and-forget pushes. With `FsStorage`'s real I/O
-/// latency, the storage-load-vs-in-memory-shard race window is widest.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn fs_relay_concurrent_add_built_batch_calls_converge() -> TestResult {
     let h = setup_relay().await?;
@@ -344,25 +283,17 @@ async fn fs_relay_concurrent_add_built_batch_calls_converge() -> TestResult {
 
     tokio::time::sleep(Duration::from_millis(400)).await;
 
-    let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     assert_eq!(
-        a_count, n as usize,
-        "A: all {n} commits present after concurrent burst"
+        h.a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(n as usize),
     );
     assert_eq!(
-        r_count, n as usize,
-        "R: all {n} commits propagated despite concurrent BatchSyncRequest barrage \
-         (got R={r_count})"
+        h.r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(n as usize),
     );
 
     let (_, stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        stats.is_empty(),
-        "post-burst sync should be empty, got received={}, sent={}",
-        stats.total_received(),
-        stats.total_sent(),
-    );
+    assert!(stats.is_empty(), "{stats:?}");
 
     Ok(())
 }

--- a/sedimentree_fs_storage/tests/relay_topology_fs.rs
+++ b/sedimentree_fs_storage/tests/relay_topology_fs.rs
@@ -1,0 +1,368 @@
+//! Relay-topology sync test using **`FsStorage`** instead of `MemoryStorage`.
+//!
+//! The equivalent test in `subduction_core/tests/relay_topology_sync.rs`
+//! passes with `MemoryStorage`. The user-observed bug only reproduces with
+//! the `subduction_cli` server, which uses `MetricsStorage<FsStorage>`.
+//! If this test fails while the `MemoryStorage` version passes, the bug
+//! is in `FsStorage` (most likely a concurrency / load-vs-save race that
+//! the synchronous in-memory map doesn't have).
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    commit::CountLeadingZeroBytes,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+};
+use sedimentree_fs_storage::FsStorage;
+use subduction_core::{
+    authenticated::Authenticated,
+    connection::test_utils::{ChannelTransport, InstantTimeout, TokioSpawn},
+    handler::sync::SyncHandler,
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    subduction::{Subduction, builder::SubductionBuilder},
+    transport::message::MessageTransport,
+};
+use subduction_crypto::signer::memory::MemorySigner;
+use tempfile::TempDir;
+use testresult::TestResult;
+
+type Conn = MessageTransport<ChannelTransport>;
+type TestSyncHandler = SyncHandler<Sendable, FsStorage, Conn, OpenPolicy, CountLeadingZeroBytes>;
+type TestSubduction = Arc<
+    Subduction<
+        'static,
+        Sendable,
+        FsStorage,
+        Conn,
+        TestSyncHandler,
+        OpenPolicy,
+        MemorySigner,
+        InstantTimeout,
+    >,
+>;
+
+const SYNC_TIMEOUT: Option<Duration> = Some(Duration::from_millis(1000));
+const PROPAGATION_PAUSE: Duration = Duration::from_millis(80);
+
+fn make_signer(seed: u8) -> MemorySigner {
+    MemorySigner::from_bytes(&[seed; 32])
+}
+
+fn make_blob(seed: u8) -> Blob {
+    let data: Vec<u8> = (0..64).map(|i| seed.wrapping_add(i)).collect();
+    Blob::new(data)
+}
+
+fn make_head(seed: u8) -> CommitId {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    bytes[1] = seed.wrapping_mul(31);
+    bytes[2] = seed.wrapping_add(7);
+    CommitId::new(bytes)
+}
+
+fn make_commit_pair(sed_id: SedimentreeId, seed: u8) -> (LooseCommit, Blob) {
+    let blob = make_blob(seed);
+    let blob_meta = BlobMeta::new(&blob);
+    let head = make_head(seed);
+    let commit = LooseCommit::new(sed_id, head, BTreeSet::new(), blob_meta);
+    (commit, blob)
+}
+
+/// Build a Subduction backed by `FsStorage` rooted at `tempdir`.
+fn make_node(signer: MemorySigner, tempdir: &TempDir) -> TestResult<TestSubduction> {
+    let storage = FsStorage::new(tempdir.path().to_path_buf())?;
+
+    let (sd, _handler, listener, manager) = SubductionBuilder::new()
+        .signer(signer)
+        .storage(storage, Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, Conn>();
+
+    tokio::spawn(listener);
+    tokio::spawn(manager);
+    Ok(sd)
+}
+
+async fn connect_pair(
+    a: &TestSubduction,
+    a_signer: &MemorySigner,
+    b: &TestSubduction,
+    b_signer: &MemorySigner,
+) -> TestResult {
+    let (transport_a, transport_b) = ChannelTransport::pair();
+
+    let conn_a = MessageTransport::new(transport_a);
+    let conn_b = MessageTransport::new(transport_b);
+
+    let peer_a = PeerId::from(a_signer.verifying_key());
+    let peer_b = PeerId::from(b_signer.verifying_key());
+
+    let auth_a: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_a, peer_b);
+    let auth_b: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_b, peer_a);
+
+    a.add_connection(auth_a).await?;
+    b.add_connection(auth_b).await?;
+
+    Ok(())
+}
+
+struct RelayHarness {
+    a: TestSubduction,
+    r: TestSubduction,
+    b: TestSubduction,
+    // Held to keep storage dirs alive for the duration of the test.
+    _dirs: [TempDir; 3],
+}
+
+async fn setup_relay() -> TestResult<RelayHarness> {
+    let dir_a = tempfile::tempdir()?;
+    let dir_r = tempfile::tempdir()?;
+    let dir_b = tempfile::tempdir()?;
+
+    let a_signer = make_signer(10);
+    let r_signer = make_signer(20);
+    let b_signer = make_signer(30);
+
+    let a = make_node(a_signer.clone(), &dir_a)?;
+    let r = make_node(r_signer.clone(), &dir_r)?;
+    let b = make_node(b_signer.clone(), &dir_b)?;
+
+    connect_pair(&a, &a_signer, &r, &r_signer).await?;
+    connect_pair(&r, &r_signer, &b, &b_signer).await?;
+
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    Ok(RelayHarness {
+        a,
+        r,
+        b,
+        _dirs: [dir_a, dir_r, dir_b],
+    })
+}
+
+/// Single-client: repeatedly `add_built_batch` (the wasm `addBatch` path)
+/// against a relay backed by `FsStorage`. Each call inserts one commit,
+/// then internally syncs with the relay. After all calls, both sides must
+/// have all commits and a follow-up sync must be empty.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fs_relay_single_client_repeated_add_built_batch_converges() -> TestResult {
+    let h = setup_relay().await?;
+    let sed_id = SedimentreeId::new([0xA1; 32]);
+
+    h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    let total = 10_u8;
+    for seed in 1..=total {
+        let pair = make_commit_pair(sed_id, seed);
+        h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        tokio::time::sleep(PROPAGATION_PAUSE).await;
+    }
+
+    assert_eq!(
+        h.a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(total as usize),
+        "A: all commits present"
+    );
+    assert_eq!(
+        h.r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(total as usize),
+        "R: all commits propagated"
+    );
+
+    let (_, stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        stats.is_empty(),
+        "follow-up sync should be empty, got received={}, sent={}",
+        stats.total_received(),
+        stats.total_sent(),
+    );
+
+    Ok(())
+}
+
+/// Two clients writing through a relay, each calling `add_built_batch`
+/// repeatedly. This is the closest analogue to the user's two-browser
+/// todo-app workflow.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fs_relay_two_clients_add_built_batch_converge_via_relay() -> TestResult {
+    let h = setup_relay().await?;
+    let sed_id = SedimentreeId::new([0xA2; 32]);
+
+    let r_peer = PeerId::from(make_signer(20).verifying_key());
+
+    // Subscribe each client to the relay for this sed_id.
+    h.a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    h.b.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    let total_pairs = 12;
+    for i in 0..total_pairs {
+        if i % 2 == 0 {
+            let pair = make_commit_pair(sed_id, (i as u8) + 1);
+            h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        } else {
+            let pair = make_commit_pair(sed_id, 100 + (i as u8));
+            h.b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        }
+        tokio::time::sleep(PROPAGATION_PAUSE).await;
+    }
+
+    let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let b_count = h.b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    assert_eq!(
+        (a_count, r_count, b_count),
+        (total_pairs, total_pairs, total_pairs),
+        "after interleaved add_built_batch from both ends, all three should hold \
+         {total_pairs} commits each (got A={a_count}, R={r_count}, B={b_count})"
+    );
+
+    let (_, a_stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    let (_, b_stats, _, _) = h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        a_stats.is_empty(),
+        "A's follow-up sync should be empty, got received={}, sent={}",
+        a_stats.total_received(),
+        a_stats.total_sent(),
+    );
+    assert!(
+        b_stats.is_empty(),
+        "B's follow-up sync should be empty, got received={}, sent={}",
+        b_stats.total_received(),
+        b_stats.total_sent(),
+    );
+
+    Ok(())
+}
+
+/// **Rapid-fire stress.** Two clients fire commits as fast as possible,
+/// with no waits between calls. Each commit involves disk I/O via
+/// `FsStorage`. With concurrent `BatchSyncRequest`s arriving while writes
+/// are still in flight, this is the most plausible setup for a
+/// load-vs-save race on the responder.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
+    let h = setup_relay().await?;
+    let sed_id = SedimentreeId::new([0xA3; 32]);
+
+    let r_peer = PeerId::from(make_signer(20).verifying_key());
+
+    h.a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    h.b.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    let total = 16usize;
+    // Each side authors `total / 2` commits in rapid succession. The
+    // `await` is required at each step (single-task issuance), but no
+    // PROPAGATION_PAUSE between them.
+    for i in 0..total {
+        if i % 2 == 0 {
+            let pair = make_commit_pair(sed_id, (i as u8) + 1);
+            h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        } else {
+            let pair = make_commit_pair(sed_id, 100 + (i as u8));
+            h.b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        }
+    }
+
+    // Give I/O + propagation a generous chance to settle.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Drive convergence explicitly.
+    h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let b_count = h.b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    assert_eq!(
+        (a_count, r_count, b_count),
+        (total, total, total),
+        "rapid-fire: all three should hold {total} commits each \
+         (got A={a_count}, R={r_count}, B={b_count})"
+    );
+
+    let (_, a_stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    let (_, b_stats, _, _) = h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        a_stats.is_empty(),
+        "A's follow-up sync after rapid-fire should be empty, got received={}, sent={}",
+        a_stats.total_received(),
+        a_stats.total_sent(),
+    );
+    assert!(
+        b_stats.is_empty(),
+        "B's follow-up sync after rapid-fire should be empty, got received={}, sent={}",
+        b_stats.total_received(),
+        b_stats.total_sent(),
+    );
+
+    Ok(())
+}
+
+/// **Concurrent add_built_batch from a single client.** Spawns multiple
+/// tasks that each call `add_built_batch` simultaneously against the
+/// relay. Each `add_built_batch` internally issues a `BatchSyncRequest`,
+/// so the relay sees a burst of concurrent requests interleaved with
+/// `LooseCommit` fire-and-forget pushes. With `FsStorage`'s real I/O
+/// latency, the storage-load-vs-in-memory-shard race window is widest.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fs_relay_concurrent_add_built_batch_calls_converge() -> TestResult {
+    let h = setup_relay().await?;
+    let sed_id = SedimentreeId::new([0xA4; 32]);
+
+    h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    let n = 12_u8;
+    let pairs: Vec<_> = (1..=n).map(|seed| make_commit_pair(sed_id, seed)).collect();
+
+    let mut handles = Vec::new();
+    for pair in pairs {
+        let a_clone = h.a.clone();
+        handles.push(tokio::spawn(async move {
+            a_clone.add_built_batch(sed_id, vec![pair], Vec::new()).await
+        }));
+    }
+    for handle in handles {
+        handle.await??;
+    }
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    assert_eq!(
+        a_count, n as usize,
+        "A: all {n} commits present after concurrent burst"
+    );
+    assert_eq!(
+        r_count, n as usize,
+        "R: all {n} commits propagated despite concurrent BatchSyncRequest barrage \
+         (got R={r_count})"
+    );
+
+    let (_, stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        stats.is_empty(),
+        "post-burst sync should be empty, got received={}, sent={}",
+        stats.total_received(),
+        stats.total_sent(),
+    );
+
+    Ok(())
+}

--- a/sedimentree_fs_storage/tests/relay_topology_fs.rs
+++ b/sedimentree_fs_storage/tests/relay_topology_fs.rs
@@ -55,7 +55,7 @@ fn make_blob(seed: u8) -> Blob {
     Blob::new(data)
 }
 
-fn make_head(seed: u8) -> CommitId {
+const fn make_head(seed: u8) -> CommitId {
     let mut bytes = [0u8; 32];
     bytes[0] = seed;
     bytes[1] = seed.wrapping_mul(31);
@@ -188,25 +188,23 @@ async fn fs_relay_two_clients_add_built_batch_converge_via_relay() -> TestResult
         .await?;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    let total_pairs = 12;
+    let total_pairs: u8 = 12;
     for i in 0..total_pairs {
         if i % 2 == 0 {
-            let pair = make_commit_pair(sed_id, (i as u8) + 1);
+            let pair = make_commit_pair(sed_id, i + 1);
             h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
         } else {
-            let pair = make_commit_pair(sed_id, 100 + (i as u8));
+            let pair = make_commit_pair(sed_id, 100 + i);
             h.b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
         }
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
 
-    let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let b_count = h.b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!(
-        (a_count, r_count, b_count),
-        (total_pairs, total_pairs, total_pairs)
-    );
+    let total = total_pairs as usize;
+    let a_count = h.a.get_commits(sed_id).await.map_or(0, |c| c.len());
+    let r_count = h.r.get_commits(sed_id).await.map_or(0, |c| c.len());
+    let b_count = h.b.get_commits(sed_id).await.map_or(0, |c| c.len());
+    assert_eq!((a_count, r_count, b_count), (total, total, total));
 
     let (_, a_stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
@@ -231,13 +229,14 @@ async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
         .await?;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    let total = 16usize;
-    for i in 0..total {
+    let total_u8: u8 = 16;
+    let total = total_u8 as usize;
+    for i in 0..total_u8 {
         if i % 2 == 0 {
-            let pair = make_commit_pair(sed_id, (i as u8) + 1);
+            let pair = make_commit_pair(sed_id, i + 1);
             h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
         } else {
-            let pair = make_commit_pair(sed_id, 100 + (i as u8));
+            let pair = make_commit_pair(sed_id, 100 + i);
             h.b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
         }
     }
@@ -248,9 +247,9 @@ async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
     h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let b_count = h.b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let a_count = h.a.get_commits(sed_id).await.map_or(0, |c| c.len());
+    let r_count = h.r.get_commits(sed_id).await.map_or(0, |c| c.len());
+    let b_count = h.b.get_commits(sed_id).await.map_or(0, |c| c.len());
     assert_eq!((a_count, r_count, b_count), (total, total, total));
 
     let (_, a_stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;

--- a/sedimentree_fs_storage/tests/relay_topology_fs.rs
+++ b/sedimentree_fs_storage/tests/relay_topology_fs.rs
@@ -203,7 +203,10 @@ async fn fs_relay_two_clients_add_built_batch_converge_via_relay() -> TestResult
     let a_count = h.a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let r_count = h.r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let b_count = h.b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!((a_count, r_count, b_count), (total_pairs, total_pairs, total_pairs));
+    assert_eq!(
+        (a_count, r_count, b_count),
+        (total_pairs, total_pairs, total_pairs)
+    );
 
     let (_, a_stats, _, _) = h.a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = h.b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
@@ -273,7 +276,9 @@ async fn fs_relay_concurrent_add_built_batch_calls_converge() -> TestResult {
     for pair in pairs {
         let a_clone = h.a.clone();
         handles.push(tokio::spawn(async move {
-            a_clone.add_built_batch(sed_id, vec![pair], Vec::new()).await
+            a_clone
+                .add_built_batch(sed_id, vec![pair], Vec::new())
+                .await
         }));
     }
     for handle in handles {

--- a/sedimentree_wasm/Cargo.toml
+++ b/sedimentree_wasm/Cargo.toml
@@ -39,7 +39,7 @@ default-features = false
 features = []
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2"
+wasm-bindgen-test = "0.3"
 
 [features]
 default = []

--- a/sedimentree_wasm/tests/fingerprint_stability_wasm.rs
+++ b/sedimentree_wasm/tests/fingerprint_stability_wasm.rs
@@ -1,0 +1,83 @@
+//! **wasm32 companion to `sedimentree_core/tests/fingerprint_stability.rs`.**
+//!
+//! Computes `Fingerprint::new(seed, CommitId)` for the same fixed inputs
+//! as the native test and asserts the resulting `u64` matches the
+//! hardcoded baselines from x86_64.
+//!
+//! If the wasm32 build produces *different* `u64` values for the same
+//! `(seed, CommitId)` inputs, this test fails — and we've found the
+//! cause of the user's "N missing, requesting N" symptom: a browser
+//! and a native peer cannot communicate via fingerprints because
+//! `Fingerprint::new` is non-portable across architectures.
+//!
+//! Run with:
+//! ```sh
+//! wasm-pack test --node sedimentree_wasm --test fingerprint_stability_wasm
+//! ```
+
+#![cfg(target_arch = "wasm32")]
+#![allow(missing_docs)]
+
+use sedimentree_core::{
+    crypto::fingerprint::{Fingerprint, FingerprintSeed},
+    loose_commit::id::CommitId,
+};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+// Constants duplicated from
+// `sedimentree_core/tests/fingerprint_stability.rs`. They must agree.
+
+const TEST_SEED_KEY0: u64 = 0x1234_5678_9ABC_DEF0;
+const TEST_SEED_KEY1: u64 = 0xFEDC_BA98_7654_3210;
+
+const EXPECTED_FP_ZEROES: u64 = 6_748_340_123_268_596_282;
+const EXPECTED_FP_ONES: u64 = 13_743_385_435_344_457_055;
+const EXPECTED_FP_SEQUENTIAL: u64 = 10_722_668_375_651_339_477;
+const EXPECTED_FP_REPEATING: u64 = 16_398_704_403_767_843_780;
+
+fn test_seed() -> FingerprintSeed {
+    FingerprintSeed::new(TEST_SEED_KEY0, TEST_SEED_KEY1)
+}
+
+fn id_sequential() -> CommitId {
+    let mut bytes = [0u8; 32];
+    for (i, b) in bytes.iter_mut().enumerate() {
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            *b = (i + 1) as u8;
+        }
+    }
+    CommitId::new(bytes)
+}
+
+#[wasm_bindgen_test]
+fn wasm_fingerprint_of_all_zero_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &CommitId::new([0u8; 32]));
+    assert_eq!(
+        fp.as_u64(),
+        EXPECTED_FP_ZEROES,
+        "Fingerprint for (seed, all-zero CommitId) on wasm32 differs from \
+         the x86_64 baseline ({EXPECTED_FP_ZEROES}); got {got}. This means \
+         SipHash output differs between wasm and native — the user's bug \
+         is reproduced at this layer.",
+        got = fp.as_u64(),
+    );
+}
+
+#[wasm_bindgen_test]
+fn wasm_fingerprint_of_all_ones_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &CommitId::new([0xFFu8; 32]));
+    assert_eq!(fp.as_u64(), EXPECTED_FP_ONES);
+}
+
+#[wasm_bindgen_test]
+fn wasm_fingerprint_of_sequential_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &id_sequential());
+    assert_eq!(fp.as_u64(), EXPECTED_FP_SEQUENTIAL);
+}
+
+#[wasm_bindgen_test]
+fn wasm_fingerprint_of_repeating_commit_id_matches_baseline() {
+    let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &CommitId::new([42u8; 32]));
+    assert_eq!(fp.as_u64(), EXPECTED_FP_REPEATING);
+}

--- a/sedimentree_wasm/tests/fingerprint_stability_wasm.rs
+++ b/sedimentree_wasm/tests/fingerprint_stability_wasm.rs
@@ -1,14 +1,6 @@
-//! **wasm32 companion to `sedimentree_core/tests/fingerprint_stability.rs`.**
-//!
-//! Computes `Fingerprint::new(seed, CommitId)` for the same fixed inputs
-//! as the native test and asserts the resulting `u64` matches the
-//! hardcoded baselines from x86_64.
-//!
-//! If the wasm32 build produces *different* `u64` values for the same
-//! `(seed, CommitId)` inputs, this test fails — and we've found the
-//! cause of the user's "N missing, requesting N" symptom: a browser
-//! and a native peer cannot communicate via fingerprints because
-//! `Fingerprint::new` is non-portable across architectures.
+//! wasm32 companion to `sedimentree_core/tests/fingerprint_stability.rs`;
+//! asserts the same baselines hold on wasm32. Constants must stay in sync
+//! with the native side.
 //!
 //! Run with:
 //! ```sh
@@ -23,9 +15,6 @@ use sedimentree_core::{
     loose_commit::id::CommitId,
 };
 use wasm_bindgen_test::wasm_bindgen_test;
-
-// Constants duplicated from
-// `sedimentree_core/tests/fingerprint_stability.rs`. They must agree.
 
 const TEST_SEED_KEY0: u64 = 0x1234_5678_9ABC_DEF0;
 const TEST_SEED_KEY1: u64 = 0xFEDC_BA98_7654_3210;
@@ -53,15 +42,7 @@ fn id_sequential() -> CommitId {
 #[wasm_bindgen_test]
 fn wasm_fingerprint_of_all_zero_commit_id_matches_baseline() {
     let fp: Fingerprint<CommitId> = Fingerprint::new(&test_seed(), &CommitId::new([0u8; 32]));
-    assert_eq!(
-        fp.as_u64(),
-        EXPECTED_FP_ZEROES,
-        "Fingerprint for (seed, all-zero CommitId) on wasm32 differs from \
-         the x86_64 baseline ({EXPECTED_FP_ZEROES}); got {got}. This means \
-         SipHash output differs between wasm and native — the user's bug \
-         is reproduced at this layer.",
-        got = fp.as_u64(),
-    );
+    assert_eq!(fp.as_u64(), EXPECTED_FP_ZEROES);
 }
 
 #[wasm_bindgen_test]

--- a/subduction_core/src/connection/test_utils.rs
+++ b/subduction_core/src/connection/test_utils.rs
@@ -3,7 +3,11 @@
 //! This module provides mock connections and helpers for testing connection-related code.
 
 use alloc::sync::Arc;
-use core::{convert::Infallible, time::Duration};
+use core::{
+    convert::Infallible,
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 
 use future_form::{FutureForm, Local, Sendable};
 use futures::future::{AbortHandle, BoxFuture, LocalBoxFuture};
@@ -476,7 +480,7 @@ impl crate::transport::Transport<Sendable> for ChannelTransport {
 #[derive(Debug, Clone)]
 pub struct CloseableChannelTransport {
     inner: ChannelTransport,
-    closed: Arc<core::sync::atomic::AtomicBool>,
+    closed: Arc<AtomicBool>,
 }
 
 impl CloseableChannelTransport {
@@ -487,11 +491,11 @@ impl CloseableChannelTransport {
         (
             Self {
                 inner: a,
-                closed: Arc::new(core::sync::atomic::AtomicBool::new(false)),
+                closed: Arc::new(AtomicBool::new(false)),
             },
             Self {
                 inner: b,
-                closed: Arc::new(core::sync::atomic::AtomicBool::new(false)),
+                closed: Arc::new(AtomicBool::new(false)),
             },
         )
     }
@@ -499,8 +503,7 @@ impl CloseableChannelTransport {
     /// Mark this side as closed. Subsequent `send_bytes` and `recv_bytes`
     /// calls return [`ChannelClosed`].
     pub fn close(&self) {
-        self.closed
-            .store(true, core::sync::atomic::Ordering::SeqCst);
+        self.closed.store(true, Ordering::SeqCst);
     }
 }
 
@@ -516,14 +519,14 @@ impl crate::transport::Transport<Sendable> for CloseableChannelTransport {
     type DisconnectionError = Infallible;
 
     fn send_bytes(&self, bytes: &[u8]) -> BoxFuture<'_, Result<(), Self::SendError>> {
-        if self.closed.load(core::sync::atomic::Ordering::SeqCst) {
+        if self.closed.load(Ordering::SeqCst) {
             return Box::pin(async { Err(ChannelClosed) });
         }
         self.inner.send_bytes(bytes)
     }
 
     fn recv_bytes(&self) -> BoxFuture<'_, Result<alloc::vec::Vec<u8>, Self::RecvError>> {
-        if self.closed.load(core::sync::atomic::Ordering::SeqCst) {
+        if self.closed.load(Ordering::SeqCst) {
             return Box::pin(async { Err(ChannelClosed) });
         }
         self.inner.recv_bytes()

--- a/subduction_core/src/connection/test_utils.rs
+++ b/subduction_core/src/connection/test_utils.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides mock connections and helpers for testing connection-related code.
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use core::{
     convert::Infallible,
     sync::atomic::{AtomicBool, Ordering},
@@ -460,7 +460,7 @@ impl crate::transport::Transport<Sendable> for ChannelTransport {
         Box::pin(async move { tx.send(data).await.map_err(|_| ChannelClosed) })
     }
 
-    fn recv_bytes(&self) -> BoxFuture<'_, Result<alloc::vec::Vec<u8>, Self::RecvError>> {
+    fn recv_bytes(&self) -> BoxFuture<'_, Result<Vec<u8>, Self::RecvError>> {
         let rx = self.rx.clone();
         Box::pin(async move { rx.recv().await.map_err(|_| ChannelClosed) })
     }
@@ -525,7 +525,7 @@ impl crate::transport::Transport<Sendable> for CloseableChannelTransport {
         self.inner.send_bytes(bytes)
     }
 
-    fn recv_bytes(&self) -> BoxFuture<'_, Result<alloc::vec::Vec<u8>, Self::RecvError>> {
+    fn recv_bytes(&self) -> BoxFuture<'_, Result<Vec<u8>, Self::RecvError>> {
         if self.closed.load(Ordering::SeqCst) {
             return Box::pin(async { Err(ChannelClosed) });
         }

--- a/subduction_core/src/connection/test_utils.rs
+++ b/subduction_core/src/connection/test_utils.rs
@@ -456,12 +456,81 @@ impl crate::transport::Transport<Sendable> for ChannelTransport {
         Box::pin(async move { tx.send(data).await.map_err(|_| ChannelClosed) })
     }
 
-    fn recv_bytes(&self) -> BoxFuture<'_, Result<Vec<u8>, Self::RecvError>> {
+    fn recv_bytes(&self) -> BoxFuture<'_, Result<alloc::vec::Vec<u8>, Self::RecvError>> {
         let rx = self.rx.clone();
         Box::pin(async move { rx.recv().await.map_err(|_| ChannelClosed) })
     }
 
     fn disconnect(&self) -> BoxFuture<'_, Result<(), Self::DisconnectionError>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+/// A [`ChannelTransport`] wrapper that can be closed mid-test to simulate
+/// transport failure (peer disconnect, dead socket, etc.).
+///
+/// Once [`close`](Self::close) is called, subsequent `send_bytes` and
+/// `recv_bytes` calls on this side return [`ChannelClosed`]. The paired
+/// transport continues to function on the underlying channel — call
+/// `close()` on both halves to fully tear the link down.
+#[derive(Debug, Clone)]
+pub struct CloseableChannelTransport {
+    inner: ChannelTransport,
+    closed: Arc<core::sync::atomic::AtomicBool>,
+}
+
+impl CloseableChannelTransport {
+    /// Create a bidirectional pair of transports, each independently closable.
+    #[must_use]
+    pub fn pair() -> (Self, Self) {
+        let (a, b) = ChannelTransport::pair();
+        (
+            Self {
+                inner: a,
+                closed: Arc::new(core::sync::atomic::AtomicBool::new(false)),
+            },
+            Self {
+                inner: b,
+                closed: Arc::new(core::sync::atomic::AtomicBool::new(false)),
+            },
+        )
+    }
+
+    /// Mark this side as closed. Subsequent `send_bytes` and `recv_bytes`
+    /// calls return [`ChannelClosed`].
+    pub fn close(&self) {
+        self.closed
+            .store(true, core::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+impl PartialEq for CloseableChannelTransport {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner && Arc::ptr_eq(&self.closed, &other.closed)
+    }
+}
+
+impl crate::transport::Transport<Sendable> for CloseableChannelTransport {
+    type SendError = ChannelClosed;
+    type RecvError = ChannelClosed;
+    type DisconnectionError = Infallible;
+
+    fn send_bytes(&self, bytes: &[u8]) -> BoxFuture<'_, Result<(), Self::SendError>> {
+        if self.closed.load(core::sync::atomic::Ordering::SeqCst) {
+            return Box::pin(async { Err(ChannelClosed) });
+        }
+        self.inner.send_bytes(bytes)
+    }
+
+    fn recv_bytes(&self) -> BoxFuture<'_, Result<alloc::vec::Vec<u8>, Self::RecvError>> {
+        if self.closed.load(core::sync::atomic::Ordering::SeqCst) {
+            return Box::pin(async { Err(ChannelClosed) });
+        }
+        self.inner.recv_bytes()
+    }
+
+    fn disconnect(&self) -> BoxFuture<'_, Result<(), Self::DisconnectionError>> {
+        self.close();
         Box::pin(async { Ok(()) })
     }
 }

--- a/subduction_core/src/connection/test_utils.rs
+++ b/subduction_core/src/connection/test_utils.rs
@@ -5,6 +5,7 @@
 use alloc::{sync::Arc, vec::Vec};
 use core::{
     convert::Infallible,
+    fmt::Error,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
@@ -25,6 +26,7 @@ use crate::{
     policy::open::OpenPolicy,
     storage::memory::MemoryStorage,
     subduction::{Subduction, builder::SubductionBuilder},
+    transport::Transport,
 };
 
 /// A minimal mock connection for testing.
@@ -72,9 +74,9 @@ impl Default for MockConnection {
 }
 
 impl Connection<Sendable, SyncMessage> for MockConnection {
-    type DisconnectionError = core::fmt::Error;
-    type SendError = core::fmt::Error;
-    type RecvError = core::fmt::Error;
+    type DisconnectionError = Error;
+    type SendError = Error;
+    type RecvError = Error;
 
     fn disconnect(
         &self,
@@ -133,9 +135,9 @@ impl Default for FailingSendMockConnection {
 }
 
 impl Connection<Sendable, SyncMessage> for FailingSendMockConnection {
-    type DisconnectionError = core::fmt::Error;
-    type SendError = core::fmt::Error;
-    type RecvError = core::fmt::Error;
+    type DisconnectionError = Error;
+    type SendError = Error;
+    type RecvError = Error;
 
     fn disconnect(
         &self,
@@ -513,7 +515,7 @@ impl PartialEq for CloseableChannelTransport {
     }
 }
 
-impl crate::transport::Transport<Sendable> for CloseableChannelTransport {
+impl Transport<Sendable> for CloseableChannelTransport {
     type SendError = ChannelClosed;
     type RecvError = ChannelClosed;
     type DisconnectionError = Infallible;

--- a/subduction_core/tests/relay_negative_cases.rs
+++ b/subduction_core/tests/relay_negative_cases.rs
@@ -1,0 +1,207 @@
+//! Negative-case relay tests: transport-level failure (mid-sync close,
+//! peer disconnect) must unregister the broken connection cleanly and
+//! leave local state intact.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::Blob, commit::CountLeadingZeroBytes, id::SedimentreeId, loose_commit::id::CommitId,
+};
+use subduction_core::{
+    authenticated::Authenticated,
+    connection::test_utils::{CloseableChannelTransport, InstantTimeout, TokioSpawn},
+    handler::sync::SyncHandler,
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    storage::memory::MemoryStorage,
+    subduction::{Subduction, builder::SubductionBuilder},
+    transport::message::MessageTransport,
+};
+use subduction_crypto::signer::memory::MemorySigner;
+use testresult::TestResult;
+
+type Conn = MessageTransport<CloseableChannelTransport>;
+
+type TestSyncHandler =
+    SyncHandler<Sendable, MemoryStorage, Conn, OpenPolicy, CountLeadingZeroBytes>;
+
+type TestSubduction = Arc<
+    Subduction<
+        'static,
+        Sendable,
+        MemoryStorage,
+        Conn,
+        TestSyncHandler,
+        OpenPolicy,
+        MemorySigner,
+        InstantTimeout,
+    >,
+>;
+
+const SYNC_TIMEOUT: Option<Duration> = Some(Duration::from_millis(500));
+const PROPAGATION_PAUSE: Duration = Duration::from_millis(50);
+
+fn make_signer(seed: u8) -> MemorySigner {
+    MemorySigner::from_bytes(&[seed; 32])
+}
+
+fn make_node(signer: MemorySigner) -> TestSubduction {
+    let (sd, _h, listener, manager) = SubductionBuilder::new()
+        .signer(signer)
+        .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, Conn>();
+    tokio::spawn(listener);
+    tokio::spawn(manager);
+    sd
+}
+
+async fn connect_pair(
+    a: &TestSubduction,
+    a_signer: &MemorySigner,
+    b: &TestSubduction,
+    b_signer: &MemorySigner,
+) -> TestResult<(CloseableChannelTransport, CloseableChannelTransport)> {
+    let (t_a, t_b) = CloseableChannelTransport::pair();
+
+    let conn_a = MessageTransport::new(t_a.clone());
+    let conn_b = MessageTransport::new(t_b.clone());
+
+    let peer_a = PeerId::from(a_signer.verifying_key());
+    let peer_b = PeerId::from(b_signer.verifying_key());
+
+    let auth_a: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_a, peer_b);
+    let auth_b: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_b, peer_a);
+
+    a.add_connection(auth_a).await?;
+    b.add_connection(auth_b).await?;
+
+    Ok((t_a, t_b))
+}
+
+/// Closing the transport before any sync activity, then calling
+/// `add_commit`, must unregister the broken peer.
+#[tokio::test]
+async fn closed_transport_unregisters_peer_on_next_send() -> TestResult {
+    let a_signer = make_signer(10);
+    let b_signer = make_signer(20);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    let (t_a, _t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    assert_eq!(a.connected_peer_ids().await.len(), 1);
+
+    t_a.close();
+
+    let sed_id = SedimentreeId::new([1u8; 32]);
+    let head = CommitId::new([1u8; 32]);
+    let blob = Blob::new(vec![0u8; 32]);
+    let _ = a.add_commit(sed_id, head, BTreeSet::new(), blob).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    assert_eq!(
+        a.connected_peer_ids().await.len(),
+        0,
+        "broken connection should be unregistered after send failure",
+    );
+
+    Ok(())
+}
+
+/// Closing A's transport after successful sync must not corrupt A's
+/// local state. A retains everything it had; subsequent sync attempts
+/// fail and drop the peer without crashing.
+#[tokio::test]
+async fn close_after_sync_preserves_local_state() -> TestResult {
+    let a_signer = make_signer(10);
+    let b_signer = make_signer(20);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    let (t_a, _t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let sed_id = SedimentreeId::new([2u8; 32]);
+    for i in 0..3_u8 {
+        a.add_commit(
+            sed_id,
+            CommitId::new([i + 1; 32]),
+            BTreeSet::new(),
+            Blob::new(vec![i; 16]),
+        )
+        .await?;
+    }
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(3));
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(3));
+
+    t_a.close();
+
+    // A's sync attempt will error out internally; must not panic and
+    // must leave local state untouched.
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(3));
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(3));
+
+    Ok(())
+}
+
+/// Mid-flight close: A authors a commit while the transport is closing.
+/// Either the commit lands on B (raced ahead of the close) or it
+/// doesn't (close won) — never both peers in an inconsistent state.
+#[tokio::test]
+async fn mid_flight_close_leaves_peers_consistent() -> TestResult {
+    let a_signer = make_signer(10);
+    let b_signer = make_signer(20);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    let (t_a, _t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let sed_id = SedimentreeId::new([3u8; 32]);
+
+    // Concurrently: schedule a commit and close the transport.
+    let a_clone = a.clone();
+    let commit_handle = tokio::spawn(async move {
+        a_clone
+            .add_commit(
+                sed_id,
+                CommitId::new([99u8; 32]),
+                BTreeSet::new(),
+                Blob::new(vec![99u8; 16]),
+            )
+            .await
+    });
+    t_a.close();
+    let _ = commit_handle.await?;
+
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let b_count = b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+
+    // A always sees its own commit. B's view may or may not include it
+    // depending on whether the broadcast won the race with the close.
+    assert_eq!(a_count, 1, "A retains its own commit");
+    assert!(
+        b_count <= 1,
+        "B saw at most the one commit; got {b_count}",
+    );
+
+    // Connection should be unregistered on A regardless.
+    assert_eq!(a.connected_peer_ids().await.len(), 0);
+
+    Ok(())
+}

--- a/subduction_core/tests/relay_negative_cases.rs
+++ b/subduction_core/tests/relay_negative_cases.rs
@@ -189,8 +189,8 @@ async fn mid_flight_close_leaves_peers_consistent() -> TestResult {
 
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let b_count = b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let a_count = a.get_commits(sed_id).await.map_or(0, |c| c.len());
+    let b_count = b.get_commits(sed_id).await.map_or(0, |c| c.len());
 
     // A always sees its own commit. B's view may or may not include it
     // depending on whether the broadcast won the race with the close.

--- a/subduction_core/tests/relay_negative_cases.rs
+++ b/subduction_core/tests/relay_negative_cases.rs
@@ -195,10 +195,7 @@ async fn mid_flight_close_leaves_peers_consistent() -> TestResult {
     // A always sees its own commit. B's view may or may not include it
     // depending on whether the broadcast won the race with the close.
     assert_eq!(a_count, 1, "A retains its own commit");
-    assert!(
-        b_count <= 1,
-        "B saw at most the one commit; got {b_count}",
-    );
+    assert!(b_count <= 1, "B saw at most the one commit; got {b_count}",);
 
     // Connection should be unregistered on A regardless.
     assert_eq!(a.connected_peer_ids().await.len(), 0);

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -70,7 +70,7 @@ fn make_blob(seed: u8) -> Blob {
     Blob::new(data)
 }
 
-fn make_head(seed: u8) -> CommitId {
+const fn make_head(seed: u8) -> CommitId {
     let mut bytes = [0u8; 32];
     bytes[0] = seed;
     bytes[1] = seed.wrapping_mul(31);
@@ -331,7 +331,7 @@ async fn relay_topology_add_built_batch_each_call_is_incremental() -> TestResult
             .await?;
         tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-        let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+        let a_count = a.get_commits(sed_id).await.map_or(0, |c| c.len());
         assert_eq!(a_count, n);
         assert!(a_count > prior_count);
         prior_count = a_count;
@@ -379,25 +379,23 @@ async fn relay_topology_two_clients_add_built_batch_converge_via_relay() -> Test
         .await?;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    let total_pairs = 12;
+    let total_pairs: u8 = 12;
     for i in 0..total_pairs {
         if i % 2 == 0 {
-            let pair = make_commit_pair(sed_id, (i as u8) + 1);
+            let pair = make_commit_pair(sed_id, i + 1);
             a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
         } else {
-            let pair = make_commit_pair(sed_id, 100 + (i as u8));
+            let pair = make_commit_pair(sed_id, 100 + i);
             b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
         }
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
 
-    let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let r_count = r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let b_count = b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!(
-        (a_count, r_count, b_count),
-        (total_pairs, total_pairs, total_pairs)
-    );
+    let total = total_pairs as usize;
+    let a_count = a.get_commits(sed_id).await.map_or(0, |c| c.len());
+    let r_count = r.get_commits(sed_id).await.map_or(0, |c| c.len());
+    let b_count = b.get_commits(sed_id).await.map_or(0, |c| c.len());
+    assert_eq!((a_count, r_count, b_count), (total, total, total));
 
     let (_, a_stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -1,0 +1,700 @@
+//! Reproduces the topology of the user-observed bug: two end-peers connected
+//! through a third Subduction acting as a relay. The relay stores commits
+//! and computes its own diffs against incoming sync requests (matching the
+//! `subduction_cli` server behavior in the logs).
+//!
+//! The user's report: when two browsers edit a todo doc through a relay
+//! server, every `BatchSyncRequest` produces a response of the form
+//! "N missing, requesting N" — i.e. zero overlap is detected despite
+//! identical content. Each update therefore re-transfers the full history,
+//! and compute grows with each edit.
+//!
+//! Existing `convergence.rs` covers two directly-connected Subductions on
+//! `MemoryStorage` and passes. These tests add the relay middle-node so we
+//! can see whether the bug is specific to that topology.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    commit::CountLeadingZeroBytes,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+};
+use subduction_core::{
+    authenticated::Authenticated,
+    connection::test_utils::{ChannelTransport, InstantTimeout, TokioSpawn},
+    handler::sync::SyncHandler,
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    storage::memory::MemoryStorage,
+    subduction::{Subduction, builder::SubductionBuilder},
+    transport::message::MessageTransport,
+};
+use subduction_crypto::signer::memory::MemorySigner;
+use testresult::TestResult;
+
+type Conn = MessageTransport<ChannelTransport>;
+
+type TestSyncHandler =
+    SyncHandler<Sendable, MemoryStorage, Conn, OpenPolicy, CountLeadingZeroBytes>;
+
+type TestSubduction = Arc<
+    Subduction<
+        'static,
+        Sendable,
+        MemoryStorage,
+        Conn,
+        TestSyncHandler,
+        OpenPolicy,
+        MemorySigner,
+        InstantTimeout,
+    >,
+>;
+
+const SYNC_TIMEOUT: Option<Duration> = Some(Duration::from_millis(500));
+
+/// Length of a single propagation hop. We let listeners drain after each
+/// state-changing step so broadcasts settle before observations.
+const PROPAGATION_PAUSE: Duration = Duration::from_millis(50);
+
+fn make_signer(seed: u8) -> MemorySigner {
+    MemorySigner::from_bytes(&[seed; 32])
+}
+
+fn make_node(signer: MemorySigner) -> TestSubduction {
+    let (sd, _handler, listener, manager) = SubductionBuilder::new()
+        .signer(signer)
+        .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, Conn>();
+
+    tokio::spawn(listener);
+    tokio::spawn(manager);
+    sd
+}
+
+fn make_blob(seed: u8) -> Blob {
+    let data: Vec<u8> = (0..64).map(|i| seed.wrapping_add(i)).collect();
+    Blob::new(data)
+}
+
+fn make_head(seed: u8) -> CommitId {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    bytes[1] = seed.wrapping_mul(31);
+    bytes[2] = seed.wrapping_add(7);
+    CommitId::new(bytes)
+}
+
+/// Build a single unsigned `(LooseCommit, Blob)` pair for use with
+/// `add_built_batch`. Mirrors what the Automerge wasm adapter builds.
+fn make_commit_pair(sed_id: SedimentreeId, seed: u8) -> (LooseCommit, Blob) {
+    let blob = make_blob(seed);
+    let blob_meta = BlobMeta::new(&blob);
+    let head = make_head(seed);
+    let commit = LooseCommit::new(sed_id, head, BTreeSet::new(), blob_meta);
+    (commit, blob)
+}
+
+/// Connect two nodes via a bidirectional channel transport pair.
+async fn connect_pair(
+    a: &TestSubduction,
+    a_signer: &MemorySigner,
+    b: &TestSubduction,
+    b_signer: &MemorySigner,
+) -> TestResult {
+    let (transport_a, transport_b) = ChannelTransport::pair();
+
+    let conn_a = MessageTransport::new(transport_a);
+    let conn_b = MessageTransport::new(transport_b);
+
+    let peer_a = PeerId::from(a_signer.verifying_key());
+    let peer_b = PeerId::from(b_signer.verifying_key());
+
+    let auth_a: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_a, peer_b);
+    let auth_b: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_b, peer_a);
+
+    a.add_connection(auth_a).await?;
+    b.add_connection(auth_b).await?;
+
+    Ok(())
+}
+
+/// Three nodes wired A ↔ R ↔ B. R only has direct connections to A and B;
+/// A and B never connect directly. R acts as a passive relay: it stores
+/// what it sees and forwards `LooseCommit` / `Fragment` messages to its
+/// other subscribers in `recv_loose_commit` / `recv_fragment`.
+async fn setup_relay_topology() -> TestResult<(
+    TestSubduction,
+    TestSubduction,
+    TestSubduction,
+    MemorySigner,
+    MemorySigner,
+    MemorySigner,
+)> {
+    let a_signer = make_signer(10);
+    let r_signer = make_signer(20);
+    let b_signer = make_signer(30);
+
+    let a = make_node(a_signer.clone());
+    let r = make_node(r_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    connect_pair(&a, &a_signer, &r, &r_signer).await?;
+    connect_pair(&r, &r_signer, &b, &b_signer).await?;
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    Ok((a, r, b, a_signer, r_signer, b_signer))
+}
+
+/// Phase 0 baseline: three-node topology converges on initial sync.
+///
+/// A makes a commit and explicitly drives sync. R and B both receive it
+/// after the sync subscribes them. The `add_commit` broadcast fallback
+/// reaches R immediately (no subscribers → broadcast to all connections);
+/// for R → B we need an explicit `full_sync_with_all_peers` from B.
+#[tokio::test]
+async fn relay_topology_converges_on_initial_sync() -> TestResult {
+    let (a, r, b, _a_signer, _r_signer, _b_signer) = setup_relay_topology().await?;
+
+    let sed_id = SedimentreeId::new([7u8; 32]);
+
+    a.add_commit(sed_id, make_head(1), BTreeSet::new(), make_blob(1))
+        .await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // Direct broadcast fallback reaches R immediately.
+    assert_eq!(
+        a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(1),
+        "A has its own commit"
+    );
+    assert_eq!(
+        r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(1),
+        "R received the direct broadcast"
+    );
+
+    // B has no sedimentree yet — needs to actively pull. Once B has issued
+    // a sync (which subscribes B to R), future commits will flow.
+    b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // Hmm: B's full_sync_with_all_peers iterates B's known sedimentrees,
+    // which is empty. So this doesn't help. We need B to explicitly call
+    // sync_with_peer for sed_id to fetch it.
+    b.sync_with_peer(
+        &PeerId::from(make_signer(20).verifying_key()),
+        sed_id,
+        true,
+        SYNC_TIMEOUT,
+    )
+    .await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    assert_eq!(
+        b.get_commits(sed_id).await.map(|c| c.len()),
+        Some(1),
+        "B received the commit after explicit sync_with_peer"
+    );
+
+    Ok(())
+}
+
+/// **The directly user-facing invariant.** After A and B have fully synced
+/// through R, a follow-up `full_sync_with_all_peers` from either side
+/// should report zero items transferred.
+///
+/// The user's logs show "19 missing, requesting 19" instead — i.e. the
+/// stats from a converged-then-resynced flow are NON-empty even though
+/// nothing has changed.
+#[tokio::test]
+async fn relay_topology_repeated_sync_after_convergence_is_empty() -> TestResult {
+    let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
+
+    let sed_id = SedimentreeId::new([8u8; 32]);
+
+    // Seed both ends with their own commits.
+    for i in 0..5_u8 {
+        a.add_commit(sed_id, make_head(i + 1), BTreeSet::new(), make_blob(i + 1))
+            .await?;
+    }
+    for i in 0..5_u8 {
+        b.add_commit(
+            sed_id,
+            make_head(100 + i),
+            BTreeSet::new(),
+            make_blob(100 + i),
+        )
+        .await?;
+    }
+
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // Drive a sync from both ends — let everything converge.
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // Sanity: all three nodes should now have 10 commits.
+    assert_eq!(
+        a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(10),
+        "A converged"
+    );
+    assert_eq!(
+        r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(10),
+        "R converged"
+    );
+    assert_eq!(
+        b.get_commits(sed_id).await.map(|c| c.len()),
+        Some(10),
+        "B converged"
+    );
+
+    // The actual invariant being tested.
+    for round in 1..=4 {
+        let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+        assert!(
+            stats.is_empty(),
+            "round {round} from A (converged): expected empty sync stats, got \
+             commits_received={}, commits_sent={}, fragments_received={}, fragments_sent={}",
+            stats.commits_received,
+            stats.commits_sent,
+            stats.fragments_received,
+            stats.fragments_sent,
+        );
+
+        let (_, stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+        assert!(
+            stats.is_empty(),
+            "round {round} from B (converged): expected empty sync stats, got \
+             commits_received={}, commits_sent={}, fragments_received={}, fragments_sent={}",
+            stats.commits_received,
+            stats.commits_sent,
+            stats.fragments_received,
+            stats.fragments_sent,
+        );
+    }
+
+    Ok(())
+}
+
+/// **Closest direct match to the user's todo-app workflow.** Both peers
+/// rapid-fire single-commit edits while the system is "live" (i.e.
+/// `add_commit` is broadcasting in the background). After things settle,
+/// a sync round must be empty.
+///
+/// Models: a user typing fast in browser A while another user is typing
+/// in browser B, both via a relay.
+#[tokio::test]
+async fn relay_topology_rapid_fire_then_idle_sync_is_empty() -> TestResult {
+    let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
+
+    let sed_id = SedimentreeId::new([9u8; 32]);
+
+    // Rapid-fire commits, no waits between them. Mirrors a user typing
+    // characters into a todo input field.
+    for i in 0..10_u8 {
+        a.add_commit(sed_id, make_head(i + 1), BTreeSet::new(), make_blob(i + 1))
+            .await?;
+    }
+    for i in 0..10_u8 {
+        b.add_commit(
+            sed_id,
+            make_head(100 + i),
+            BTreeSet::new(),
+            make_blob(100 + i),
+        )
+        .await?;
+    }
+
+    // Give broadcasts a generous window to propagate through the relay.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // One sync to drive any residual convergence.
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // All three nodes should have 20 commits.
+    assert_eq!(
+        a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(20),
+        "A converged after rapid-fire"
+    );
+    assert_eq!(
+        r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(20),
+        "R converged after rapid-fire"
+    );
+    assert_eq!(
+        b.get_commits(sed_id).await.map(|c| c.len()),
+        Some(20),
+        "B converged after rapid-fire"
+    );
+
+    // The invariant: now-idle sync must report zero.
+    let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        stats.is_empty(),
+        "idle sync after rapid-fire should be empty, got \
+         commits_received={}, commits_sent={}, fragments_received={}, fragments_sent={}",
+        stats.commits_received,
+        stats.commits_sent,
+        stats.fragments_received,
+        stats.fragments_sent,
+    );
+
+    Ok(())
+}
+
+/// **One-more-commit incrementality.** After convergence, a single new
+/// commit on A should result in B receiving exactly one commit on the
+/// next sync — not the whole history.
+///
+/// The user's symptom maps directly to this assertion failing with N+1
+/// instead of 1.
+#[tokio::test]
+async fn relay_topology_one_more_commit_transfers_only_the_delta() -> TestResult {
+    let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
+
+    let sed_id = SedimentreeId::new([11u8; 32]);
+
+    // Warm-up: A authors 8 commits; B authors 8 commits.
+    for i in 0..8_u8 {
+        a.add_commit(sed_id, make_head(i + 1), BTreeSet::new(), make_blob(i + 1))
+            .await?;
+    }
+    for i in 0..8_u8 {
+        b.add_commit(
+            sed_id,
+            make_head(100 + i),
+            BTreeSet::new(),
+            make_blob(100 + i),
+        )
+        .await?;
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Drive convergence.
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(16));
+    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(16));
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(16));
+
+    // A authors exactly one more commit. The broadcast from `add_commit`
+    // is intentionally NOT awaited — we want the sync to be responsible
+    // for delivering this one commit so we can measure delta size.
+    //
+    // (In a real client there is no `add_commit` broadcast; the wasm
+    // adapter just calls the local-only path. Modeling the same here
+    // would require `add_built_batch_locally` or similar; for now we
+    // accept that the broadcast may race.)
+    a.add_commit(
+        sed_id,
+        make_head(99),
+        BTreeSet::new(),
+        make_blob(99),
+    )
+    .await?;
+
+    // No sleep — go straight to sync to measure what arrives via sync
+    // vs what arrived via broadcast.
+    let (_, a_stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    let (_, b_stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // After everything: 17 commits on each side.
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(17));
+    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(17));
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(17));
+
+    // The bug as described would produce stats with received≈16, sent≈16
+    // on each side (the full history echoed back). Allow up to 2 extra
+    // transfers as slack for the race with the broadcast.
+    let max_acceptable = 2;
+    assert!(
+        a_stats.total_received() <= max_acceptable
+            && a_stats.total_sent() <= max_acceptable,
+        "A's incremental sync should transfer ≤{max_acceptable} items, got \
+         received={}, sent={}",
+        a_stats.total_received(),
+        a_stats.total_sent(),
+    );
+    assert!(
+        b_stats.total_received() <= max_acceptable
+            && b_stats.total_sent() <= max_acceptable,
+        "B's incremental sync should transfer ≤{max_acceptable} items, got \
+         received={}, sent={}",
+        b_stats.total_received(),
+        b_stats.total_sent(),
+    );
+
+    // The follow-up sync must be empty (re-convergence).
+    let (_, a_stats2, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    let (_, b_stats2, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        a_stats2.is_empty(),
+        "A: follow-up sync should be empty, got received={}, sent={}",
+        a_stats2.total_received(),
+        a_stats2.total_sent(),
+    );
+    assert!(
+        b_stats2.is_empty(),
+        "B: follow-up sync should be empty, got received={}, sent={}",
+        b_stats2.total_received(),
+        b_stats2.total_sent(),
+    );
+
+    Ok(())
+}
+
+/// **The most direct reproduction of the user's todo-app workflow.** The
+/// wasm `addBatch` API calls `add_built_batch`, which performs a local
+/// insert+minimize then `sync_with_all_peers` with `subscribe: true`. This
+/// is the path the Automerge-repo adapter uses on every change.
+///
+/// We repeatedly call `add_built_batch` (one commit at a time) and observe
+/// the `SyncStats` for each call. The first call has nothing to sync
+/// against (no peer state yet); subsequent calls should each transfer
+/// exactly the delta. If the bug exists, stats from call N would show
+/// transfers proportional to the total history.
+#[tokio::test]
+async fn relay_topology_add_built_batch_each_call_is_incremental() -> TestResult {
+    let (a, _r, _b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
+    let sed_id = SedimentreeId::new([13u8; 32]);
+
+    // First: do an initial sync to subscribe both A and the relay (and
+    // through it, B) to this sedimentree. The tree doesn't exist yet on
+    // any node, so this is essentially a no-op except that it registers
+    // intent. (In a real client the tree would exist before any sync.)
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // Issue 10 single-commit `add_built_batch` calls on A. Each goes
+    // through the same path as `addBatch` in wasm:
+    //   1. local insert+minimize
+    //   2. sync_with_all_peers(id, subscribe=true)
+    //
+    // After call N, A should have N commits. After the BatchSyncRequest
+    // in step 2 lands and the responder echoes "you have new stuff"
+    // back via fire-and-forget, the relay should also have N commits.
+    let mut commit_pairs = Vec::new();
+    for seed in 1..=10_u8 {
+        commit_pairs.push(make_commit_pair(sed_id, seed));
+    }
+
+    let mut prior_count = 0usize;
+    for (idx, pair) in commit_pairs.into_iter().enumerate() {
+        let n = idx + 1;
+        a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+        // A should have exactly N commits.
+        let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+        assert_eq!(
+            a_count, n,
+            "after call {n}: A should have {n} commits (sees {a_count})"
+        );
+
+        // Sanity: the count is monotonic.
+        assert!(a_count > prior_count, "monotonic growth");
+        prior_count = a_count;
+    }
+
+    Ok(())
+}
+
+/// **The actual invariant we are hunting.** Same `add_built_batch` flow
+/// as above, but we measure that the BatchSyncRequest embedded in each
+/// call doesn't echo the entire history back. Concretely: after call N,
+/// the relay should hold N commits and a follow-up explicit sync from A
+/// should be empty.
+#[tokio::test]
+async fn relay_topology_repeated_add_built_batch_then_sync_is_empty() -> TestResult {
+    let (a, r, _b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
+    let sed_id = SedimentreeId::new([14u8; 32]);
+
+    // Subscribe.
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    for seed in 1..=10_u8 {
+        let pair = make_commit_pair(sed_id, seed);
+        a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        tokio::time::sleep(PROPAGATION_PAUSE).await;
+    }
+
+    // Final state: A has 10 commits. R should too (received them via the
+    // fire-and-forget responses to each BatchSyncRequest).
+    assert_eq!(
+        a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(10),
+        "A has all 10 commits"
+    );
+    assert_eq!(
+        r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(10),
+        "R received all 10 commits via the BatchSyncRequest reply flow"
+    );
+
+    // Explicit follow-up sync: must report zero transfer in either direction.
+    let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        stats.is_empty(),
+        "after 10 add_built_batch calls, A→R should be in sync (received={}, sent={})",
+        stats.total_received(),
+        stats.total_sent(),
+    );
+
+    Ok(())
+}
+
+/// **Two browsers, one relay, both updating a shared doc.** Most directly
+/// mirrors the user's setup: two clients (A, B) each repeatedly call
+/// `add_built_batch` (the wasm `addBatch` path) against a single relay
+/// (R). After all updates land, the relay's view should fully match both
+/// clients and a follow-up sync should be empty for both.
+///
+/// If the bug from the logs reproduces here, we'd see one of:
+/// - Final commit counts disagreeing across A, R, B.
+/// - The trailing `full_sync_with_all_peers` from A or B reporting
+///   non-empty stats despite all data being present everywhere.
+#[tokio::test]
+async fn relay_topology_two_clients_add_built_batch_converge_via_relay() -> TestResult {
+    let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
+    let sed_id = SedimentreeId::new([15u8; 32]);
+
+    // Subscribe both ends to the relay for this sedimentree. Because the
+    // tree doesn't exist anywhere yet, `full_sync_with_all_peers` over a
+    // known-empty key-set is a no-op for subscription purposes — we have
+    // to seed each side with an explicit per-id sync.
+    a.sync_with_peer(
+        &PeerId::from(make_signer(20).verifying_key()),
+        sed_id,
+        true,
+        SYNC_TIMEOUT,
+    )
+    .await?;
+    b.sync_with_peer(
+        &PeerId::from(make_signer(20).verifying_key()),
+        sed_id,
+        true,
+        SYNC_TIMEOUT,
+    )
+    .await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // Interleaved single-commit `add_built_batch` calls from both ends.
+    // Mirrors two users typing into a shared todo simultaneously.
+    let total_pairs = 12;
+    for i in 0..total_pairs {
+        if i % 2 == 0 {
+            let pair = make_commit_pair(sed_id, (i as u8) + 1);
+            a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        } else {
+            let pair = make_commit_pair(sed_id, 100 + (i as u8));
+            b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        }
+        tokio::time::sleep(PROPAGATION_PAUSE).await;
+    }
+
+    // All three nodes should now hold all 12 commits.
+    let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let r_count = r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let b_count = b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    assert_eq!(
+        (a_count, r_count, b_count),
+        (total_pairs, total_pairs, total_pairs),
+        "after interleaved add_built_batch from both ends, all three should hold \
+         {total_pairs} commits each (got A={a_count}, R={r_count}, B={b_count})"
+    );
+
+    // Follow-up sync from each end must report empty stats.
+    let (_, a_stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    let (_, b_stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+
+    assert!(
+        a_stats.is_empty(),
+        "A's follow-up sync should be empty, got received={}, sent={}",
+        a_stats.total_received(),
+        a_stats.total_sent(),
+    );
+    assert!(
+        b_stats.is_empty(),
+        "B's follow-up sync should be empty, got received={}, sent={}",
+        b_stats.total_received(),
+        b_stats.total_sent(),
+    );
+
+    Ok(())
+}
+
+/// **Concurrent BatchSyncRequests from the same peer.** Most direct
+/// reproduction of the race I suspected in the responder's
+/// `recv_batch_sync_request`: the responder loads commits from storage
+/// then locks the in-memory shard, but those steps are interleaved with
+/// concurrent writes from other ingestion paths.
+///
+/// We fire many simultaneous `add_built_batch` calls (each containing
+/// its own embedded `sync_with_all_peers`) and assert final convergence.
+#[tokio::test]
+async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResult {
+    let (a, r, _b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
+    let sed_id = SedimentreeId::new([16u8; 32]);
+
+    a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // Launch 8 add_built_batch calls in parallel from A.
+    let n = 8_u8;
+    let pairs: Vec<_> = (1..=n).map(|seed| make_commit_pair(sed_id, seed)).collect();
+
+    let mut handles = Vec::new();
+    for pair in pairs {
+        let a_clone = a.clone();
+        handles.push(tokio::spawn(async move {
+            a_clone.add_built_batch(sed_id, vec![pair], Vec::new()).await
+        }));
+    }
+
+    for h in handles {
+        h.await??;
+    }
+
+    // Give things time to settle. The concurrent calls each issue a
+    // `sync_with_all_peers` internally, so the relay sees a burst of
+    // BatchSyncRequests with different seeds.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Both sides should have all `n` commits.
+    let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    let r_count = r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
+    assert_eq!(a_count, n as usize, "A should have all {n} commits");
+    assert_eq!(
+        r_count, n as usize,
+        "R should have all {n} commits (despite the concurrent BatchSyncRequest barrage)"
+    );
+
+    // Final sync must be empty.
+    let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
+    assert!(
+        stats.is_empty(),
+        "post-burst sync should be empty, got received={}, sent={}",
+        stats.total_received(),
+        stats.total_sent(),
+    );
+
+    Ok(())
+}

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -1,7 +1,7 @@
 //! Three-node A↔R↔B sync over `MemoryStorage` + `ChannelTransport`.
 //! The middle relay only has direct connections to A and B; the end
-//! peers never connect directly. Reproduces the user-reported topology
-//! where two browsers sync through a relay server.
+//! peers never connect directly — i.e. clients talking through a
+//! relay server.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing)]
 
@@ -169,7 +169,6 @@ async fn relay_topology_converges_on_initial_sync() -> TestResult {
 
 /// After A and B have fully converged through R, repeated
 /// `full_sync_with_all_peers` from either side must report empty stats.
-/// The bug shape "N missing, requesting N" violates this.
 #[tokio::test]
 async fn relay_topology_repeated_sync_after_convergence_is_empty() -> TestResult {
     let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
@@ -252,13 +251,10 @@ async fn relay_topology_rapid_fire_then_idle_sync_is_empty() -> TestResult {
     Ok(())
 }
 
-/// After convergence, one new commit on A should transfer at most a
-/// small delta (not the full history) to B on the next sync, and the
-/// follow-up round must be empty.
-///
-/// Note: `max_acceptable = 2` is slack for the race between `add_commit`'s
-/// broadcast and the explicit sync — to be tightened once we have a
-/// "local-only insert" path on Subduction.
+/// After convergence, one new commit on A propagates to the relay and
+/// to B by the time both peers explicitly sync, and the sync itself
+/// transfers at most that one commit (never the whole history). The
+/// follow-up round must be exactly empty.
 #[tokio::test]
 async fn relay_topology_one_more_commit_transfers_only_the_delta() -> TestResult {
     let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
@@ -288,8 +284,13 @@ async fn relay_topology_one_more_commit_transfers_only_the_delta() -> TestResult
     assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(16));
     assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(16));
 
+    // Author one new commit on A and let the broadcast propagate before
+    // measuring delta-sync behavior. `add_commit` broadcasts via the
+    // subscription path; without the pause its delivery races with the
+    // explicit sync we're about to invoke.
     a.add_commit(sed_id, make_head(99), BTreeSet::new(), make_blob(99))
         .await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
 
     let (_, a_stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
@@ -299,15 +300,14 @@ async fn relay_topology_one_more_commit_transfers_only_the_delta() -> TestResult
     assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(17));
     assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(17));
 
-    let max_acceptable = 2;
+    // Either the broadcast won (0 transferred during sync) or the sync
+    // delivered the new commit (1 transferred) — never the full history.
     assert!(
-        a_stats.total_received() <= max_acceptable
-            && a_stats.total_sent() <= max_acceptable,
+        a_stats.total_received() <= 1 && a_stats.total_sent() <= 1,
         "A delta: {a_stats:?}",
     );
     assert!(
-        b_stats.total_received() <= max_acceptable
-            && b_stats.total_sent() <= max_acceptable,
+        b_stats.total_received() <= 1 && b_stats.total_sent() <= 1,
         "B delta: {b_stats:?}",
     );
 

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -200,15 +200,9 @@ async fn relay_topology_repeated_sync_after_convergence_is_empty() -> TestResult
 
     for round in 1..=4 {
         let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-        assert!(
-            stats.is_empty(),
-            "round {round} from A: {stats:?}",
-        );
+        assert!(stats.is_empty(), "round {round} from A: {stats:?}",);
         let (_, stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-        assert!(
-            stats.is_empty(),
-            "round {round} from B: {stats:?}",
-        );
+        assert!(stats.is_empty(), "round {round} from B: {stats:?}",);
     }
 
     Ok(())
@@ -379,8 +373,10 @@ async fn relay_topology_two_clients_add_built_batch_converge_via_relay() -> Test
     let sed_id = SedimentreeId::new([15u8; 32]);
 
     let r_peer = PeerId::from(make_signer(20).verifying_key());
-    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT).await?;
-    b.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT).await?;
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    b.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
     let total_pairs = 12;
@@ -398,7 +394,10 @@ async fn relay_topology_two_clients_add_built_batch_converge_via_relay() -> Test
     let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let r_count = r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let b_count = b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!((a_count, r_count, b_count), (total_pairs, total_pairs, total_pairs));
+    assert_eq!(
+        (a_count, r_count, b_count),
+        (total_pairs, total_pairs, total_pairs)
+    );
 
     let (_, a_stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
@@ -427,7 +426,9 @@ async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResul
     for pair in pairs {
         let a_clone = a.clone();
         handles.push(tokio::spawn(async move {
-            a_clone.add_built_batch(sed_id, vec![pair], Vec::new()).await
+            a_clone
+                .add_built_batch(sed_id, vec![pair], Vec::new())
+                .await
         }));
     }
     for h in handles {
@@ -436,8 +437,14 @@ async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResul
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(n as usize));
-    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(n as usize));
+    assert_eq!(
+        a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(n as usize)
+    );
+    assert_eq!(
+        r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(n as usize)
+    );
 
     let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     assert!(stats.is_empty(), "{stats:?}");

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -1,17 +1,7 @@
-//! Reproduces the topology of the user-observed bug: two end-peers connected
-//! through a third Subduction acting as a relay. The relay stores commits
-//! and computes its own diffs against incoming sync requests (matching the
-//! `subduction_cli` server behavior in the logs).
-//!
-//! The user's report: when two browsers edit a todo doc through a relay
-//! server, every `BatchSyncRequest` produces a response of the form
-//! "N missing, requesting N" — i.e. zero overlap is detected despite
-//! identical content. Each update therefore re-transfers the full history,
-//! and compute grows with each edit.
-//!
-//! Existing `convergence.rs` covers two directly-connected Subductions on
-//! `MemoryStorage` and passes. These tests add the relay middle-node so we
-//! can see whether the bug is specific to that topology.
+//! Three-node A↔R↔B sync over `MemoryStorage` + `ChannelTransport`.
+//! The middle relay only has direct connections to A and B; the end
+//! peers never connect directly. Reproduces the user-reported topology
+//! where two browsers sync through a relay server.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing)]
 
@@ -56,9 +46,6 @@ type TestSubduction = Arc<
 >;
 
 const SYNC_TIMEOUT: Option<Duration> = Some(Duration::from_millis(500));
-
-/// Length of a single propagation hop. We let listeners drain after each
-/// state-changing step so broadcasts settle before observations.
 const PROPAGATION_PAUSE: Duration = Duration::from_millis(50);
 
 fn make_signer(seed: u8) -> MemorySigner {
@@ -91,8 +78,8 @@ fn make_head(seed: u8) -> CommitId {
     CommitId::new(bytes)
 }
 
-/// Build a single unsigned `(LooseCommit, Blob)` pair for use with
-/// `add_built_batch`. Mirrors what the Automerge wasm adapter builds.
+/// Unsigned `(LooseCommit, Blob)` pair for `add_built_batch`. Mirrors
+/// what the Automerge wasm adapter builds.
 fn make_commit_pair(sed_id: SedimentreeId, seed: u8) -> (LooseCommit, Blob) {
     let blob = make_blob(seed);
     let blob_meta = BlobMeta::new(&blob);
@@ -101,7 +88,6 @@ fn make_commit_pair(sed_id: SedimentreeId, seed: u8) -> (LooseCommit, Blob) {
     (commit, blob)
 }
 
-/// Connect two nodes via a bidirectional channel transport pair.
 async fn connect_pair(
     a: &TestSubduction,
     a_signer: &MemorySigner,
@@ -125,10 +111,6 @@ async fn connect_pair(
     Ok(())
 }
 
-/// Three nodes wired A ↔ R ↔ B. R only has direct connections to A and B;
-/// A and B never connect directly. R acts as a passive relay: it stores
-/// what it sees and forwards `LooseCommit` / `Fragment` messages to its
-/// other subscribers in `recv_loose_commit` / `recv_fragment`.
 async fn setup_relay_topology() -> TestResult<(
     TestSubduction,
     TestSubduction,
@@ -153,12 +135,6 @@ async fn setup_relay_topology() -> TestResult<(
     Ok((a, r, b, a_signer, r_signer, b_signer))
 }
 
-/// Phase 0 baseline: three-node topology converges on initial sync.
-///
-/// A makes a commit and explicitly drives sync. R and B both receive it
-/// after the sync subscribes them. The `add_commit` broadcast fallback
-/// reaches R immediately (no subscribers → broadcast to all connections);
-/// for R → B we need an explicit `full_sync_with_all_peers` from B.
 #[tokio::test]
 async fn relay_topology_converges_on_initial_sync() -> TestResult {
     let (a, r, b, _a_signer, _r_signer, _b_signer) = setup_relay_topology().await?;
@@ -169,26 +145,14 @@ async fn relay_topology_converges_on_initial_sync() -> TestResult {
         .await?;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // Direct broadcast fallback reaches R immediately.
-    assert_eq!(
-        a.get_commits(sed_id).await.map(|c| c.len()),
-        Some(1),
-        "A has its own commit"
-    );
-    assert_eq!(
-        r.get_commits(sed_id).await.map(|c| c.len()),
-        Some(1),
-        "R received the direct broadcast"
-    );
+    // `add_commit`'s broadcast fallback (no subscribers → broadcast to all
+    // connections) reaches R immediately.
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(1));
+    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(1));
 
-    // B has no sedimentree yet — needs to actively pull. Once B has issued
-    // a sync (which subscribes B to R), future commits will flow.
-    b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    tokio::time::sleep(PROPAGATION_PAUSE).await;
-
-    // Hmm: B's full_sync_with_all_peers iterates B's known sedimentrees,
-    // which is empty. So this doesn't help. We need B to explicitly call
-    // sync_with_peer for sed_id to fetch it.
+    // B has no sedimentree yet, so `full_sync_with_all_peers` (which
+    // iterates B's known sedimentrees) is a no-op for this id. Force a
+    // per-id sync to subscribe B and pull the data.
     b.sync_with_peer(
         &PeerId::from(make_signer(20).verifying_key()),
         sed_id,
@@ -198,29 +162,20 @@ async fn relay_topology_converges_on_initial_sync() -> TestResult {
     .await?;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    assert_eq!(
-        b.get_commits(sed_id).await.map(|c| c.len()),
-        Some(1),
-        "B received the commit after explicit sync_with_peer"
-    );
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(1));
 
     Ok(())
 }
 
-/// **The directly user-facing invariant.** After A and B have fully synced
-/// through R, a follow-up `full_sync_with_all_peers` from either side
-/// should report zero items transferred.
-///
-/// The user's logs show "19 missing, requesting 19" instead — i.e. the
-/// stats from a converged-then-resynced flow are NON-empty even though
-/// nothing has changed.
+/// After A and B have fully converged through R, repeated
+/// `full_sync_with_all_peers` from either side must report empty stats.
+/// The bug shape "N missing, requesting N" violates this.
 #[tokio::test]
 async fn relay_topology_repeated_sync_after_convergence_is_empty() -> TestResult {
     let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
 
     let sed_id = SedimentreeId::new([8u8; 32]);
 
-    // Seed both ends with their own commits.
     for i in 0..5_u8 {
         a.add_commit(sed_id, make_head(i + 1), BTreeSet::new(), make_blob(i + 1))
             .await?;
@@ -234,74 +189,40 @@ async fn relay_topology_repeated_sync_after_convergence_is_empty() -> TestResult
         )
         .await?;
     }
-
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // Drive a sync from both ends — let everything converge.
     a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // Sanity: all three nodes should now have 10 commits.
-    assert_eq!(
-        a.get_commits(sed_id).await.map(|c| c.len()),
-        Some(10),
-        "A converged"
-    );
-    assert_eq!(
-        r.get_commits(sed_id).await.map(|c| c.len()),
-        Some(10),
-        "R converged"
-    );
-    assert_eq!(
-        b.get_commits(sed_id).await.map(|c| c.len()),
-        Some(10),
-        "B converged"
-    );
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(10));
+    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(10));
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(10));
 
-    // The actual invariant being tested.
     for round in 1..=4 {
         let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
         assert!(
             stats.is_empty(),
-            "round {round} from A (converged): expected empty sync stats, got \
-             commits_received={}, commits_sent={}, fragments_received={}, fragments_sent={}",
-            stats.commits_received,
-            stats.commits_sent,
-            stats.fragments_received,
-            stats.fragments_sent,
+            "round {round} from A: {stats:?}",
         );
-
         let (_, stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
         assert!(
             stats.is_empty(),
-            "round {round} from B (converged): expected empty sync stats, got \
-             commits_received={}, commits_sent={}, fragments_received={}, fragments_sent={}",
-            stats.commits_received,
-            stats.commits_sent,
-            stats.fragments_received,
-            stats.fragments_sent,
+            "round {round} from B: {stats:?}",
         );
     }
 
     Ok(())
 }
 
-/// **Closest direct match to the user's todo-app workflow.** Both peers
-/// rapid-fire single-commit edits while the system is "live" (i.e.
-/// `add_commit` is broadcasting in the background). After things settle,
-/// a sync round must be empty.
-///
-/// Models: a user typing fast in browser A while another user is typing
-/// in browser B, both via a relay.
+/// Two peers rapid-fire single-commit edits, then an idle sync round
+/// must be empty. Models two browsers typing into a shared doc.
 #[tokio::test]
 async fn relay_topology_rapid_fire_then_idle_sync_is_empty() -> TestResult {
     let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
 
     let sed_id = SedimentreeId::new([9u8; 32]);
 
-    // Rapid-fire commits, no waits between them. Mirrors a user typing
-    // characters into a todo input field.
     for i in 0..10_u8 {
         a.add_commit(sed_id, make_head(i + 1), BTreeSet::new(), make_blob(i + 1))
             .await?;
@@ -315,60 +236,35 @@ async fn relay_topology_rapid_fire_then_idle_sync_is_empty() -> TestResult {
         )
         .await?;
     }
-
-    // Give broadcasts a generous window to propagate through the relay.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // One sync to drive any residual convergence.
     a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // All three nodes should have 20 commits.
-    assert_eq!(
-        a.get_commits(sed_id).await.map(|c| c.len()),
-        Some(20),
-        "A converged after rapid-fire"
-    );
-    assert_eq!(
-        r.get_commits(sed_id).await.map(|c| c.len()),
-        Some(20),
-        "R converged after rapid-fire"
-    );
-    assert_eq!(
-        b.get_commits(sed_id).await.map(|c| c.len()),
-        Some(20),
-        "B converged after rapid-fire"
-    );
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(20));
+    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(20));
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(20));
 
-    // The invariant: now-idle sync must report zero.
     let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        stats.is_empty(),
-        "idle sync after rapid-fire should be empty, got \
-         commits_received={}, commits_sent={}, fragments_received={}, fragments_sent={}",
-        stats.commits_received,
-        stats.commits_sent,
-        stats.fragments_received,
-        stats.fragments_sent,
-    );
+    assert!(stats.is_empty(), "idle sync after rapid-fire: {stats:?}");
 
     Ok(())
 }
 
-/// **One-more-commit incrementality.** After convergence, a single new
-/// commit on A should result in B receiving exactly one commit on the
-/// next sync — not the whole history.
+/// After convergence, one new commit on A should transfer at most a
+/// small delta (not the full history) to B on the next sync, and the
+/// follow-up round must be empty.
 ///
-/// The user's symptom maps directly to this assertion failing with N+1
-/// instead of 1.
+/// Note: `max_acceptable = 2` is slack for the race between `add_commit`'s
+/// broadcast and the explicit sync — to be tightened once we have a
+/// "local-only insert" path on Subduction.
 #[tokio::test]
 async fn relay_topology_one_more_commit_transfers_only_the_delta() -> TestResult {
     let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
 
     let sed_id = SedimentreeId::new([11u8; 32]);
 
-    // Warm-up: A authors 8 commits; B authors 8 commits.
     for i in 0..8_u8 {
         a.add_commit(sed_id, make_head(i + 1), BTreeSet::new(), make_blob(i + 1))
             .await?;
@@ -384,7 +280,6 @@ async fn relay_topology_one_more_commit_transfers_only_the_delta() -> TestResult
     }
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    // Drive convergence.
     a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
@@ -393,211 +288,101 @@ async fn relay_topology_one_more_commit_transfers_only_the_delta() -> TestResult
     assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(16));
     assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(16));
 
-    // A authors exactly one more commit. The broadcast from `add_commit`
-    // is intentionally NOT awaited — we want the sync to be responsible
-    // for delivering this one commit so we can measure delta size.
-    //
-    // (In a real client there is no `add_commit` broadcast; the wasm
-    // adapter just calls the local-only path. Modeling the same here
-    // would require `add_built_batch_locally` or similar; for now we
-    // accept that the broadcast may race.)
-    a.add_commit(
-        sed_id,
-        make_head(99),
-        BTreeSet::new(),
-        make_blob(99),
-    )
-    .await?;
+    a.add_commit(sed_id, make_head(99), BTreeSet::new(), make_blob(99))
+        .await?;
 
-    // No sleep — go straight to sync to measure what arrives via sync
-    // vs what arrived via broadcast.
     let (_, a_stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // After everything: 17 commits on each side.
     assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(17));
     assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(17));
     assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(17));
 
-    // The bug as described would produce stats with received≈16, sent≈16
-    // on each side (the full history echoed back). Allow up to 2 extra
-    // transfers as slack for the race with the broadcast.
     let max_acceptable = 2;
     assert!(
         a_stats.total_received() <= max_acceptable
             && a_stats.total_sent() <= max_acceptable,
-        "A's incremental sync should transfer ≤{max_acceptable} items, got \
-         received={}, sent={}",
-        a_stats.total_received(),
-        a_stats.total_sent(),
+        "A delta: {a_stats:?}",
     );
     assert!(
         b_stats.total_received() <= max_acceptable
             && b_stats.total_sent() <= max_acceptable,
-        "B's incremental sync should transfer ≤{max_acceptable} items, got \
-         received={}, sent={}",
-        b_stats.total_received(),
-        b_stats.total_sent(),
+        "B delta: {b_stats:?}",
     );
 
-    // The follow-up sync must be empty (re-convergence).
     let (_, a_stats2, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats2, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        a_stats2.is_empty(),
-        "A: follow-up sync should be empty, got received={}, sent={}",
-        a_stats2.total_received(),
-        a_stats2.total_sent(),
-    );
-    assert!(
-        b_stats2.is_empty(),
-        "B: follow-up sync should be empty, got received={}, sent={}",
-        b_stats2.total_received(),
-        b_stats2.total_sent(),
-    );
+    assert!(a_stats2.is_empty(), "A follow-up: {a_stats2:?}");
+    assert!(b_stats2.is_empty(), "B follow-up: {b_stats2:?}");
 
     Ok(())
 }
 
-/// **The most direct reproduction of the user's todo-app workflow.** The
-/// wasm `addBatch` API calls `add_built_batch`, which performs a local
-/// insert+minimize then `sync_with_all_peers` with `subscribe: true`. This
-/// is the path the Automerge-repo adapter uses on every change.
-///
-/// We repeatedly call `add_built_batch` (one commit at a time) and observe
-/// the `SyncStats` for each call. The first call has nothing to sync
-/// against (no peer state yet); subsequent calls should each transfer
-/// exactly the delta. If the bug exists, stats from call N would show
-/// transfers proportional to the total history.
+/// `add_built_batch` is the wasm `addBatch` path: local insert+minimize
+/// then `sync_with_all_peers(subscribe=true)`. Each call should leave A
+/// with monotonically growing commit count.
 #[tokio::test]
 async fn relay_topology_add_built_batch_each_call_is_incremental() -> TestResult {
     let (a, _r, _b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
     let sed_id = SedimentreeId::new([13u8; 32]);
 
-    // First: do an initial sync to subscribe both A and the relay (and
-    // through it, B) to this sedimentree. The tree doesn't exist yet on
-    // any node, so this is essentially a no-op except that it registers
-    // intent. (In a real client the tree would exist before any sync.)
     a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // Issue 10 single-commit `add_built_batch` calls on A. Each goes
-    // through the same path as `addBatch` in wasm:
-    //   1. local insert+minimize
-    //   2. sync_with_all_peers(id, subscribe=true)
-    //
-    // After call N, A should have N commits. After the BatchSyncRequest
-    // in step 2 lands and the responder echoes "you have new stuff"
-    // back via fire-and-forget, the relay should also have N commits.
-    let mut commit_pairs = Vec::new();
-    for seed in 1..=10_u8 {
-        commit_pairs.push(make_commit_pair(sed_id, seed));
-    }
-
     let mut prior_count = 0usize;
-    for (idx, pair) in commit_pairs.into_iter().enumerate() {
-        let n = idx + 1;
-        a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+    for seed in 1..=10_u8 {
+        let n = seed as usize;
+        a.add_built_batch(sed_id, vec![make_commit_pair(sed_id, seed)], Vec::new())
+            .await?;
         tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-        // A should have exactly N commits.
         let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-        assert_eq!(
-            a_count, n,
-            "after call {n}: A should have {n} commits (sees {a_count})"
-        );
-
-        // Sanity: the count is monotonic.
-        assert!(a_count > prior_count, "monotonic growth");
+        assert_eq!(a_count, n);
+        assert!(a_count > prior_count);
         prior_count = a_count;
     }
 
     Ok(())
 }
 
-/// **The actual invariant we are hunting.** Same `add_built_batch` flow
-/// as above, but we measure that the BatchSyncRequest embedded in each
-/// call doesn't echo the entire history back. Concretely: after call N,
-/// the relay should hold N commits and a follow-up explicit sync from A
-/// should be empty.
+/// After repeated `add_built_batch` calls, A and R must hold the same
+/// commit set, and an explicit follow-up sync must be empty.
 #[tokio::test]
 async fn relay_topology_repeated_add_built_batch_then_sync_is_empty() -> TestResult {
     let (a, r, _b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
     let sed_id = SedimentreeId::new([14u8; 32]);
 
-    // Subscribe.
     a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
     for seed in 1..=10_u8 {
-        let pair = make_commit_pair(sed_id, seed);
-        a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        a.add_built_batch(sed_id, vec![make_commit_pair(sed_id, seed)], Vec::new())
+            .await?;
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
 
-    // Final state: A has 10 commits. R should too (received them via the
-    // fire-and-forget responses to each BatchSyncRequest).
-    assert_eq!(
-        a.get_commits(sed_id).await.map(|c| c.len()),
-        Some(10),
-        "A has all 10 commits"
-    );
-    assert_eq!(
-        r.get_commits(sed_id).await.map(|c| c.len()),
-        Some(10),
-        "R received all 10 commits via the BatchSyncRequest reply flow"
-    );
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(10));
+    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(10));
 
-    // Explicit follow-up sync: must report zero transfer in either direction.
     let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        stats.is_empty(),
-        "after 10 add_built_batch calls, A→R should be in sync (received={}, sent={})",
-        stats.total_received(),
-        stats.total_sent(),
-    );
+    assert!(stats.is_empty(), "{stats:?}");
 
     Ok(())
 }
 
-/// **Two browsers, one relay, both updating a shared doc.** Most directly
-/// mirrors the user's setup: two clients (A, B) each repeatedly call
-/// `add_built_batch` (the wasm `addBatch` path) against a single relay
-/// (R). After all updates land, the relay's view should fully match both
-/// clients and a follow-up sync should be empty for both.
-///
-/// If the bug from the logs reproduces here, we'd see one of:
-/// - Final commit counts disagreeing across A, R, B.
-/// - The trailing `full_sync_with_all_peers` from A or B reporting
-///   non-empty stats despite all data being present everywhere.
+/// Interleaved `add_built_batch` from A and B; the relay must end up
+/// with the union, and a follow-up sync from either client must be empty.
 #[tokio::test]
 async fn relay_topology_two_clients_add_built_batch_converge_via_relay() -> TestResult {
     let (a, r, b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
     let sed_id = SedimentreeId::new([15u8; 32]);
 
-    // Subscribe both ends to the relay for this sedimentree. Because the
-    // tree doesn't exist anywhere yet, `full_sync_with_all_peers` over a
-    // known-empty key-set is a no-op for subscription purposes — we have
-    // to seed each side with an explicit per-id sync.
-    a.sync_with_peer(
-        &PeerId::from(make_signer(20).verifying_key()),
-        sed_id,
-        true,
-        SYNC_TIMEOUT,
-    )
-    .await?;
-    b.sync_with_peer(
-        &PeerId::from(make_signer(20).verifying_key()),
-        sed_id,
-        true,
-        SYNC_TIMEOUT,
-    )
-    .await?;
+    let r_peer = PeerId::from(make_signer(20).verifying_key());
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT).await?;
+    b.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT).await?;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // Interleaved single-commit `add_built_batch` calls from both ends.
-    // Mirrors two users typing into a shared todo simultaneously.
     let total_pairs = 12;
     for i in 0..total_pairs {
         if i % 2 == 0 {
@@ -610,45 +395,23 @@ async fn relay_topology_two_clients_add_built_batch_converge_via_relay() -> Test
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
 
-    // All three nodes should now hold all 12 commits.
     let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let r_count = r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
     let b_count = b.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!(
-        (a_count, r_count, b_count),
-        (total_pairs, total_pairs, total_pairs),
-        "after interleaved add_built_batch from both ends, all three should hold \
-         {total_pairs} commits each (got A={a_count}, R={r_count}, B={b_count})"
-    );
+    assert_eq!((a_count, r_count, b_count), (total_pairs, total_pairs, total_pairs));
 
-    // Follow-up sync from each end must report empty stats.
     let (_, a_stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     let (_, b_stats, _, _) = b.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-
-    assert!(
-        a_stats.is_empty(),
-        "A's follow-up sync should be empty, got received={}, sent={}",
-        a_stats.total_received(),
-        a_stats.total_sent(),
-    );
-    assert!(
-        b_stats.is_empty(),
-        "B's follow-up sync should be empty, got received={}, sent={}",
-        b_stats.total_received(),
-        b_stats.total_sent(),
-    );
+    assert!(a_stats.is_empty(), "A: {a_stats:?}");
+    assert!(b_stats.is_empty(), "B: {b_stats:?}");
 
     Ok(())
 }
 
-/// **Concurrent BatchSyncRequests from the same peer.** Most direct
-/// reproduction of the race I suspected in the responder's
-/// `recv_batch_sync_request`: the responder loads commits from storage
-/// then locks the in-memory shard, but those steps are interleaved with
-/// concurrent writes from other ingestion paths.
-///
-/// We fire many simultaneous `add_built_batch` calls (each containing
-/// its own embedded `sync_with_all_peers`) and assert final convergence.
+/// Many concurrent `add_built_batch` calls from A. Each issues an
+/// embedded `BatchSyncRequest`, so the relay sees a burst of concurrent
+/// requests interleaved with `LooseCommit` pushes. Probes the
+/// load-vs-save race window in the responder.
 #[tokio::test]
 async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResult {
     let (a, r, _b, _a_s, _r_s, _b_s) = setup_relay_topology().await?;
@@ -657,7 +420,6 @@ async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResul
     a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
-    // Launch 8 add_built_batch calls in parallel from A.
     let n = 8_u8;
     let pairs: Vec<_> = (1..=n).map(|seed| make_commit_pair(sed_id, seed)).collect();
 
@@ -668,33 +430,17 @@ async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResul
             a_clone.add_built_batch(sed_id, vec![pair], Vec::new()).await
         }));
     }
-
     for h in handles {
         h.await??;
     }
 
-    // Give things time to settle. The concurrent calls each issue a
-    // `sync_with_all_peers` internally, so the relay sees a burst of
-    // BatchSyncRequests with different seeds.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // Both sides should have all `n` commits.
-    let a_count = a.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    let r_count = r.get_commits(sed_id).await.map(|c| c.len()).unwrap_or(0);
-    assert_eq!(a_count, n as usize, "A should have all {n} commits");
-    assert_eq!(
-        r_count, n as usize,
-        "R should have all {n} commits (despite the concurrent BatchSyncRequest barrage)"
-    );
+    assert_eq!(a.get_commits(sed_id).await.map(|c| c.len()), Some(n as usize));
+    assert_eq!(r.get_commits(sed_id).await.map(|c| c.len()), Some(n as usize));
 
-    // Final sync must be empty.
     let (_, stats, _, _) = a.full_sync_with_all_peers(SYNC_TIMEOUT).await;
-    assert!(
-        stats.is_empty(),
-        "post-burst sync should be empty, got received={}, sent={}",
-        stats.total_received(),
-        stats.total_sent(),
-    );
+    assert!(stats.is_empty(), "{stats:?}");
 
     Ok(())
 }

--- a/subduction_core/tests/seed_round_trip.rs
+++ b/subduction_core/tests/seed_round_trip.rs
@@ -28,7 +28,7 @@ fn commit(seed: u8, parents: &[CommitId]) -> LooseCommit {
     )
 }
 
-fn head(seed: u8) -> CommitId {
+const fn head(seed: u8) -> CommitId {
     CommitId::new([seed; 32])
 }
 

--- a/subduction_core/tests/seed_round_trip.rs
+++ b/subduction_core/tests/seed_round_trip.rs
@@ -1,0 +1,431 @@
+//! **Wire-codec round-trip tests for `FingerprintSeed` and
+//! `FingerprintSummary`** — answers the question "could the seed be
+//! mis-encoded, or could the responder be using a different seed than
+//! the one in the summary?"
+//!
+//! The diff layer documents this invariant: the responder must
+//! fingerprint its own items using `remote.seed()` (the seed field of
+//! the incoming `FingerprintSummary`), and the fingerprints inside that
+//! summary were computed by the requester using the same seed. If
+//! either side computes with a different seed, the sets are disjoint
+//! and we see the "N missing, requesting N" symptom.
+//!
+//! These tests pin down that:
+//!
+//! 1. The wire codec encodes and decodes the seed byte-identically.
+//! 2. The fingerprints inside a `FingerprintSummary` survive the
+//!    round-trip byte-identically.
+//! 3. After a round-trip, the responder's diff against the decoded
+//!    summary produces the identical result it would have produced
+//!    against the original summary.
+//! 4. Two peers running the same code, given the same `CommitId`
+//!    bytes and the same seed, always compute the same fingerprint.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
+
+use std::collections::BTreeSet;
+
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    crypto::fingerprint::{Fingerprint, FingerprintSeed},
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+    sedimentree::{FingerprintSummary, Sedimentree},
+};
+use subduction_core::{
+    connection::message::{BatchSyncRequest, RequestId, SyncMessage},
+    peer::id::PeerId,
+};
+
+const SED_ID: SedimentreeId = SedimentreeId::new([42u8; 32]);
+
+fn commit(seed: u8, parents: &[CommitId]) -> LooseCommit {
+    let blob = Blob::new(vec![seed; 64]);
+    let blob_meta = BlobMeta::new(&blob);
+    let head = CommitId::new([seed; 32]);
+    LooseCommit::new(
+        SED_ID,
+        head,
+        parents.iter().copied().collect::<BTreeSet<_>>(),
+        blob_meta,
+    )
+}
+
+fn head(seed: u8) -> CommitId {
+    CommitId::new([seed; 32])
+}
+
+fn tree_of(commits: Vec<LooseCommit>) -> Sedimentree {
+    Sedimentree::new(vec![], commits)
+}
+
+fn make_request(summary: FingerprintSummary) -> BatchSyncRequest {
+    BatchSyncRequest {
+        id: SED_ID,
+        req_id: RequestId {
+            requestor: PeerId::new([0xAB; 32]),
+            nonce: 0xDEADBEEF_CAFEF00D,
+        },
+        fingerprint_summary: summary,
+        subscribe: true,
+    }
+}
+
+fn encode_decode_request(req: &BatchSyncRequest) -> BatchSyncRequest {
+    let msg = SyncMessage::BatchSyncRequest(req.clone());
+    let bytes = msg.encode();
+    let decoded = SyncMessage::try_decode(bytes.as_slice()).expect("decode should succeed");
+    match decoded {
+        SyncMessage::BatchSyncRequest(req) => req,
+        other => panic!("expected BatchSyncRequest, got {other:?}"),
+    }
+}
+
+// ============================================================================
+// Section 1: seed and fingerprint bytes survive the wire codec
+// ============================================================================
+
+/// The seed encoded into a `BatchSyncRequest` must decode back to the
+/// same `FingerprintSeed`. Plain round-trip test.
+#[test]
+fn seed_round_trips_through_wire_codec() {
+    let seed = FingerprintSeed::new(0x1234_5678_9ABC_DEF0, 0xFEDC_BA98_7654_3210);
+    let summary = FingerprintSummary::new(seed, BTreeSet::new(), BTreeSet::new());
+    let req = make_request(summary);
+
+    let decoded = encode_decode_request(&req);
+    let decoded_seed = decoded.fingerprint_summary.seed();
+
+    assert_eq!(decoded_seed.key0(), 0x1234_5678_9ABC_DEF0);
+    assert_eq!(decoded_seed.key1(), 0xFEDC_BA98_7654_3210);
+    assert_eq!(decoded_seed, &seed, "seed must round-trip byte-identically");
+}
+
+/// Every fingerprint value in the summary must survive the wire codec
+/// byte-identically. If even one bit flips, the set difference at the
+/// receiver yields wrong results.
+#[test]
+fn fingerprint_values_round_trip_through_wire_codec() {
+    let seed = FingerprintSeed::new(11, 22);
+    let local = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+    let original_summary = local.fingerprint_summarize(&seed);
+
+    let req = make_request(original_summary.clone());
+    let decoded = encode_decode_request(&req);
+    let decoded_summary = decoded.fingerprint_summary;
+
+    assert_eq!(
+        decoded_summary.seed(),
+        original_summary.seed(),
+        "seed survives"
+    );
+    assert_eq!(
+        decoded_summary.commit_fingerprints(),
+        original_summary.commit_fingerprints(),
+        "commit fingerprint set survives byte-identically"
+    );
+    assert_eq!(
+        decoded_summary.fragment_fingerprints(),
+        original_summary.fragment_fingerprints(),
+        "fragment fingerprint set survives byte-identically"
+    );
+}
+
+/// **The strongest version of the user's question.** Encode a summary
+/// computed by the requester, decode it on the responder, then have the
+/// responder fingerprint *its own commits* using the decoded seed and
+/// check those match the requester's fingerprints for shared commits.
+///
+/// If this fails: the seed transport is broken, OR
+/// `Fingerprint::new(seed, x)` is non-deterministic. Either way, the
+/// "N missing, requesting N" symptom is explained.
+#[test]
+fn after_round_trip_responder_fingerprints_match_requesters_for_shared_commits() {
+    let seed = FingerprintSeed::new(0xAA_BB_CC_DD_11_22_33_44, 0xCAFE_BABE_DEAD_BEEF);
+
+    // Requester's tree
+    let requester_tree = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+    let requester_summary = requester_tree.fingerprint_summarize(&seed);
+
+    // Responder's tree happens to have the same 3 commits (post-sync)
+    let responder_tree = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+
+    // Wire round-trip the summary
+    let req = make_request(requester_summary.clone());
+    let decoded = encode_decode_request(&req);
+    let decoded_summary = decoded.fingerprint_summary;
+
+    // Responder computes its fingerprints with the *decoded* seed
+    let decoded_seed = decoded_summary.seed();
+    let responder_commit_fps: BTreeSet<Fingerprint<CommitId>> = responder_tree
+        .loose_commits()
+        .map(|c| Fingerprint::new(decoded_seed, &c.head()))
+        .collect();
+
+    // The two sets must be identical: requester's fps decoded from the
+    // wire == responder's fps computed locally with the same seed.
+    assert_eq!(
+        &responder_commit_fps,
+        decoded_summary.commit_fingerprints(),
+        "responder fps (using decoded seed) MUST match decoded fps from \
+         requester. If this assertion fails, either the seed didn't \
+         round-trip or Fingerprint::new is non-deterministic — both \
+         would produce the 'N missing, requesting N' bug."
+    );
+}
+
+/// Same as the above but with a `diff_remote_fingerprints` call — the
+/// end-to-end path the protocol actually uses.
+#[test]
+fn diff_against_round_tripped_summary_finds_full_overlap_when_data_matches() {
+    let seed = FingerprintSeed::new(123, 456);
+
+    let shared_commits = vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ];
+    let requester_tree = tree_of(shared_commits.clone());
+    let responder_tree = tree_of(shared_commits);
+
+    let req = make_request(requester_tree.fingerprint_summarize(&seed));
+    let decoded = encode_decode_request(&req);
+    let diff = responder_tree.diff_remote_fingerprints(&decoded.fingerprint_summary);
+
+    assert!(
+        diff.local_only_commits.is_empty(),
+        "identical data + round-tripped summary: nothing should be local-only, \
+         got {} commits — this would mean the seed broke transport",
+        diff.local_only_commits.len(),
+    );
+    assert!(
+        diff.remote_only_commit_fingerprints.is_empty(),
+        "identical data + round-tripped summary: no fingerprints should be \
+         remote-only, got {} — this would mean the seed broke transport",
+        diff.remote_only_commit_fingerprints.len(),
+    );
+}
+
+/// Same diff result before vs. after the codec round-trip. Catches
+/// any subtle codec asymmetry that doesn't show up as a byte-identity
+/// failure (e.g., if `BTreeSet` ordering or duplicate filtering
+/// differs).
+#[test]
+fn diff_result_is_invariant_under_codec_round_trip() {
+    let seed = FingerprintSeed::new(0xABCD, 0xEF01);
+
+    // Requester has commits 1, 2, 3, 4. Responder has 1, 2, 5, 6.
+    // Two are shared (1, 2), each has 2 unique.
+    let requester_tree = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+        commit(4, &[head(3)]),
+    ]);
+    let responder_tree = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(5, &[head(2)]),
+        commit(6, &[head(5)]),
+    ]);
+
+    let original_summary = requester_tree.fingerprint_summarize(&seed);
+
+    // Diff against the ORIGINAL summary (no codec)
+    let direct_diff = responder_tree.diff_remote_fingerprints(&original_summary);
+
+    // Diff against the ROUND-TRIPPED summary
+    let req = make_request(original_summary);
+    let decoded = encode_decode_request(&req);
+    let codec_diff = responder_tree.diff_remote_fingerprints(&decoded.fingerprint_summary);
+
+    let direct_local_only_ids: BTreeSet<CommitId> = direct_diff
+        .local_only_commits
+        .iter()
+        .map(|(id, _)| **id)
+        .collect();
+    let codec_local_only_ids: BTreeSet<CommitId> = codec_diff
+        .local_only_commits
+        .iter()
+        .map(|(id, _)| **id)
+        .collect();
+    assert_eq!(
+        direct_local_only_ids, codec_local_only_ids,
+        "round-trip must not change which local commits are flagged as missing"
+    );
+
+    let direct_remote_only: BTreeSet<Fingerprint<CommitId>> =
+        direct_diff.remote_only_commit_fingerprints.iter().copied().collect();
+    let codec_remote_only: BTreeSet<Fingerprint<CommitId>> =
+        codec_diff.remote_only_commit_fingerprints.iter().copied().collect();
+    assert_eq!(
+        direct_remote_only, codec_remote_only,
+        "round-trip must not change the echoed-back fingerprint set"
+    );
+}
+
+// ============================================================================
+// Section 2: Fingerprint::new is deterministic given the same inputs
+// ============================================================================
+
+/// **The most fundamental invariant.** `Fingerprint::new(seed, value)`
+/// must produce the same `u64` every time given the same inputs.
+#[test]
+fn fingerprint_new_is_deterministic_for_fixed_seed_and_value() {
+    let seed = FingerprintSeed::new(7, 11);
+    let id = head(42);
+
+    let fp1: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
+    let fp2: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
+    let fp3: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
+
+    assert_eq!(fp1, fp2);
+    assert_eq!(fp2, fp3);
+    assert_eq!(fp1.as_u64(), fp2.as_u64());
+}
+
+/// Different seeds produce different fingerprints (with extremely high
+/// probability; collisions are ~2^-64).
+#[test]
+fn different_seeds_produce_different_fingerprints() {
+    let id = head(42);
+    let seed_a = FingerprintSeed::new(1, 2);
+    let seed_b = FingerprintSeed::new(3, 4);
+
+    let fp_a: Fingerprint<CommitId> = Fingerprint::new(&seed_a, &id);
+    let fp_b: Fingerprint<CommitId> = Fingerprint::new(&seed_b, &id);
+
+    assert_ne!(
+        fp_a, fp_b,
+        "different seeds should produce different fingerprints for the same value"
+    );
+}
+
+/// Same seed, different values → different fingerprints.
+#[test]
+fn different_values_produce_different_fingerprints() {
+    let seed = FingerprintSeed::new(7, 11);
+    let id_a = head(1);
+    let id_b = head(2);
+
+    let fp_a: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_a);
+    let fp_b: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_b);
+
+    assert_ne!(fp_a, fp_b);
+}
+
+/// CommitId bytes round-trip through `as_bytes()` and `CommitId::new`
+/// produce a CommitId with the same hash.
+#[test]
+fn commit_id_bytes_round_trip_preserve_fingerprint() {
+    let original = head(99);
+    let bytes = *original.as_bytes();
+    let reconstructed = CommitId::new(bytes);
+
+    assert_eq!(original, reconstructed);
+
+    let seed = FingerprintSeed::new(123, 456);
+    let fp_original: Fingerprint<CommitId> = Fingerprint::new(&seed, &original);
+    let fp_reconstructed: Fingerprint<CommitId> = Fingerprint::new(&seed, &reconstructed);
+    assert_eq!(fp_original, fp_reconstructed);
+}
+
+// ============================================================================
+// Section 3: Adversarial / corrupt-seed scenarios
+// ============================================================================
+
+/// **What if a buggy peer sent a summary whose seed doesn't match its
+/// fingerprints?** I.e. the summary's fingerprints were computed with
+/// seed S1, but the summary's seed field claims S2. This is exactly
+/// the "wrong seed" scenario the user is asking about.
+///
+/// We construct that situation manually and confirm: the responder's
+/// diff produces the disjoint-sets pattern ("N missing, requesting N"),
+/// exactly matching the bug shape.
+#[test]
+fn summary_with_mismatched_seed_produces_full_disjoint_diff() {
+    let real_seed = FingerprintSeed::new(0xAAAA_AAAA_AAAA_AAAA, 0xBBBB_BBBB_BBBB_BBBB);
+    let claimed_seed = FingerprintSeed::new(0xCCCC_CCCC_CCCC_CCCC, 0xDDDD_DDDD_DDDD_DDDD);
+
+    // Requester computes fingerprints with the REAL seed
+    let requester_tree = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+    let real_summary = requester_tree.fingerprint_summarize(&real_seed);
+
+    // Manually construct a corrupt summary: same fingerprints, but the
+    // seed field claims to be `claimed_seed` instead of `real_seed`.
+    let corrupt_summary = FingerprintSummary::new(
+        claimed_seed,
+        real_summary.commit_fingerprints().clone(),
+        real_summary.fragment_fingerprints().clone(),
+    );
+
+    // Responder has the SAME tree as requester
+    let responder_tree = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+
+    let diff = responder_tree.diff_remote_fingerprints(&corrupt_summary);
+
+    // Because the responder hashes its commits with `claimed_seed` (the
+    // wrong seed) and compares to fingerprints computed with `real_seed`,
+    // every local commit appears as local-only AND every remote
+    // fingerprint appears as remote-only.
+    assert_eq!(
+        diff.local_only_commits.len(),
+        3,
+        "mismatched seed reproduces the 'N missing' symptom: \
+         responder thinks all {} of its commits are unknown to requester",
+        diff.local_only_commits.len(),
+    );
+    assert_eq!(
+        diff.remote_only_commit_fingerprints.len(),
+        3,
+        "mismatched seed reproduces the 'requesting N' symptom: \
+         responder thinks none of requester's {} fps match anything",
+        diff.remote_only_commit_fingerprints.len(),
+    );
+}
+
+/// Sanity check on the corrupt-seed scenario: when the seed field is
+/// correct (same on both sides) AND the tree contents match, the diff
+/// is empty. This confirms the corruption test above isolates the seed
+/// as the variable.
+#[test]
+fn matching_seed_and_identical_data_produces_empty_diff() {
+    let seed = FingerprintSeed::new(123, 456);
+
+    let tree_a = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+    let tree_b = tree_of(vec![
+        commit(1, &[]),
+        commit(2, &[head(1)]),
+        commit(3, &[head(2)]),
+    ]);
+
+    let summary_a = tree_a.fingerprint_summarize(&seed);
+    let diff = tree_b.diff_remote_fingerprints(&summary_a);
+
+    assert!(diff.local_only_commits.is_empty());
+    assert!(diff.remote_only_commit_fingerprints.is_empty());
+}

--- a/subduction_core/tests/seed_round_trip.rs
+++ b/subduction_core/tests/seed_round_trip.rs
@@ -1,8 +1,6 @@
-//! Wire-codec round-trip for `FingerprintSeed` and `FingerprintSummary`:
-//! the seed and fingerprint bytes inside a `BatchSyncRequest` must
-//! survive encode-then-decode byte-identically, and a responder that
-//! computes its own fingerprints under the decoded seed must agree with
-//! the requester's for shared commits.
+//! Targeted seed/fingerprint sanity checks. Codec round-trip and diff
+//! invariance are covered by `tests/sync_codec_props.rs` (bolero) and
+//! `subduction_core::connection::message::proptests::prop_message_codec_roundtrip`.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
 
@@ -14,10 +12,6 @@ use sedimentree_core::{
     id::SedimentreeId,
     loose_commit::{LooseCommit, id::CommitId},
     sedimentree::{FingerprintSummary, Sedimentree},
-};
-use subduction_core::{
-    connection::message::{BatchSyncRequest, RequestId, SyncMessage},
-    peer::id::PeerId,
 };
 
 const SED_ID: SedimentreeId = SedimentreeId::new([42u8; 32]);
@@ -42,187 +36,6 @@ fn tree_of(commits: Vec<LooseCommit>) -> Sedimentree {
     Sedimentree::new(vec![], commits)
 }
 
-fn make_request(summary: FingerprintSummary) -> BatchSyncRequest {
-    BatchSyncRequest {
-        id: SED_ID,
-        req_id: RequestId {
-            requestor: PeerId::new([0xAB; 32]),
-            nonce: 0xDEADBEEF_CAFEF00D,
-        },
-        fingerprint_summary: summary,
-        subscribe: true,
-    }
-}
-
-fn encode_decode_request(req: &BatchSyncRequest) -> BatchSyncRequest {
-    let msg = SyncMessage::BatchSyncRequest(req.clone());
-    let bytes = msg.encode();
-    let decoded = SyncMessage::try_decode(bytes.as_slice()).expect("decode should succeed");
-    match decoded {
-        SyncMessage::BatchSyncRequest(req) => req,
-        other => panic!("expected BatchSyncRequest, got {other:?}"),
-    }
-}
-
-#[test]
-fn seed_round_trips_through_wire_codec() {
-    let seed = FingerprintSeed::new(0x1234_5678_9ABC_DEF0, 0xFEDC_BA98_7654_3210);
-    let summary = FingerprintSummary::new(seed, BTreeSet::new(), BTreeSet::new());
-    let req = make_request(summary);
-
-    let decoded = encode_decode_request(&req);
-    let decoded_seed = decoded.fingerprint_summary.seed();
-
-    assert_eq!(decoded_seed.key0(), 0x1234_5678_9ABC_DEF0);
-    assert_eq!(decoded_seed.key1(), 0xFEDC_BA98_7654_3210);
-    assert_eq!(decoded_seed, &seed);
-}
-
-#[test]
-fn fingerprint_values_round_trip_through_wire_codec() {
-    let seed = FingerprintSeed::new(11, 22);
-    let local = tree_of(vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(3, &[head(2)]),
-    ]);
-    let original_summary = local.fingerprint_summarize(&seed);
-
-    let req = make_request(original_summary.clone());
-    let decoded = encode_decode_request(&req);
-    let decoded_summary = decoded.fingerprint_summary;
-
-    assert_eq!(decoded_summary.seed(), original_summary.seed());
-    assert_eq!(
-        decoded_summary.commit_fingerprints(),
-        original_summary.commit_fingerprints(),
-    );
-    assert_eq!(
-        decoded_summary.fragment_fingerprints(),
-        original_summary.fragment_fingerprints(),
-    );
-}
-
-/// Decoded summary's fingerprints (computed by requester) must match
-/// fingerprints the responder computes locally using the decoded seed.
-/// If this fails, either the seed didn't round-trip or `Fingerprint::new`
-/// has hidden state — either way the "N missing, requesting N" symptom
-/// would result.
-#[test]
-fn after_round_trip_responder_fingerprints_match_requesters_for_shared_commits() {
-    let seed = FingerprintSeed::new(0xAA_BB_CC_DD_11_22_33_44, 0xCAFE_BABE_DEAD_BEEF);
-
-    let requester_tree = tree_of(vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(3, &[head(2)]),
-    ]);
-    let requester_summary = requester_tree.fingerprint_summarize(&seed);
-
-    let responder_tree = tree_of(vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(3, &[head(2)]),
-    ]);
-
-    let req = make_request(requester_summary.clone());
-    let decoded = encode_decode_request(&req);
-    let decoded_summary = decoded.fingerprint_summary;
-
-    let decoded_seed = decoded_summary.seed();
-    let responder_commit_fps: BTreeSet<Fingerprint<CommitId>> = responder_tree
-        .loose_commits()
-        .map(|c| Fingerprint::new(decoded_seed, &c.head()))
-        .collect();
-
-    assert_eq!(&responder_commit_fps, decoded_summary.commit_fingerprints());
-}
-
-#[test]
-fn diff_against_round_tripped_summary_finds_full_overlap_when_data_matches() {
-    let seed = FingerprintSeed::new(123, 456);
-
-    let shared_commits = vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(3, &[head(2)]),
-    ];
-    let requester_tree = tree_of(shared_commits.clone());
-    let responder_tree = tree_of(shared_commits);
-
-    let req = make_request(requester_tree.fingerprint_summarize(&seed));
-    let decoded = encode_decode_request(&req);
-    let diff = responder_tree.diff_remote_fingerprints(&decoded.fingerprint_summary);
-
-    assert!(diff.local_only_commits.is_empty());
-    assert!(diff.remote_only_commit_fingerprints.is_empty());
-}
-
-/// The codec must not change the diff result. Catches asymmetries that
-/// don't show up as byte-identity failures (e.g. ordering, duplicate
-/// filtering).
-#[test]
-fn diff_result_is_invariant_under_codec_round_trip() {
-    let seed = FingerprintSeed::new(0xABCD, 0xEF01);
-
-    let requester_tree = tree_of(vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(3, &[head(2)]),
-        commit(4, &[head(3)]),
-    ]);
-    let responder_tree = tree_of(vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(5, &[head(2)]),
-        commit(6, &[head(5)]),
-    ]);
-
-    let original_summary = requester_tree.fingerprint_summarize(&seed);
-    let direct_diff = responder_tree.diff_remote_fingerprints(&original_summary);
-
-    let req = make_request(original_summary);
-    let decoded = encode_decode_request(&req);
-    let codec_diff = responder_tree.diff_remote_fingerprints(&decoded.fingerprint_summary);
-
-    let direct_local_only_ids: BTreeSet<CommitId> = direct_diff
-        .local_only_commits
-        .iter()
-        .map(|(id, _)| **id)
-        .collect();
-    let codec_local_only_ids: BTreeSet<CommitId> = codec_diff
-        .local_only_commits
-        .iter()
-        .map(|(id, _)| **id)
-        .collect();
-    assert_eq!(direct_local_only_ids, codec_local_only_ids);
-
-    let direct_remote_only: BTreeSet<Fingerprint<CommitId>> = direct_diff
-        .remote_only_commit_fingerprints
-        .iter()
-        .copied()
-        .collect();
-    let codec_remote_only: BTreeSet<Fingerprint<CommitId>> = codec_diff
-        .remote_only_commit_fingerprints
-        .iter()
-        .copied()
-        .collect();
-    assert_eq!(direct_remote_only, codec_remote_only);
-}
-
-#[test]
-fn fingerprint_new_is_deterministic_for_fixed_seed_and_value() {
-    let seed = FingerprintSeed::new(7, 11);
-    let id = head(42);
-
-    let fp1: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
-    let fp2: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
-    let fp3: Fingerprint<CommitId> = Fingerprint::new(&seed, &id);
-
-    assert_eq!(fp1, fp2);
-    assert_eq!(fp2, fp3);
-}
-
 #[test]
 fn different_seeds_produce_different_fingerprints() {
     let id = head(42);
@@ -244,13 +57,14 @@ fn different_values_produce_different_fingerprints() {
     assert_ne!(fp_a, fp_b);
 }
 
+/// `Fingerprint::new(seed, x)` depends only on `x`'s 32 raw bytes — it
+/// must not be sensitive to any hidden state on `CommitId`.
 #[test]
-fn commit_id_bytes_round_trip_preserve_fingerprint() {
+fn fingerprint_depends_only_on_commit_id_bytes() {
+    let seed = FingerprintSeed::new(123, 456);
     let original = head(99);
     let reconstructed = CommitId::new(*original.as_bytes());
-    assert_eq!(original, reconstructed);
 
-    let seed = FingerprintSeed::new(123, 456);
     let fp_original: Fingerprint<CommitId> = Fingerprint::new(&seed, &original);
     let fp_reconstructed: Fingerprint<CommitId> = Fingerprint::new(&seed, &reconstructed);
     assert_eq!(fp_original, fp_reconstructed);
@@ -258,7 +72,7 @@ fn commit_id_bytes_round_trip_preserve_fingerprint() {
 
 /// A buggy peer sending a summary whose seed field doesn't match the
 /// seed actually used to compute the fingerprints produces a fully
-/// disjoint diff — exactly the user's bug shape, isolated to the seed.
+/// disjoint diff, isolating the seed as the failure dimension.
 #[test]
 fn summary_with_mismatched_seed_produces_full_disjoint_diff() {
     let real_seed = FingerprintSeed::new(0xAAAA_AAAA_AAAA_AAAA, 0xBBBB_BBBB_BBBB_BBBB);
@@ -288,26 +102,4 @@ fn summary_with_mismatched_seed_produces_full_disjoint_diff() {
 
     assert_eq!(diff.local_only_commits.len(), 3);
     assert_eq!(diff.remote_only_commit_fingerprints.len(), 3);
-}
-
-#[test]
-fn matching_seed_and_identical_data_produces_empty_diff() {
-    let seed = FingerprintSeed::new(123, 456);
-
-    let tree_a = tree_of(vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(3, &[head(2)]),
-    ]);
-    let tree_b = tree_of(vec![
-        commit(1, &[]),
-        commit(2, &[head(1)]),
-        commit(3, &[head(2)]),
-    ]);
-
-    let summary_a = tree_a.fingerprint_summarize(&seed);
-    let diff = tree_b.diff_remote_fingerprints(&summary_a);
-
-    assert!(diff.local_only_commits.is_empty());
-    assert!(diff.remote_only_commit_fingerprints.is_empty());
 }

--- a/subduction_core/tests/seed_round_trip.rs
+++ b/subduction_core/tests/seed_round_trip.rs
@@ -1,25 +1,8 @@
-//! **Wire-codec round-trip tests for `FingerprintSeed` and
-//! `FingerprintSummary`** — answers the question "could the seed be
-//! mis-encoded, or could the responder be using a different seed than
-//! the one in the summary?"
-//!
-//! The diff layer documents this invariant: the responder must
-//! fingerprint its own items using `remote.seed()` (the seed field of
-//! the incoming `FingerprintSummary`), and the fingerprints inside that
-//! summary were computed by the requester using the same seed. If
-//! either side computes with a different seed, the sets are disjoint
-//! and we see the "N missing, requesting N" symptom.
-//!
-//! These tests pin down that:
-//!
-//! 1. The wire codec encodes and decodes the seed byte-identically.
-//! 2. The fingerprints inside a `FingerprintSummary` survive the
-//!    round-trip byte-identically.
-//! 3. After a round-trip, the responder's diff against the decoded
-//!    summary produces the identical result it would have produced
-//!    against the original summary.
-//! 4. Two peers running the same code, given the same `CommitId`
-//!    bytes and the same seed, always compute the same fingerprint.
+//! Wire-codec round-trip for `FingerprintSeed` and `FingerprintSummary`:
+//! the seed and fingerprint bytes inside a `BatchSyncRequest` must
+//! survive encode-then-decode byte-identically, and a responder that
+//! computes its own fingerprints under the decoded seed must agree with
+//! the requester's for shared commits.
 
 #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
 
@@ -81,12 +64,6 @@ fn encode_decode_request(req: &BatchSyncRequest) -> BatchSyncRequest {
     }
 }
 
-// ============================================================================
-// Section 1: seed and fingerprint bytes survive the wire codec
-// ============================================================================
-
-/// The seed encoded into a `BatchSyncRequest` must decode back to the
-/// same `FingerprintSeed`. Plain round-trip test.
 #[test]
 fn seed_round_trips_through_wire_codec() {
     let seed = FingerprintSeed::new(0x1234_5678_9ABC_DEF0, 0xFEDC_BA98_7654_3210);
@@ -98,12 +75,9 @@ fn seed_round_trips_through_wire_codec() {
 
     assert_eq!(decoded_seed.key0(), 0x1234_5678_9ABC_DEF0);
     assert_eq!(decoded_seed.key1(), 0xFEDC_BA98_7654_3210);
-    assert_eq!(decoded_seed, &seed, "seed must round-trip byte-identically");
+    assert_eq!(decoded_seed, &seed);
 }
 
-/// Every fingerprint value in the summary must survive the wire codec
-/// byte-identically. If even one bit flips, the set difference at the
-/// receiver yields wrong results.
 #[test]
 fn fingerprint_values_round_trip_through_wire_codec() {
     let seed = FingerprintSeed::new(11, 22);
@@ -118,36 +92,26 @@ fn fingerprint_values_round_trip_through_wire_codec() {
     let decoded = encode_decode_request(&req);
     let decoded_summary = decoded.fingerprint_summary;
 
-    assert_eq!(
-        decoded_summary.seed(),
-        original_summary.seed(),
-        "seed survives"
-    );
+    assert_eq!(decoded_summary.seed(), original_summary.seed());
     assert_eq!(
         decoded_summary.commit_fingerprints(),
         original_summary.commit_fingerprints(),
-        "commit fingerprint set survives byte-identically"
     );
     assert_eq!(
         decoded_summary.fragment_fingerprints(),
         original_summary.fragment_fingerprints(),
-        "fragment fingerprint set survives byte-identically"
     );
 }
 
-/// **The strongest version of the user's question.** Encode a summary
-/// computed by the requester, decode it on the responder, then have the
-/// responder fingerprint *its own commits* using the decoded seed and
-/// check those match the requester's fingerprints for shared commits.
-///
-/// If this fails: the seed transport is broken, OR
-/// `Fingerprint::new(seed, x)` is non-deterministic. Either way, the
-/// "N missing, requesting N" symptom is explained.
+/// Decoded summary's fingerprints (computed by requester) must match
+/// fingerprints the responder computes locally using the decoded seed.
+/// If this fails, either the seed didn't round-trip or `Fingerprint::new`
+/// has hidden state — either way the "N missing, requesting N" symptom
+/// would result.
 #[test]
 fn after_round_trip_responder_fingerprints_match_requesters_for_shared_commits() {
     let seed = FingerprintSeed::new(0xAA_BB_CC_DD_11_22_33_44, 0xCAFE_BABE_DEAD_BEEF);
 
-    // Requester's tree
     let requester_tree = tree_of(vec![
         commit(1, &[]),
         commit(2, &[head(1)]),
@@ -155,39 +119,25 @@ fn after_round_trip_responder_fingerprints_match_requesters_for_shared_commits()
     ]);
     let requester_summary = requester_tree.fingerprint_summarize(&seed);
 
-    // Responder's tree happens to have the same 3 commits (post-sync)
     let responder_tree = tree_of(vec![
         commit(1, &[]),
         commit(2, &[head(1)]),
         commit(3, &[head(2)]),
     ]);
 
-    // Wire round-trip the summary
     let req = make_request(requester_summary.clone());
     let decoded = encode_decode_request(&req);
     let decoded_summary = decoded.fingerprint_summary;
 
-    // Responder computes its fingerprints with the *decoded* seed
     let decoded_seed = decoded_summary.seed();
     let responder_commit_fps: BTreeSet<Fingerprint<CommitId>> = responder_tree
         .loose_commits()
         .map(|c| Fingerprint::new(decoded_seed, &c.head()))
         .collect();
 
-    // The two sets must be identical: requester's fps decoded from the
-    // wire == responder's fps computed locally with the same seed.
-    assert_eq!(
-        &responder_commit_fps,
-        decoded_summary.commit_fingerprints(),
-        "responder fps (using decoded seed) MUST match decoded fps from \
-         requester. If this assertion fails, either the seed didn't \
-         round-trip or Fingerprint::new is non-deterministic — both \
-         would produce the 'N missing, requesting N' bug."
-    );
+    assert_eq!(&responder_commit_fps, decoded_summary.commit_fingerprints());
 }
 
-/// Same as the above but with a `diff_remote_fingerprints` call — the
-/// end-to-end path the protocol actually uses.
 #[test]
 fn diff_against_round_tripped_summary_finds_full_overlap_when_data_matches() {
     let seed = FingerprintSeed::new(123, 456);
@@ -204,30 +154,17 @@ fn diff_against_round_tripped_summary_finds_full_overlap_when_data_matches() {
     let decoded = encode_decode_request(&req);
     let diff = responder_tree.diff_remote_fingerprints(&decoded.fingerprint_summary);
 
-    assert!(
-        diff.local_only_commits.is_empty(),
-        "identical data + round-tripped summary: nothing should be local-only, \
-         got {} commits — this would mean the seed broke transport",
-        diff.local_only_commits.len(),
-    );
-    assert!(
-        diff.remote_only_commit_fingerprints.is_empty(),
-        "identical data + round-tripped summary: no fingerprints should be \
-         remote-only, got {} — this would mean the seed broke transport",
-        diff.remote_only_commit_fingerprints.len(),
-    );
+    assert!(diff.local_only_commits.is_empty());
+    assert!(diff.remote_only_commit_fingerprints.is_empty());
 }
 
-/// Same diff result before vs. after the codec round-trip. Catches
-/// any subtle codec asymmetry that doesn't show up as a byte-identity
-/// failure (e.g., if `BTreeSet` ordering or duplicate filtering
-/// differs).
+/// The codec must not change the diff result. Catches asymmetries that
+/// don't show up as byte-identity failures (e.g. ordering, duplicate
+/// filtering).
 #[test]
 fn diff_result_is_invariant_under_codec_round_trip() {
     let seed = FingerprintSeed::new(0xABCD, 0xEF01);
 
-    // Requester has commits 1, 2, 3, 4. Responder has 1, 2, 5, 6.
-    // Two are shared (1, 2), each has 2 unique.
     let requester_tree = tree_of(vec![
         commit(1, &[]),
         commit(2, &[head(1)]),
@@ -242,11 +179,8 @@ fn diff_result_is_invariant_under_codec_round_trip() {
     ]);
 
     let original_summary = requester_tree.fingerprint_summarize(&seed);
-
-    // Diff against the ORIGINAL summary (no codec)
     let direct_diff = responder_tree.diff_remote_fingerprints(&original_summary);
 
-    // Diff against the ROUND-TRIPPED summary
     let req = make_request(original_summary);
     let decoded = encode_decode_request(&req);
     let codec_diff = responder_tree.diff_remote_fingerprints(&decoded.fingerprint_summary);
@@ -261,27 +195,21 @@ fn diff_result_is_invariant_under_codec_round_trip() {
         .iter()
         .map(|(id, _)| **id)
         .collect();
-    assert_eq!(
-        direct_local_only_ids, codec_local_only_ids,
-        "round-trip must not change which local commits are flagged as missing"
-    );
+    assert_eq!(direct_local_only_ids, codec_local_only_ids);
 
-    let direct_remote_only: BTreeSet<Fingerprint<CommitId>> =
-        direct_diff.remote_only_commit_fingerprints.iter().copied().collect();
-    let codec_remote_only: BTreeSet<Fingerprint<CommitId>> =
-        codec_diff.remote_only_commit_fingerprints.iter().copied().collect();
-    assert_eq!(
-        direct_remote_only, codec_remote_only,
-        "round-trip must not change the echoed-back fingerprint set"
-    );
+    let direct_remote_only: BTreeSet<Fingerprint<CommitId>> = direct_diff
+        .remote_only_commit_fingerprints
+        .iter()
+        .copied()
+        .collect();
+    let codec_remote_only: BTreeSet<Fingerprint<CommitId>> = codec_diff
+        .remote_only_commit_fingerprints
+        .iter()
+        .copied()
+        .collect();
+    assert_eq!(direct_remote_only, codec_remote_only);
 }
 
-// ============================================================================
-// Section 2: Fingerprint::new is deterministic given the same inputs
-// ============================================================================
-
-/// **The most fundamental invariant.** `Fingerprint::new(seed, value)`
-/// must produce the same `u64` every time given the same inputs.
 #[test]
 fn fingerprint_new_is_deterministic_for_fixed_seed_and_value() {
     let seed = FingerprintSeed::new(7, 11);
@@ -293,11 +221,8 @@ fn fingerprint_new_is_deterministic_for_fixed_seed_and_value() {
 
     assert_eq!(fp1, fp2);
     assert_eq!(fp2, fp3);
-    assert_eq!(fp1.as_u64(), fp2.as_u64());
 }
 
-/// Different seeds produce different fingerprints (with extremely high
-/// probability; collisions are ~2^-64).
 #[test]
 fn different_seeds_produce_different_fingerprints() {
     let id = head(42);
@@ -307,33 +232,22 @@ fn different_seeds_produce_different_fingerprints() {
     let fp_a: Fingerprint<CommitId> = Fingerprint::new(&seed_a, &id);
     let fp_b: Fingerprint<CommitId> = Fingerprint::new(&seed_b, &id);
 
-    assert_ne!(
-        fp_a, fp_b,
-        "different seeds should produce different fingerprints for the same value"
-    );
+    assert_ne!(fp_a, fp_b);
 }
 
-/// Same seed, different values → different fingerprints.
 #[test]
 fn different_values_produce_different_fingerprints() {
     let seed = FingerprintSeed::new(7, 11);
-    let id_a = head(1);
-    let id_b = head(2);
-
-    let fp_a: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_a);
-    let fp_b: Fingerprint<CommitId> = Fingerprint::new(&seed, &id_b);
+    let fp_a: Fingerprint<CommitId> = Fingerprint::new(&seed, &head(1));
+    let fp_b: Fingerprint<CommitId> = Fingerprint::new(&seed, &head(2));
 
     assert_ne!(fp_a, fp_b);
 }
 
-/// CommitId bytes round-trip through `as_bytes()` and `CommitId::new`
-/// produce a CommitId with the same hash.
 #[test]
 fn commit_id_bytes_round_trip_preserve_fingerprint() {
     let original = head(99);
-    let bytes = *original.as_bytes();
-    let reconstructed = CommitId::new(bytes);
-
+    let reconstructed = CommitId::new(*original.as_bytes());
     assert_eq!(original, reconstructed);
 
     let seed = FingerprintSeed::new(123, 456);
@@ -342,24 +256,14 @@ fn commit_id_bytes_round_trip_preserve_fingerprint() {
     assert_eq!(fp_original, fp_reconstructed);
 }
 
-// ============================================================================
-// Section 3: Adversarial / corrupt-seed scenarios
-// ============================================================================
-
-/// **What if a buggy peer sent a summary whose seed doesn't match its
-/// fingerprints?** I.e. the summary's fingerprints were computed with
-/// seed S1, but the summary's seed field claims S2. This is exactly
-/// the "wrong seed" scenario the user is asking about.
-///
-/// We construct that situation manually and confirm: the responder's
-/// diff produces the disjoint-sets pattern ("N missing, requesting N"),
-/// exactly matching the bug shape.
+/// A buggy peer sending a summary whose seed field doesn't match the
+/// seed actually used to compute the fingerprints produces a fully
+/// disjoint diff — exactly the user's bug shape, isolated to the seed.
 #[test]
 fn summary_with_mismatched_seed_produces_full_disjoint_diff() {
     let real_seed = FingerprintSeed::new(0xAAAA_AAAA_AAAA_AAAA, 0xBBBB_BBBB_BBBB_BBBB);
     let claimed_seed = FingerprintSeed::new(0xCCCC_CCCC_CCCC_CCCC, 0xDDDD_DDDD_DDDD_DDDD);
 
-    // Requester computes fingerprints with the REAL seed
     let requester_tree = tree_of(vec![
         commit(1, &[]),
         commit(2, &[head(1)]),
@@ -367,15 +271,13 @@ fn summary_with_mismatched_seed_produces_full_disjoint_diff() {
     ]);
     let real_summary = requester_tree.fingerprint_summarize(&real_seed);
 
-    // Manually construct a corrupt summary: same fingerprints, but the
-    // seed field claims to be `claimed_seed` instead of `real_seed`.
+    // Same fingerprints, but the seed field lies.
     let corrupt_summary = FingerprintSummary::new(
         claimed_seed,
         real_summary.commit_fingerprints().clone(),
         real_summary.fragment_fingerprints().clone(),
     );
 
-    // Responder has the SAME tree as requester
     let responder_tree = tree_of(vec![
         commit(1, &[]),
         commit(2, &[head(1)]),
@@ -384,30 +286,10 @@ fn summary_with_mismatched_seed_produces_full_disjoint_diff() {
 
     let diff = responder_tree.diff_remote_fingerprints(&corrupt_summary);
 
-    // Because the responder hashes its commits with `claimed_seed` (the
-    // wrong seed) and compares to fingerprints computed with `real_seed`,
-    // every local commit appears as local-only AND every remote
-    // fingerprint appears as remote-only.
-    assert_eq!(
-        diff.local_only_commits.len(),
-        3,
-        "mismatched seed reproduces the 'N missing' symptom: \
-         responder thinks all {} of its commits are unknown to requester",
-        diff.local_only_commits.len(),
-    );
-    assert_eq!(
-        diff.remote_only_commit_fingerprints.len(),
-        3,
-        "mismatched seed reproduces the 'requesting N' symptom: \
-         responder thinks none of requester's {} fps match anything",
-        diff.remote_only_commit_fingerprints.len(),
-    );
+    assert_eq!(diff.local_only_commits.len(), 3);
+    assert_eq!(diff.remote_only_commit_fingerprints.len(), 3);
 }
 
-/// Sanity check on the corrupt-seed scenario: when the seed field is
-/// correct (same on both sides) AND the tree contents match, the diff
-/// is empty. This confirms the corruption test above isolates the seed
-/// as the variable.
 #[test]
 fn matching_seed_and_identical_data_produces_empty_diff() {
     let seed = FingerprintSeed::new(123, 456);

--- a/subduction_core/tests/sync_codec_props.rs
+++ b/subduction_core/tests/sync_codec_props.rs
@@ -39,10 +39,11 @@ fn tree_from(commits: &[LooseCommit]) -> Sedimentree {
 
 fn codec_roundtrip(req: BatchSyncRequest) -> BatchSyncRequest {
     let bytes = SyncMessage::BatchSyncRequest(req).encode();
-    match SyncMessage::try_decode(&bytes).expect("decode should succeed") {
-        SyncMessage::BatchSyncRequest(r) => r,
-        other => panic!("expected BatchSyncRequest, got {other:?}"),
-    }
+    let decoded = SyncMessage::try_decode(&bytes).expect("decode should succeed");
+    let SyncMessage::BatchSyncRequest(r) = decoded else {
+        panic!("expected BatchSyncRequest, got {decoded:?}");
+    };
+    r
 }
 
 /// `diff_remote_fingerprints` against a decoded summary returns the same

--- a/subduction_core/tests/sync_codec_props.rs
+++ b/subduction_core/tests/sync_codec_props.rs
@@ -1,8 +1,8 @@
 //! Property tests for the `SyncMessage` codec's effect on
 //! `diff_remote_fingerprints`. Byte-identity round-trip is already
 //! covered by `subduction_core::connection::message::proptests` and
-//! `tests/codec_proptest.rs`; what's tested here is the stronger claim
-//! that the codec preserves the *semantic* answer of
+//! `tests/codec_proptest.rs`; what's tested here is the stronger
+//! claim that the codec preserves the *semantic* answer of
 //! `diff_remote_fingerprints`.
 
 #![cfg(feature = "bolero")]

--- a/subduction_core/tests/sync_codec_props.rs
+++ b/subduction_core/tests/sync_codec_props.rs
@@ -1,0 +1,124 @@
+//! Property tests for the `SyncMessage` codec's effect on
+//! `diff_remote_fingerprints`. Byte-identity round-trip is already
+//! covered by `subduction_core::connection::message::proptests` and
+//! `tests/codec_proptest.rs`; what's tested here is the stronger claim
+//! that the codec preserves the *semantic* answer of
+//! `diff_remote_fingerprints`.
+
+#![cfg(feature = "bolero")]
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::collections::BTreeSet;
+
+use sedimentree_core::{
+    crypto::fingerprint::{Fingerprint, FingerprintSeed},
+    loose_commit::{LooseCommit, id::CommitId},
+    sedimentree::Sedimentree,
+};
+use subduction_core::connection::message::{BatchSyncRequest, SyncMessage};
+
+fn close_ancestry(commits: &[LooseCommit]) -> Vec<LooseCommit> {
+    let ids: BTreeSet<CommitId> = commits.iter().map(LooseCommit::head).collect();
+    commits
+        .iter()
+        .map(|c| {
+            let pruned_parents: BTreeSet<CommitId> = c
+                .parents()
+                .iter()
+                .copied()
+                .filter(|p| ids.contains(p))
+                .collect();
+            LooseCommit::new(c.sedimentree_id(), c.head(), pruned_parents, *c.blob_meta())
+        })
+        .collect()
+}
+
+fn tree_from(commits: &[LooseCommit]) -> Sedimentree {
+    Sedimentree::new(vec![], close_ancestry(commits))
+}
+
+fn codec_roundtrip(req: BatchSyncRequest) -> BatchSyncRequest {
+    let bytes = SyncMessage::BatchSyncRequest(req).encode();
+    match SyncMessage::try_decode(&bytes).expect("decode should succeed") {
+        SyncMessage::BatchSyncRequest(r) => r,
+        other => panic!("expected BatchSyncRequest, got {other:?}"),
+    }
+}
+
+/// `diff_remote_fingerprints` against a decoded summary returns the same
+/// answer as against the original summary. Byte-identity of the codec
+/// is not enough — this pins the semantic invariant that callers care
+/// about.
+#[test]
+fn prop_codec_roundtrip_preserves_diff_result() {
+    bolero::check!()
+        .with_arbitrary::<(Vec<LooseCommit>, BatchSyncRequest)>()
+        .for_each(|(responder_commits, request)| {
+            let responder = tree_from(responder_commits);
+
+            let direct = responder.diff_remote_fingerprints(&request.fingerprint_summary);
+            let after_codec_req = codec_roundtrip(request.clone());
+            let codec = responder.diff_remote_fingerprints(&after_codec_req.fingerprint_summary);
+
+            let direct_local: BTreeSet<CommitId> = direct
+                .local_only_commits
+                .iter()
+                .map(|(id, _)| **id)
+                .collect();
+            let codec_local: BTreeSet<CommitId> = codec
+                .local_only_commits
+                .iter()
+                .map(|(id, _)| **id)
+                .collect();
+            assert_eq!(direct_local, codec_local);
+
+            let direct_remote: BTreeSet<Fingerprint<CommitId>> = direct
+                .remote_only_commit_fingerprints
+                .iter()
+                .copied()
+                .collect();
+            let codec_remote: BTreeSet<Fingerprint<CommitId>> = codec
+                .remote_only_commit_fingerprints
+                .iter()
+                .copied()
+                .collect();
+            assert_eq!(direct_remote, codec_remote);
+        });
+}
+
+/// A responder that computes its fingerprints under the seed found in
+/// a decoded `BatchSyncRequest` gets the same fingerprints the requester
+/// included. Catches "the seed travels on the wire but isn't actually
+/// being used end-to-end to compute fingerprints" class of bug.
+#[test]
+fn prop_decoded_seed_yields_matching_fingerprints_for_shared_commits() {
+    bolero::check!()
+        .with_arbitrary::<(Vec<LooseCommit>, FingerprintSeed)>()
+        .for_each(|(commits, seed)| {
+            let tree = tree_from(commits);
+
+            // Encode + decode a summary built from `seed`.
+            let summary = tree.fingerprint_summarize(seed);
+            let dummy_req = BatchSyncRequest {
+                id: sedimentree_core::id::SedimentreeId::new([0; 32]),
+                req_id: subduction_core::connection::message::RequestId {
+                    requestor: subduction_core::peer::id::PeerId::new([0; 32]),
+                    nonce: 0,
+                },
+                fingerprint_summary: summary.clone(),
+                subscribe: false,
+            };
+            let decoded = codec_roundtrip(dummy_req);
+            let decoded_summary = decoded.fingerprint_summary;
+
+            // For every commit the responder has, the fp it computes
+            // under the decoded seed must be in the decoded summary.
+            for commit in tree.loose_commits() {
+                let fp = Fingerprint::new(decoded_summary.seed(), &commit.head());
+                assert!(
+                    decoded_summary.commit_fingerprints().contains(&fp),
+                    "fp computed under decoded seed missing from decoded summary",
+                );
+            }
+        });
+}


### PR DESCRIPTION
It turns out that `Hash` behaves differently on 32- and 64-bit architectures (passes differently padded byte arrays to the hasher... in this case `SipHash`). This was causing a failure to converge on fingerprint-based sync between wasm32 and our 64-bit server :scream: 

This is like a ~30 LOC change with 2k lines of tests so that this NEVER HAPPENS AGAIN :sweat_smile: 