### PR TITLE
More descriptive names for generics

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -66,7 +66,12 @@ timeout_multiplier = 2.0
 # kill legitimate mutant tests early.
 minimum_test_timeout = 60
 
-# Pass `--features arbitrary` so bolero-driven property tests run
-# during mutation testing. Without this, ~half the proptest coverage is
-# silently disabled and survivors balloon.
-additional_cargo_test_args = ["--features", "arbitrary"]
+# Pass `--features arbitrary,metrics` so:
+#   - bolero-driven property tests run during mutation testing.
+#     Without `arbitrary`, ~half the proptest coverage is silently
+#     disabled and survivors balloon.
+#   - feature-gated metrics-storage tests run. Without `metrics`,
+#     `subduction_core/tests/metrics_storage.rs` (which covers the
+#     `MetricsStorage` wrapper delegation paths) is skipped and ~40
+#     mutants in `subduction_core/src/storage/metrics.rs` survive.
+additional_cargo_test_args = ["--features", "arbitrary,metrics"]

--- a/subduction_core/src/authenticated.rs
+++ b/subduction_core/src/authenticated.rs
@@ -1,6 +1,6 @@
 //! Authenticated connection wrapper.
 //!
-//! Provides [`Authenticated<C, K>`], a witness type proving that a connection
+//! Provides [`Authenticated<Conn, Async>`], a witness type proving that a connection
 //! has completed cryptographic handshake verification.
 
 use core::marker::PhantomData;
@@ -21,8 +21,8 @@ use crate::{
 ///
 /// # Type Parameters
 ///
-/// * `C` — The connection type (struct bound relaxed to `Clone`)
-/// * `K` — The [`FutureForm`] (e.g., [`Sendable`] or [`Local`])
+/// * `Conn` — The connection type (struct bound relaxed to `Clone`)
+/// * `Async` — The [`FutureForm`] (e.g., [`Sendable`] or [`Local`])
 ///
 /// [`Sendable`]: future_form::Sendable
 /// [`Local`]: future_form::Local
@@ -34,13 +34,13 @@ use crate::{
 ///
 /// [`handshake::initiate`]: super::handshake::initiate
 /// [`handshake::respond`]: super::handshake::respond
-pub struct Authenticated<C: Clone, K: FutureForm> {
-    inner: C,
+pub struct Authenticated<Conn: Clone, Async: FutureForm> {
+    inner: Conn,
     peer_id: PeerId,
-    _marker: PhantomData<fn() -> K>,
+    _marker: PhantomData<fn() -> Async>,
 }
 
-impl<C: Clone, K: FutureForm> Clone for Authenticated<C, K> {
+impl<Conn: Clone, Async: FutureForm> Clone for Authenticated<Conn, Async> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -50,13 +50,15 @@ impl<C: Clone, K: FutureForm> Clone for Authenticated<C, K> {
     }
 }
 
-impl<C: Clone + PartialEq, K: FutureForm> PartialEq for Authenticated<C, K> {
+impl<Conn: Clone + PartialEq, Async: FutureForm> PartialEq for Authenticated<Conn, Async> {
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner
     }
 }
 
-impl<C: Clone + core::fmt::Debug, K: FutureForm> core::fmt::Debug for Authenticated<C, K> {
+impl<Conn: Clone + core::fmt::Debug, Async: FutureForm> core::fmt::Debug
+    for Authenticated<Conn, Async>
+{
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Authenticated")
             .field("peer_id", &self.peer_id)
@@ -65,7 +67,7 @@ impl<C: Clone + core::fmt::Debug, K: FutureForm> core::fmt::Debug for Authentica
     }
 }
 
-impl<C: Clone, K: FutureForm> Authenticated<C, K> {
+impl<Conn: Clone, Async: FutureForm> Authenticated<Conn, Async> {
     /// Construct from a successful handshake.
     ///
     /// This is only accessible within the `connection` module.
@@ -74,7 +76,7 @@ impl<C: Clone, K: FutureForm> Authenticated<C, K> {
     ///
     /// [`handshake::initiate`]: super::handshake::initiate
     /// [`handshake::respond`]: super::handshake::respond
-    pub(crate) fn from_handshake(inner: C, peer_id: PeerId) -> Self {
+    pub(crate) fn from_handshake(inner: Conn, peer_id: PeerId) -> Self {
         Self {
             inner,
             peer_id,
@@ -93,7 +95,7 @@ impl<C: Clone, K: FutureForm> Authenticated<C, K> {
     /// type (e.g., `WebSocket` → `UnifiedWebSocket`) while preserving the
     /// proof that the underlying connection completed handshake verification.
     #[must_use]
-    pub fn map<D: Clone>(self, f: impl FnOnce(C) -> D) -> Authenticated<D, K> {
+    pub fn map<D: Clone>(self, f: impl FnOnce(Conn) -> D) -> Authenticated<D, Async> {
         Authenticated {
             inner: f(self.inner),
             peer_id: self.peer_id,
@@ -105,7 +107,7 @@ impl<C: Clone, K: FutureForm> Authenticated<C, K> {
     ///
     /// This bypasses handshake verification and should only be used in tests.
     #[cfg(any(test, feature = "test_utils"))]
-    pub fn new_for_test(inner: C, peer_id: PeerId) -> Self {
+    pub fn new_for_test(inner: Conn, peer_id: PeerId) -> Self {
         Self {
             inner,
             peer_id,
@@ -114,44 +116,44 @@ impl<C: Clone, K: FutureForm> Authenticated<C, K> {
     }
 
     /// Access the inner connection.
-    pub const fn inner(&self) -> &C {
+    pub const fn inner(&self) -> &Conn {
         &self.inner
     }
 
     /// Consume and return the inner connection.
-    pub fn into_inner(self) -> C {
+    pub fn into_inner(self) -> Conn {
         self.inner
     }
 }
 
 // ── Delegation impls ────────────────────────────────────────────────────
 
-impl<C: Connection<K, M>, K: FutureForm, M: Encode + Decode> Connection<K, M>
-    for Authenticated<C, K>
+impl<Conn: Connection<Async, WireMsg>, Async: FutureForm, WireMsg: Encode + Decode>
+    Connection<Async, WireMsg> for Authenticated<Conn, Async>
 {
-    type DisconnectionError = C::DisconnectionError;
-    type SendError = C::SendError;
-    type RecvError = C::RecvError;
+    type DisconnectionError = Conn::DisconnectionError;
+    type SendError = Conn::SendError;
+    type RecvError = Conn::RecvError;
 
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>> {
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>> {
         self.inner.disconnect()
     }
 
-    fn send(&self, message: &M) -> K::Future<'_, Result<(), Self::SendError>> {
+    fn send(&self, message: &WireMsg) -> Async::Future<'_, Result<(), Self::SendError>> {
         self.inner.send(message)
     }
 
-    fn recv(&self) -> K::Future<'_, Result<M, Self::RecvError>> {
+    fn recv(&self) -> Async::Future<'_, Result<WireMsg, Self::RecvError>> {
         self.inner.recv()
     }
 }
 
-impl<C: Reconnect<K, M>, K: FutureForm, M: Encode + Decode> Reconnect<K, M>
-    for Authenticated<C, K>
+impl<Conn: Reconnect<Async, WireMsg>, Async: FutureForm, WireMsg: Encode + Decode>
+    Reconnect<Async, WireMsg> for Authenticated<Conn, Async>
 {
-    type ReconnectionError = C::ReconnectionError;
+    type ReconnectionError = Conn::ReconnectionError;
 
-    fn reconnect(&mut self) -> K::Future<'_, Result<(), Self::ReconnectionError>> {
+    fn reconnect(&mut self) -> Async::Future<'_, Result<(), Self::ReconnectionError>> {
         self.inner.reconnect()
     }
 

--- a/subduction_core/src/connection.rs
+++ b/subduction_core/src/connection.rs
@@ -80,7 +80,9 @@ where
 ///
 /// Connections implementing this trait can be automatically reconnected
 /// by the connection manager when they drop unexpectedly.
-pub trait Reconnect<Async: FutureForm, WireMsg: Encode + Decode>: Connection<Async, WireMsg> {
+pub trait Reconnect<Async: FutureForm, WireMsg: Encode + Decode>:
+    Connection<Async, WireMsg>
+{
     /// A problem when reconnecting.
     type ReconnectionError: core::error::Error + Send + 'static;
 

--- a/subduction_core/src/connection.rs
+++ b/subduction_core/src/connection.rs
@@ -1,6 +1,6 @@
 //! Manage connections to peers in the network.
 //!
-//! [`Connection<K, M>`] models fire-and-forget cast + async recv (mailbox).
+//! [`Connection<Async, WireMsg>`] models fire-and-forget cast + async recv (mailbox).
 //! Transports implement this trait via [`MessageTransport`](crate::transport::message::MessageTransport).
 
 pub mod backoff;
@@ -21,13 +21,15 @@ use thiserror::Error;
 
 /// Fire-and-forget messaging (cast) and async receive (mailbox).
 ///
-/// The message type `M` must know how to encode/decode itself to bytes.
-/// Transports call `msg.encode()` in send and `M::try_decode(bytes)` in
-/// recv — they never need to know what `M` _is_.
+/// The message type `WireMsg` must know how to encode/decode itself to bytes.
+/// Transports call `msg.encode()` in send and `WireMsg::try_decode(bytes)` in
+/// recv — they never need to know what `WireMsg` _is_.
 ///
 /// It is assumed that a [`Connection`] is authenticated to a particular peer.
 /// Encrypting this channel is also strongly recommended.
-pub trait Connection<K: FutureForm + ?Sized, M: Encode + Decode>: Clone + PartialEq {
+pub trait Connection<Async: FutureForm + ?Sized, WireMsg: Encode + Decode>:
+    Clone + PartialEq
+{
     /// A problem when gracefully disconnecting.
     type DisconnectionError: core::error::Error;
 
@@ -38,36 +40,36 @@ pub trait Connection<K: FutureForm + ?Sized, M: Encode + Decode>: Clone + Partia
     type RecvError: core::error::Error;
 
     /// Disconnect from the peer gracefully.
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>>;
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>>;
 
     /// Send a message (fire-and-forget).
-    fn send(&self, message: &M) -> K::Future<'_, Result<(), Self::SendError>>;
+    fn send(&self, message: &WireMsg) -> Async::Future<'_, Result<(), Self::SendError>>;
 
     /// Receive the next message from the peer.
-    fn recv(&self) -> K::Future<'_, Result<M, Self::RecvError>>;
+    fn recv(&self) -> Async::Future<'_, Result<WireMsg, Self::RecvError>>;
 }
 
 // ── Blanket impls for Arc<T> ────────────────────────────────────────────
 
-impl<T, K, M> Connection<K, M> for Arc<T>
+impl<T, Async, WireMsg> Connection<Async, WireMsg> for Arc<T>
 where
-    T: Connection<K, M>,
-    K: FutureForm,
-    M: Encode + Decode,
+    T: Connection<Async, WireMsg>,
+    Async: FutureForm,
+    WireMsg: Encode + Decode,
 {
     type DisconnectionError = T::DisconnectionError;
     type SendError = T::SendError;
     type RecvError = T::RecvError;
 
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>> {
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>> {
         T::disconnect(self)
     }
 
-    fn send(&self, message: &M) -> K::Future<'_, Result<(), Self::SendError>> {
+    fn send(&self, message: &WireMsg) -> Async::Future<'_, Result<(), Self::SendError>> {
         T::send(self, message)
     }
 
-    fn recv(&self) -> K::Future<'_, Result<M, Self::RecvError>> {
+    fn recv(&self) -> Async::Future<'_, Result<WireMsg, Self::RecvError>> {
         T::recv(self)
     }
 }
@@ -78,7 +80,7 @@ where
 ///
 /// Connections implementing this trait can be automatically reconnected
 /// by the connection manager when they drop unexpectedly.
-pub trait Reconnect<K: FutureForm, M: Encode + Decode>: Connection<K, M> {
+pub trait Reconnect<Async: FutureForm, WireMsg: Encode + Decode>: Connection<Async, WireMsg> {
     /// A problem when reconnecting.
     type ReconnectionError: core::error::Error + Send + 'static;
 
@@ -88,7 +90,7 @@ pub trait Reconnect<K: FutureForm, M: Encode + Decode>: Connection<K, M> {
     /// 1. Close any existing connection resources
     /// 2. Establish a fresh connection
     /// 3. Complete the handshake
-    fn reconnect(&mut self) -> K::Future<'_, Result<(), Self::ReconnectionError>>;
+    fn reconnect(&mut self) -> Async::Future<'_, Result<(), Self::ReconnectionError>>;
 
     /// Classify whether an error is retryable.
     ///

--- a/subduction_core/src/connection/managed.rs
+++ b/subduction_core/src/connection/managed.rs
@@ -7,10 +7,10 @@
 //! # Architecture
 //!
 //! ```text
-//! ManagedConnection<C, K, O>
-//!   ├── Authenticated<C, K>   — the connection + verified peer identity
-//!   ├── Arc<Multiplexer>      — pending map + request ID counter
-//!   └── O                     — timeout strategy (e.g., TokioTimeout, JsTimeout)
+//! ManagedConnection<Conn, Async, Timer>
+//!   ├── Authenticated<Conn, Async>   — the connection + verified peer identity
+//!   ├── Arc<Multiplexer>             — pending map + request ID counter
+//!   └── Timer                        — timeout strategy (e.g., TokioTimeout, JsTimeout)
 //! ```
 //!
 //! The [`call`](ManagedConnection::call) method sends a
@@ -39,13 +39,13 @@ use crate::{
 
 /// A connection paired with its request-response multiplexer and timeout.
 #[derive(Debug)]
-pub struct ManagedConnection<C: Clone, K: FutureForm, O> {
-    authenticated: Authenticated<C, K>,
+pub struct ManagedConnection<Conn: Clone, Async: FutureForm, Timer> {
+    authenticated: Authenticated<Conn, Async>,
     multiplexer: Arc<Multiplexer>,
-    timer: O,
+    timer: Timer,
 }
 
-impl<C: Clone, K: FutureForm, O: Clone> Clone for ManagedConnection<C, K, O> {
+impl<Conn: Clone, Async: FutureForm, Timer: Clone> Clone for ManagedConnection<Conn, Async, Timer> {
     fn clone(&self) -> Self {
         Self {
             authenticated: self.authenticated.clone(),
@@ -55,18 +55,20 @@ impl<C: Clone, K: FutureForm, O: Clone> Clone for ManagedConnection<C, K, O> {
     }
 }
 
-impl<C: Clone + PartialEq, K: FutureForm, O> PartialEq for ManagedConnection<C, K, O> {
+impl<Conn: Clone + PartialEq, Async: FutureForm, Timer> PartialEq
+    for ManagedConnection<Conn, Async, Timer>
+{
     fn eq(&self, other: &Self) -> bool {
         self.authenticated == other.authenticated
     }
 }
 
-impl<C: Clone, K: FutureForm, O> ManagedConnection<C, K, O> {
+impl<Conn: Clone, Async: FutureForm, Timer> ManagedConnection<Conn, Async, Timer> {
     /// Create a new managed connection.
     pub const fn new(
-        authenticated: Authenticated<C, K>,
+        authenticated: Authenticated<Conn, Async>,
         multiplexer: Arc<Multiplexer>,
-        timer: O,
+        timer: Timer,
     ) -> Self {
         Self {
             authenticated,
@@ -83,7 +85,7 @@ impl<C: Clone, K: FutureForm, O> ManagedConnection<C, K, O> {
 
     /// Access the authenticated connection.
     #[must_use]
-    pub const fn authenticated(&self) -> &Authenticated<C, K> {
+    pub const fn authenticated(&self) -> &Authenticated<Conn, Async> {
         &self.authenticated
     }
 
@@ -95,7 +97,7 @@ impl<C: Clone, K: FutureForm, O> ManagedConnection<C, K, O> {
 
     /// Consume the managed connection, returning the authenticated connection.
     #[must_use]
-    pub fn into_authenticated(self) -> Authenticated<C, K> {
+    pub fn into_authenticated(self) -> Authenticated<Conn, Async> {
         self.authenticated
     }
 
@@ -107,10 +109,10 @@ impl<C: Clone, K: FutureForm, O> ManagedConnection<C, K, O> {
 
 /// Error from a roundtrip [`call`](ManagedConnection::call).
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum CallError<S: core::error::Error> {
+pub enum CallError<SendErr: core::error::Error> {
     /// The transport failed to send the request.
     #[error("send error: {0}")]
-    Send(S),
+    Send(SendErr),
 
     /// The response channel was dropped (peer disconnected).
     #[error("response channel dropped")]
@@ -121,7 +123,7 @@ pub enum CallError<S: core::error::Error> {
     Timeout,
 }
 
-impl<S: core::error::Error> CallError<S> {
+impl<SendErr: core::error::Error> CallError<SendErr> {
     /// Short error name suitable for JS `Error.name` or logging.
     #[must_use]
     pub const fn error_name(&self) -> &'static str {
@@ -133,7 +135,10 @@ impl<S: core::error::Error> CallError<S> {
     }
 
     /// Map the inner send-error type.
-    pub fn map_send<S2: core::error::Error>(self, f: impl FnOnce(S) -> S2) -> CallError<S2> {
+    pub fn map_send<SendErr2: core::error::Error>(
+        self,
+        f: impl FnOnce(SendErr) -> SendErr2,
+    ) -> CallError<SendErr2> {
         match self {
             Self::Send(e) => CallError::Send(f(e)),
             Self::ResponseDropped => CallError::ResponseDropped,
@@ -146,8 +151,8 @@ impl<S: core::error::Error> CallError<S> {
 ///
 /// This trait bridges the `Sendable` and `Local` implementations of
 /// [`ManagedConnection::call`], making the method available in code
-/// generic over `K: FutureForm`.
-pub trait ManagedCall<K: FutureForm, M>: Sized {
+/// generic over `Async: FutureForm`.
+pub trait ManagedCall<Async: FutureForm, WireMsg>: Sized {
     /// The connection's send-error type.
     type SendError: core::error::Error;
 
@@ -160,40 +165,40 @@ pub trait ManagedCall<K: FutureForm, M>: Sized {
         &self,
         req: BatchSyncRequest,
         timeout: Option<Duration>,
-    ) -> K::Future<'_, Result<BatchSyncResponse, CallError<Self::SendError>>>;
+    ) -> Async::Future<'_, Result<BatchSyncResponse, CallError<Self::SendError>>>;
 }
 
-impl<C: Clone, O> ManagedConnection<C, Sendable, O>
+impl<Conn: Clone, Timer> ManagedConnection<Conn, Sendable, Timer>
 where
-    O: Timeout<Sendable> + Send + Sync,
+    Timer: Timeout<Sendable> + Send + Sync,
 {
     /// Send a [`BatchSyncRequest`] and await the matching [`BatchSyncResponse`].
     ///
     /// The request is wrapped in `SyncMessage::BatchSyncRequest`, converted to
-    /// the handler's wire type `M` via `From<SyncMessage>`, and sent via
+    /// the handler's wire type `WireMsg` via `From<SyncMessage>`, and sent via
     /// `Connection::send`. The response arrives via the `Multiplexer`'s
     /// pending map, which is resolved by the `Subduction` listen loop.
     ///
     /// # Errors
     ///
     /// Returns [`CallError`] on send failure, dropped response, or timeout.
-    pub fn call_inner<M>(
+    pub fn call_inner<WireMsg>(
         &self,
         req: BatchSyncRequest,
         timeout: Option<Duration>,
-    ) -> futures::future::BoxFuture<'_, Result<BatchSyncResponse, CallError<C::SendError>>>
+    ) -> futures::future::BoxFuture<'_, Result<BatchSyncResponse, CallError<Conn::SendError>>>
     where
-        C: Connection<Sendable, M> + PartialEq + Send + Sync,
-        C::SendError: Send + 'static,
-        M: Encode + Decode + From<SyncMessage> + Send,
+        Conn: Connection<Sendable, WireMsg> + PartialEq + Send + Sync,
+        Conn::SendError: Send + 'static,
+        WireMsg: Encode + Decode + From<SyncMessage> + Send,
     {
         let time_limit = timeout.unwrap_or(self.multiplexer.default_time_limit());
         async move {
             let req_id = req.req_id;
             let rx = self.multiplexer.register_pending(req_id).await;
 
-            let wire_msg: M = SyncMessage::BatchSyncRequest(req).into();
-            Connection::<Sendable, M>::send(&self.authenticated, &wire_msg)
+            let wire_msg: WireMsg = SyncMessage::BatchSyncRequest(req).into();
+            Connection::<Sendable, WireMsg>::send(&self.authenticated, &wire_msg)
                 .await
                 .map_err(CallError::Send)?;
 
@@ -217,14 +222,15 @@ where
     }
 }
 
-impl<C, M, O> ManagedCall<Sendable, M> for ManagedConnection<C, Sendable, O>
+impl<Conn, WireMsg, Timer> ManagedCall<Sendable, WireMsg>
+    for ManagedConnection<Conn, Sendable, Timer>
 where
-    C: Connection<Sendable, M> + PartialEq + Clone + Send + Sync,
-    C::SendError: Send + 'static,
-    M: Encode + Decode + From<SyncMessage> + Send,
-    O: Timeout<Sendable> + Send + Sync,
+    Conn: Connection<Sendable, WireMsg> + PartialEq + Clone + Send + Sync,
+    Conn::SendError: Send + 'static,
+    WireMsg: Encode + Decode + From<SyncMessage> + Send,
+    Timer: Timeout<Sendable> + Send + Sync,
 {
-    type SendError = C::SendError;
+    type SendError = Conn::SendError;
 
     fn call(
         &self,
@@ -235,9 +241,9 @@ where
     }
 }
 
-impl<C: Clone, O> ManagedConnection<C, Local, O>
+impl<Conn: Clone, Timer> ManagedConnection<Conn, Local, Timer>
 where
-    O: Timeout<Local>,
+    Timer: Timeout<Local>,
 {
     /// Send a [`BatchSyncRequest`] and await the matching [`BatchSyncResponse`].
     ///
@@ -246,22 +252,22 @@ where
     /// # Errors
     ///
     /// Returns [`CallError`] on send failure, dropped response, or timeout.
-    pub fn call_inner<M>(
+    pub fn call_inner<WireMsg>(
         &self,
         req: BatchSyncRequest,
         timeout: Option<Duration>,
-    ) -> futures::future::LocalBoxFuture<'_, Result<BatchSyncResponse, CallError<C::SendError>>>
+    ) -> futures::future::LocalBoxFuture<'_, Result<BatchSyncResponse, CallError<Conn::SendError>>>
     where
-        C: Connection<Local, M> + PartialEq,
-        M: Encode + Decode + From<SyncMessage>,
+        Conn: Connection<Local, WireMsg> + PartialEq,
+        WireMsg: Encode + Decode + From<SyncMessage>,
     {
         let time_limit = timeout.unwrap_or(self.multiplexer.default_time_limit());
         async move {
             let req_id = req.req_id;
             let rx = self.multiplexer.register_pending(req_id).await;
 
-            let wire_msg: M = SyncMessage::BatchSyncRequest(req).into();
-            Connection::<Local, M>::send(&self.authenticated, &wire_msg)
+            let wire_msg: WireMsg = SyncMessage::BatchSyncRequest(req).into();
+            Connection::<Local, WireMsg>::send(&self.authenticated, &wire_msg)
                 .await
                 .map_err(CallError::Send)?;
 
@@ -285,13 +291,13 @@ where
     }
 }
 
-impl<C, M, O> ManagedCall<Local, M> for ManagedConnection<C, Local, O>
+impl<Conn, WireMsg, Timer> ManagedCall<Local, WireMsg> for ManagedConnection<Conn, Local, Timer>
 where
-    C: Connection<Local, M> + PartialEq + Clone,
-    M: Encode + Decode + From<SyncMessage>,
-    O: Timeout<Local>,
+    Conn: Connection<Local, WireMsg> + PartialEq + Clone,
+    WireMsg: Encode + Decode + From<SyncMessage>,
+    Timer: Timeout<Local>,
 {
-    type SendError = C::SendError;
+    type SendError = Conn::SendError;
 
     fn call(
         &self,

--- a/subduction_core/src/connection/managed.rs
+++ b/subduction_core/src/connection/managed.rs
@@ -135,10 +135,10 @@ impl<SendErr: core::error::Error> CallError<SendErr> {
     }
 
     /// Map the inner send-error type.
-    pub fn map_send<SendErr2: core::error::Error>(
+    pub fn map_send<OutErr: core::error::Error>(
         self,
-        f: impl FnOnce(SendErr) -> SendErr2,
-    ) -> CallError<SendErr2> {
+        f: impl FnOnce(SendErr) -> OutErr,
+    ) -> CallError<OutErr> {
         match self {
             Self::Send(e) => CallError::Send(f(e)),
             Self::ResponseDropped => CallError::ResponseDropped,

--- a/subduction_core/src/connection/manager.rs
+++ b/subduction_core/src/connection/manager.rs
@@ -28,18 +28,18 @@ type TaskId = usize;
 
 /// Commands that can be sent to the [`ConnectionManager`].
 #[derive(Debug)]
-pub enum Command<C> {
+pub enum Command<Conn> {
     /// Add a new connection to be managed.
     ///
     /// The manager assigns a new [`ConnectionId`] and returns it via the closed channel
     /// when the connection drops.
-    Add(C, PeerId),
+    Add(Conn, PeerId),
 
     /// Re-add a reconnected connection, preserving its [`ConnectionId`].
     ///
     /// Used after a successful reconnection to restore the connection to the manager
     /// with the same logical identity.
-    ReAdd(ConnectionId, C, PeerId),
+    ReAdd(ConnectionId, Conn, PeerId),
 
     /// Remove a connection by its [`ConnectionId`] (aborts its task immediately).
     RemoveById(ConnectionId),
@@ -47,26 +47,26 @@ pub enum Command<C> {
     /// Remove a connection by reference (aborts its task immediately).
     ///
     /// Useful when you have a connection object but not its ID.
-    Remove(C),
+    Remove(Conn),
 }
 
 /// Trait for spawning connection handler tasks.
 ///
 /// Implement this for your runtime (e.g., tokio, async-std, wasm-bindgen-futures).
-pub trait Spawn<K: FutureForm> {
+pub trait Spawn<Async: FutureForm> {
     /// Spawn a future as a background task.
     ///
     /// The future should be driven to completion. The returned [`AbortHandle`]
     /// can be used to cancel the task.
-    fn spawn(&self, fut: K::Future<'static, ()>) -> AbortHandle;
+    fn spawn(&self, fut: Async::Future<'static, ()>) -> AbortHandle;
 }
 
 /// Manages connections by spawning an independent task for each one.
 ///
 /// Unlike [`SelectAll`]-based approaches, each connection runs in its own task,
 /// providing isolation and (on multi-threaded runtimes) true parallelism.
-pub struct ConnectionManager<K: FutureForm, C, M: Encode + Decode, S: Spawn<K>> {
-    spawner: S,
+pub struct ConnectionManager<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>> {
+    spawner: Spawner,
 
     /// Counter for generating internal task IDs.
     next_task_id: AtomicUsize,
@@ -76,15 +76,15 @@ pub struct ConnectionManager<K: FutureForm, C, M: Encode + Decode, S: Spawn<K>> 
 
     /// Active tasks: maps (`ConnectionId`, `TaskId`) to (`AbortHandle`, `Connection`).
     ///
-    /// The connection is stored to enable `Remove(C)` lookup via `PartialEq`.
+    /// The connection is stored to enable `Remove(Conn)` lookup via `PartialEq`.
     #[allow(clippy::type_complexity)]
-    tasks: Arc<Mutex<Vec<(ConnectionId, TaskId, AbortHandle, C)>>>,
+    tasks: Arc<Mutex<Vec<(ConnectionId, TaskId, AbortHandle, Conn)>>>,
 
     /// Inbound commands (add/remove connections).
-    commands: async_channel::Receiver<Command<C>>,
+    commands: async_channel::Receiver<Command<Conn>>,
 
     /// Outbound messages from all connections (bounded — provides backpressure).
-    messages: async_channel::Sender<(C, M)>,
+    messages: async_channel::Sender<(Conn, WireMsg)>,
 
     /// Fast path for response messages (bounded at high capacity).
     ///
@@ -93,30 +93,30 @@ pub struct ConnectionManager<K: FutureForm, C, M: Encode + Decode, S: Spawn<K>> 
     /// by a full request queue. Bounded at 8192 to cap memory usage if a
     /// peer floods fake responses; legitimate use never exceeds a few
     /// hundred concurrent in-flight requests.
-    responses: async_channel::Sender<(C, M)>,
+    responses: async_channel::Sender<(Conn, WireMsg)>,
 
     /// Predicate to identify response messages that should use the fast path.
-    is_response: fn(&M) -> bool,
+    is_response: fn(&WireMsg) -> bool,
 
     /// Notification when a connection closes (either normally or due to error).
     ///
     /// Sends the [`ConnectionId`] and connection object so the caller can
     /// decide whether to attempt reconnection.
-    closed: async_channel::Sender<(ConnectionId, C)>,
+    closed: async_channel::Sender<(ConnectionId, Conn)>,
 
-    _marker: core::marker::PhantomData<K>,
+    _marker: core::marker::PhantomData<Async>,
 }
 
-impl<K: FutureForm, C, M: Encode + Decode, S: Spawn<K>> ConnectionManager<K, C, M, S> {
+impl<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>> ConnectionManager<Async, Conn, WireMsg, Spawner> {
     /// Create a new [`ConnectionManager`].
     #[must_use]
     pub fn new(
-        spawner: S,
-        commands: async_channel::Receiver<Command<C>>,
-        messages: async_channel::Sender<(C, M)>,
-        responses: async_channel::Sender<(C, M)>,
-        is_response: fn(&M) -> bool,
-        closed: async_channel::Sender<(ConnectionId, C)>,
+        spawner: Spawner,
+        commands: async_channel::Receiver<Command<Conn>>,
+        messages: async_channel::Sender<(Conn, WireMsg)>,
+        responses: async_channel::Sender<(Conn, WireMsg)>,
+        is_response: fn(&WireMsg) -> bool,
+        closed: async_channel::Sender<(ConnectionId, Conn)>,
     ) -> Self {
         Self {
             spawner,
@@ -138,10 +138,10 @@ impl<K: FutureForm, C, M: Encode + Decode, S: Spawn<K>> ConnectionManager<K, C, 
     }
 }
 
-impl<K: FutureForm, C: Connection<K, M>, M: Encode + Decode, S: Spawn<K>>
-    ConnectionManager<K, C, M, S>
+impl<Async: FutureForm, Conn: Connection<Async, WireMsg>, WireMsg: Encode + Decode, Spawner: Spawn<Async>>
+    ConnectionManager<Async, Conn, WireMsg, Spawner>
 {
-    async fn remove_connection_by_ref(&self, conn: &C) {
+    async fn remove_connection_by_ref(&self, conn: &Conn) {
         let mut tasks = self.tasks.lock().await;
         if let Some(pos) = tasks.iter().position(|(_, _, _, c)| c == conn) {
             let (conn_id, task_id, handle, _) = tasks.swap_remove(pos);
@@ -166,40 +166,40 @@ impl<K: FutureForm, C: Connection<K, M>, M: Encode + Decode, S: Spawn<K>>
 
 /// Trait for running the connection manager.
 ///
-/// This trait enables generic code to call `run()` on `ConnectionManager<K, C, M, S>`
-/// without knowing whether K is `Sendable` or `Local`.
-pub trait RunManager<C, M: Encode + Decode>: FutureForm + Sized {
+/// This trait enables generic code to call `run()` on `ConnectionManager<Async, Conn, WireMsg, Spawner>`
+/// without knowing whether Async is `Sendable` or `Local`.
+pub trait RunManager<Conn, WireMsg: Encode + Decode>: FutureForm + Sized {
     /// Run the manager, processing commands to add/remove connections.
-    fn run_manager<S: Spawn<Self> + Send + Sync + 'static>(
-        manager: ConnectionManager<Self, C, M, S>,
+    fn run_manager<Spawner: Spawn<Self> + Send + Sync + 'static>(
+        manager: ConnectionManager<Self, Conn, WireMsg, Spawner>,
     ) -> Self::Future<'static, ()>
     where
-        C: Connection<Self, M> + Clone + 'static;
+        Conn: Connection<Self, WireMsg> + Clone + 'static;
 }
 
-impl<K: FutureForm + RunManager<C, M>, C, M: Encode + Decode, S: Spawn<K> + Send + Sync + 'static>
-    ConnectionManager<K, C, M, S>
+impl<Async: FutureForm + RunManager<Conn, WireMsg>, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async> + Send + Sync + 'static>
+    ConnectionManager<Async, Conn, WireMsg, Spawner>
 {
     /// Run the manager, processing commands to add/remove connections.
-    pub fn run(self) -> K::Future<'static, ()>
+    pub fn run(self) -> Async::Future<'static, ()>
     where
-        C: Connection<K, M> + Clone + 'static,
+        Conn: Connection<Async, WireMsg> + Clone + 'static,
     {
-        K::run_manager(self)
+        Async::run_manager(self)
     }
 }
 
 // Implementations of RunManager for Sendable and Local
 #[future_form(
-    Sendable where C: Connection<Sendable, M> + Clone + Send + Sync + 'static, C::RecvError: Send, M: Send + Sync + 'static,
-    Local where C: Connection<Local, M> + Clone + 'static, M: 'static
+    Sendable where Conn: Connection<Sendable, WireMsg> + Clone + Send + Sync + 'static, Conn::RecvError: Send, WireMsg: Send + Sync + 'static,
+    Local where Conn: Connection<Local, WireMsg> + Clone + 'static, WireMsg: 'static
 )]
-impl<K: FutureForm, C, M: Encode + Decode> RunManager<C, M> for K {
+impl<Async: FutureForm, Conn, WireMsg: Encode + Decode> RunManager<Conn, WireMsg> for Async {
     #[allow(clippy::too_many_lines)]
-    fn run_manager<S: Spawn<Self> + Send + Sync + 'static>(
-        manager: ConnectionManager<Self, C, M, S>,
+    fn run_manager<Spawner: Spawn<Self> + Send + Sync + 'static>(
+        manager: ConnectionManager<Self, Conn, WireMsg, Spawner>,
     ) -> Self::Future<'static, ()> {
-        K::from_future(async move {
+        Async::from_future(async move {
             while let Ok(cmd) = manager.commands.recv().await {
                 match cmd {
                     Command::Add(conn, peer_id) => {
@@ -218,7 +218,7 @@ impl<K: FutureForm, C, M: Encode + Decode> RunManager<C, M> for K {
                         let closed = manager.closed.clone();
                         let conn_clone = conn.clone();
 
-                        let fut = K::from_future(async move {
+                        let fut = Async::from_future(async move {
                             connection_loop(
                                 conn_clone.clone(),
                                 peer_id,
@@ -232,7 +232,7 @@ impl<K: FutureForm, C, M: Encode + Decode> RunManager<C, M> for K {
                             let mut tasks_guard = tasks.lock().await;
                             let target_id: TaskId = task_id;
                             if let Some(pos) = tasks_guard.iter().position(
-                                |(_, id, _, _): &(ConnectionId, TaskId, AbortHandle, C)| {
+                                |(_, id, _, _): &(ConnectionId, TaskId, AbortHandle, Conn)| {
                                     *id == target_id
                                 },
                             ) {
@@ -264,7 +264,7 @@ impl<K: FutureForm, C, M: Encode + Decode> RunManager<C, M> for K {
                         let closed = manager.closed.clone();
                         let conn_clone = conn.clone();
 
-                        let fut = K::from_future(async move {
+                        let fut = Async::from_future(async move {
                             connection_loop(
                                 conn_clone.clone(),
                                 peer_id,
@@ -278,7 +278,7 @@ impl<K: FutureForm, C, M: Encode + Decode> RunManager<C, M> for K {
                             let mut tasks_guard = tasks.lock().await;
                             let target_id: TaskId = task_id;
                             if let Some(pos) = tasks_guard.iter().position(
-                                |(_, id, _, _): &(ConnectionId, TaskId, AbortHandle, C)| {
+                                |(_, id, _, _): &(ConnectionId, TaskId, AbortHandle, Conn)| {
                                     *id == target_id
                                 },
                             ) {
@@ -307,7 +307,7 @@ impl<K: FutureForm, C, M: Encode + Decode> RunManager<C, M> for K {
             }
             tracing::debug!("ConnectionManager: command channel closed, shutting down");
 
-            // Abort outstanding `connection_loop`s and drop our `C` clones
+            // Abort outstanding `connection_loop`s and drop our `Conn` clones
             // so transports with `Clone`d channel senders (e.g. WebSocket)
             // can close their inbound channels.
             let mut tasks_guard = manager.tasks.lock().await;
@@ -323,12 +323,12 @@ impl<K: FutureForm, C, M: Encode + Decode> RunManager<C, M> for K {
     }
 }
 
-async fn connection_loop<K: FutureForm, C: Connection<K, M>, M: Encode + Decode>(
-    conn: C,
+async fn connection_loop<Async: FutureForm, Conn: Connection<Async, WireMsg>, WireMsg: Encode + Decode>(
+    conn: Conn,
     peer_id: PeerId,
-    messages: async_channel::Sender<(C, M)>,
-    responses: async_channel::Sender<(C, M)>,
-    is_response: fn(&M) -> bool,
+    messages: async_channel::Sender<(Conn, WireMsg)>,
+    responses: async_channel::Sender<(Conn, WireMsg)>,
+    is_response: fn(&WireMsg) -> bool,
 ) {
     loop {
         match conn.recv().await {
@@ -352,8 +352,8 @@ async fn connection_loop<K: FutureForm, C: Connection<K, M>, M: Encode + Decode>
     }
 }
 
-impl<K: FutureForm, C, M: Encode + Decode, S: Spawn<K>> core::fmt::Debug
-    for ConnectionManager<K, C, M, S>
+impl<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>> core::fmt::Debug
+    for ConnectionManager<Async, Conn, WireMsg, Spawner>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ConnectionManager").finish_non_exhaustive()
@@ -363,13 +363,13 @@ impl<K: FutureForm, C, M: Encode + Decode, S: Spawn<K>> core::fmt::Debug
 /// A future representing the running [`ConnectionManager`].
 ///
 /// This allows the caller to monitor and control the lifecycle of the manager.
-pub struct ManagerFuture<K: FutureForm> {
-    fut: core::pin::Pin<alloc::boxed::Box<futures::stream::Abortable<K::Future<'static, ()>>>>,
+pub struct ManagerFuture<Async: FutureForm> {
+    fut: core::pin::Pin<alloc::boxed::Box<futures::stream::Abortable<Async::Future<'static, ()>>>>,
 }
 
-impl<K: FutureForm> ManagerFuture<K> {
+impl<Async: FutureForm> ManagerFuture<Async> {
     /// Create a new manager future from an abortable future.
-    pub fn new(fut: futures::stream::Abortable<K::Future<'static, ()>>) -> Self {
+    pub fn new(fut: futures::stream::Abortable<Async::Future<'static, ()>>) -> Self {
         Self {
             fut: alloc::boxed::Box::pin(fut),
         }
@@ -382,7 +382,7 @@ impl<K: FutureForm> ManagerFuture<K> {
     }
 }
 
-impl<K: FutureForm> core::future::Future for ManagerFuture<K> {
+impl<Async: FutureForm> core::future::Future for ManagerFuture<Async> {
     type Output = Result<(), futures::stream::Aborted>;
 
     fn poll(
@@ -393,9 +393,9 @@ impl<K: FutureForm> core::future::Future for ManagerFuture<K> {
     }
 }
 
-impl<K: FutureForm> Unpin for ManagerFuture<K> {}
+impl<Async: FutureForm> Unpin for ManagerFuture<Async> {}
 
-impl<K: FutureForm> core::fmt::Debug for ManagerFuture<K> {
+impl<Async: FutureForm> core::fmt::Debug for ManagerFuture<Async> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ManagerFuture")
             .field("is_aborted", &self.is_aborted())

--- a/subduction_core/src/connection/manager.rs
+++ b/subduction_core/src/connection/manager.rs
@@ -65,7 +65,12 @@ pub trait Spawn<Async: FutureForm> {
 ///
 /// Unlike [`SelectAll`]-based approaches, each connection runs in its own task,
 /// providing isolation and (on multi-threaded runtimes) true parallelism.
-pub struct ConnectionManager<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>> {
+pub struct ConnectionManager<
+    Async: FutureForm,
+    Conn,
+    WireMsg: Encode + Decode,
+    Spawner: Spawn<Async>,
+> {
     spawner: Spawner,
 
     /// Counter for generating internal task IDs.
@@ -107,7 +112,9 @@ pub struct ConnectionManager<Async: FutureForm, Conn, WireMsg: Encode + Decode, 
     _marker: core::marker::PhantomData<Async>,
 }
 
-impl<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>> ConnectionManager<Async, Conn, WireMsg, Spawner> {
+impl<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>>
+    ConnectionManager<Async, Conn, WireMsg, Spawner>
+{
     /// Create a new [`ConnectionManager`].
     #[must_use]
     pub fn new(
@@ -138,8 +145,12 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>> C
     }
 }
 
-impl<Async: FutureForm, Conn: Connection<Async, WireMsg>, WireMsg: Encode + Decode, Spawner: Spawn<Async>>
-    ConnectionManager<Async, Conn, WireMsg, Spawner>
+impl<
+    Async: FutureForm,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
+    Spawner: Spawn<Async>,
+> ConnectionManager<Async, Conn, WireMsg, Spawner>
 {
     async fn remove_connection_by_ref(&self, conn: &Conn) {
         let mut tasks = self.tasks.lock().await;
@@ -177,8 +188,12 @@ pub trait RunManager<Conn, WireMsg: Encode + Decode>: FutureForm + Sized {
         Conn: Connection<Self, WireMsg> + Clone + 'static;
 }
 
-impl<Async: FutureForm + RunManager<Conn, WireMsg>, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async> + Send + Sync + 'static>
-    ConnectionManager<Async, Conn, WireMsg, Spawner>
+impl<
+    Async: FutureForm + RunManager<Conn, WireMsg>,
+    Conn,
+    WireMsg: Encode + Decode,
+    Spawner: Spawn<Async> + Send + Sync + 'static,
+> ConnectionManager<Async, Conn, WireMsg, Spawner>
 {
     /// Run the manager, processing commands to add/remove connections.
     pub fn run(self) -> Async::Future<'static, ()>
@@ -323,7 +338,11 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode> RunManager<Conn, WireMsg
     }
 }
 
-async fn connection_loop<Async: FutureForm, Conn: Connection<Async, WireMsg>, WireMsg: Encode + Decode>(
+async fn connection_loop<
+    Async: FutureForm,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
+>(
     conn: Conn,
     peer_id: PeerId,
     messages: async_channel::Sender<(Conn, WireMsg)>,

--- a/subduction_core/src/handler.rs
+++ b/subduction_core/src/handler.rs
@@ -19,27 +19,27 @@
 //!     storage: Arc<MyStorage>,
 //! }
 //!
-//! impl<K, C> Handler<K, C> for MyHandler
+//! impl<Async, Conn> Handler<Async, Conn> for MyHandler
 //! where
-//!     K: FutureForm,
-//!     C: Clone,
+//!     Async: FutureForm,
+//!     Conn: Clone,
 //! {
 //!     type Message = SyncMessage;
 //!     type HandlerError = MyError;
 //!
 //!     fn handle<'a>(
 //!         &'a self,
-//!         conn: &'a Authenticated<C, K>,
+//!         conn: &'a Authenticated<Conn, Async>,
 //!         message: SyncMessage,
-//!     ) -> K::Future<'a, Result<(), MyError>> {
-//!         K::from_future(async move {
+//!     ) -> Async::Future<'a, Result<(), MyError>> {
+//!         Async::from_future(async move {
 //!             // process message ...
 //!             Ok(())
 //!         })
 //!     }
 //!
-//!     fn on_peer_disconnect(&self, _peer: PeerId) -> K::Future<'_, ()> {
-//!         K::from_future(async {})
+//!     fn on_peer_disconnect(&self, _peer: PeerId) -> Async::Future<'_, ()> {
+//!         Async::from_future(async {})
 //!     }
 //! }
 //! ```
@@ -72,12 +72,12 @@ use crate::{
 ///
 /// # Type Parameters
 ///
-/// `C` is minimally bounded (`Clone`) because [`Authenticated<C, K>`]
+/// `Conn` is minimally bounded (`Clone`) because [`Authenticated<Conn, Async>`]
 /// requires it. Individual impls specify their own additional bounds
-/// (e.g., `C: Connection<K, SyncMessage>`).
+/// (e.g., `Conn: Connection<Async, SyncMessage>`).
 ///
-/// [`Authenticated<C, K>`]: crate::authenticated::Authenticated
-pub trait Handler<K: FutureForm, C: Clone> {
+/// [`Authenticated<Conn, Async>`]: crate::authenticated::Authenticated
+pub trait Handler<Async: FutureForm, Conn: Clone> {
     /// The message type this handler processes.
     ///
     /// For the standard Subduction protocol, this is
@@ -98,9 +98,9 @@ pub trait Handler<K: FutureForm, C: Clone> {
     /// The returned future borrows both `self` and `conn` for lifetime `'a`.
     fn handle<'a>(
         &'a self,
-        conn: &'a Authenticated<C, K>,
+        conn: &'a Authenticated<Conn, Async>,
         message: Self::Message,
-    ) -> K::Future<'a, Result<(), Self::HandlerError>>;
+    ) -> Async::Future<'a, Result<(), Self::HandlerError>>;
 
     /// Extract a [`BatchSyncResponse`] from a message, if present.
     ///
@@ -132,5 +132,5 @@ pub trait Handler<K: FutureForm, C: Clone> {
     /// that the peer has no remaining connections.
     ///
     /// [`remove_connection`]: crate::subduction::Subduction::remove_connection
-    fn on_peer_disconnect(&self, peer: PeerId) -> K::Future<'_, ()>;
+    fn on_peer_disconnect(&self, peer: PeerId) -> Async::Future<'_, ()>;
 }

--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -76,33 +76,33 @@ use crate::{
 /// [`Subduction`]: crate::subduction::Subduction
 #[allow(clippy::type_complexity)]
 pub struct SyncHandler<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, SyncMessage> + PartialEq + Clone + 'static,
-    P: StoragePolicy<F>,
-    M: DepthMetric,
-    const N: usize = 256,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'static,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
+    const SHARDS: usize = 256,
     R: RemoteHeadsObserver = NoRemoteHeadsObserver,
 > {
-    sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, N>>,
-    connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>>,
+    sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>,
+    connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
     subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
-    storage: StoragePowerbox<S, P>,
+    storage: StoragePowerbox<Store, Auth>,
     pending_blob_requests: Arc<Mutex<PendingBlobRequests>>,
-    depth_metric: M,
+    depth_metric: Metric,
     heads_notifier: FilteredHeadsNotifier<R>,
     send_counter: PeerCounter,
 }
 
 impl<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, SyncMessage> + PartialEq + Clone + 'static,
-    P: StoragePolicy<F>,
-    M: DepthMetric,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'static,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
     R: RemoteHeadsObserver,
-    const N: usize,
-> core::fmt::Debug for SyncHandler<F, S, C, P, M, N, R>
+    const SHARDS: usize,
+> core::fmt::Debug for SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS, R>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("SyncHandler").finish_non_exhaustive()
@@ -110,14 +110,14 @@ impl<
 }
 
 impl<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, SyncMessage> + PartialEq + Clone + 'static,
-    P: StoragePolicy<F>,
-    M: DepthMetric + Clone,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'static,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric + Clone,
     R: RemoteHeadsObserver + Clone,
-    const N: usize,
-> Clone for SyncHandler<F, S, C, P, M, N, R>
+    const SHARDS: usize,
+> Clone for SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS, R>
 {
     fn clone(&self) -> Self {
         Self {
@@ -134,13 +134,13 @@ impl<
 }
 
 impl<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, SyncMessage> + PartialEq + Clone + 'static,
-    P: StoragePolicy<F>,
-    M: DepthMetric,
-    const N: usize,
-> SyncHandler<F, S, C, P, M, N, NoRemoteHeadsObserver>
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'static,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS, NoRemoteHeadsObserver>
 {
     /// Create a new `SyncHandler` from shared state.
     ///
@@ -151,12 +151,12 @@ impl<
     /// [`Subduction::new`]: crate::subduction::Subduction::new
     #[allow(clippy::type_complexity)]
     pub fn new(
-        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, N>>,
-        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>>,
+        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>,
+        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
-        storage: StoragePowerbox<S, P>,
+        storage: StoragePowerbox<Store, Auth>,
         pending_blob_requests: Arc<Mutex<PendingBlobRequests>>,
-        depth_metric: M,
+        depth_metric: Metric,
     ) -> Self {
         Self {
             sedimentrees,
@@ -172,24 +172,24 @@ impl<
 }
 
 impl<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, SyncMessage> + PartialEq + Clone + 'static,
-    P: StoragePolicy<F>,
-    M: DepthMetric,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'static,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
     R: RemoteHeadsObserver,
-    const N: usize,
-> SyncHandler<F, S, C, P, M, N, R>
+    const SHARDS: usize,
+> SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS, R>
 {
     /// Create a new `SyncHandler` with a custom remote heads observer.
     #[allow(clippy::type_complexity)]
     pub fn with_remote_heads_observer(
-        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, N>>,
-        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>>,
+        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>,
+        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
-        storage: StoragePowerbox<S, P>,
+        storage: StoragePowerbox<Store, Auth>,
         pending_blob_requests: Arc<Mutex<PendingBlobRequests>>,
-        depth_metric: M,
+        depth_metric: Metric,
         remote_heads_observer: R,
     ) -> Self {
         Self {
@@ -211,7 +211,7 @@ impl<
     ///
     /// [`EphemeralHandler`]: subduction_ephemeral::handler::EphemeralHandler
     #[allow(clippy::type_complexity)]
-    pub fn connections(&self) -> Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>> {
+    pub fn connections(&self) -> Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>> {
         self.connections.clone()
     }
 
@@ -233,29 +233,29 @@ impl<
 
 #[future_form(
     Sendable where
-        S: Storage<Sendable> + Send + Sync + core::fmt::Debug,
-        C: Connection<Sendable, SyncMessage> + PartialEq + Clone + Send + Sync + core::fmt::Debug + 'static,
-        P: StoragePolicy<Sendable> + Send + Sync,
-        P::FetchDisallowed: Send + 'static,
-        P::PutDisallowed: Send + 'static,
-        M: DepthMetric + Send + Sync,
-        S::Error: Send + 'static,
-        C::SendError: Send + 'static,
-        C::RecvError: Send + 'static,
-        C::DisconnectionError: Send + 'static,
+        Store: Storage<Sendable> + Send + Sync + core::fmt::Debug,
+        Conn: Connection<Sendable, SyncMessage> + PartialEq + Clone + Send + Sync + core::fmt::Debug + 'static,
+        Auth: StoragePolicy<Sendable> + Send + Sync,
+        Auth::FetchDisallowed: Send + 'static,
+        Auth::PutDisallowed: Send + 'static,
+        Metric: DepthMetric + Send + Sync,
+        Store::Error: Send + 'static,
+        Conn::SendError: Send + 'static,
+        Conn::RecvError: Send + 'static,
+        Conn::DisconnectionError: Send + 'static,
         R: RemoteHeadsObserver + Send + Sync,
     Local where
-        S: Storage<Local> + core::fmt::Debug,
-        C: Connection<Local, SyncMessage> + PartialEq + Clone + core::fmt::Debug + 'static,
-        P: StoragePolicy<Local>,
-        M: DepthMetric,
+        Store: Storage<Local> + core::fmt::Debug,
+        Conn: Connection<Local, SyncMessage> + PartialEq + Clone + core::fmt::Debug + 'static,
+        Auth: StoragePolicy<Local>,
+        Metric: DepthMetric,
         R: RemoteHeadsObserver
 )]
-impl<K: FutureForm, S, C, P, M, R, const N: usize> Handler<K, C>
-    for SyncHandler<K, S, C, P, M, N, R>
+impl<Async: FutureForm, Store, Conn, Auth, Metric, R, const SHARDS: usize> Handler<Async, Conn>
+    for SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS, R>
 {
     type Message = SyncMessage;
-    type HandlerError = ListenError<K, S, C, SyncMessage>;
+    type HandlerError = ListenError<Async, Store, Conn, SyncMessage>;
 
     fn as_batch_sync_response(msg: &Self::Message) -> Option<&BatchSyncResponse> {
         match msg {
@@ -273,16 +273,16 @@ impl<K: FutureForm, S, C, P, M, R, const N: usize> Handler<K, C>
 
     fn handle<'a>(
         &'a self,
-        conn: &'a Authenticated<C, K>,
+        conn: &'a Authenticated<Conn, Async>,
         message: Self::Message,
-    ) -> K::Future<'a, Result<(), Self::HandlerError>> {
-        K::from_future(async move { self.dispatch(conn, message).await })
+    ) -> Async::Future<'a, Result<(), Self::HandlerError>> {
+        Async::from_future(async move { self.dispatch(conn, message).await })
     }
 
-    fn on_peer_disconnect(&self, _peer: PeerId) -> K::Future<'_, ()> {
+    fn on_peer_disconnect(&self, _peer: PeerId) -> Async::Future<'_, ()> {
         // Sync subscriptions are already cleaned by `peers::remove_connection`,
         // so there is nothing extra to do here.
-        K::from_future(async {})
+        Async::from_future(async {})
     }
 }
 
@@ -291,14 +291,14 @@ impl<K: FutureForm, S, C, P, M, R, const N: usize> Handler<K, C>
 // ---------------------------------------------------------------------------
 
 impl<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, SyncMessage> + PartialEq + Clone + 'static,
-    P: StoragePolicy<F>,
-    M: DepthMetric,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'static,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
     R: RemoteHeadsObserver,
-    const N: usize,
-> RemoteHeadsNotifier for SyncHandler<F, S, C, P, M, N, R>
+    const SHARDS: usize,
+> RemoteHeadsNotifier for SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS, R>
 {
     fn notify_remote_heads(&self, id: SedimentreeId, peer: PeerId, heads: RemoteHeads) {
         self.heads_notifier.notify(id, peer, heads);
@@ -310,21 +310,21 @@ impl<
 // ---------------------------------------------------------------------------
 
 impl<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, SyncMessage> + PartialEq + Clone + 'static,
-    P: StoragePolicy<F>,
-    M: DepthMetric,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'static,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
     R: RemoteHeadsObserver,
-    const N: usize,
-> SyncHandler<F, S, C, P, M, N, R>
+    const SHARDS: usize,
+> SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS, R>
 {
     #[allow(clippy::too_many_lines)]
     async fn dispatch(
         &self,
-        conn: &Authenticated<C, F>,
+        conn: &Authenticated<Conn, Async>,
         message: SyncMessage,
-    ) -> Result<(), ListenError<F, S, C, SyncMessage>> {
+    ) -> Result<(), ListenError<Async, Store, Conn, SyncMessage>> {
         let from = conn.peer_id();
         tracing::debug!(
             from = %from,
@@ -470,8 +470,8 @@ impl<
         id: SedimentreeId,
         signed_commit: &Signed<LooseCommit>,
         blob: Blob,
-        conn: &Authenticated<C, F>,
-    ) -> Result<bool, IoError<F, S, C, SyncMessage>> {
+        conn: &Authenticated<Conn, Async>,
+    ) -> Result<bool, IoError<Async, Store, Conn, SyncMessage>> {
         let verified = match signed_commit.try_verify() {
             Ok(v) => v,
             Err(e) => {
@@ -492,7 +492,7 @@ impl<
             author
         );
 
-        let putter = match self.storage.get_putter::<F>(*from, author, id).await {
+        let putter = match self.storage.get_putter::<Async>(*from, author, id).await {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(
@@ -566,8 +566,8 @@ impl<
         id: SedimentreeId,
         signed_fragment: &Signed<Fragment>,
         blob: Blob,
-        conn: &Authenticated<C, F>,
-    ) -> Result<bool, IoError<F, S, C, SyncMessage>> {
+        conn: &Authenticated<Conn, Async>,
+    ) -> Result<bool, IoError<Async, Store, Conn, SyncMessage>> {
         let verified = match signed_fragment.try_verify() {
             Ok(v) => v,
             Err(e) => {
@@ -588,7 +588,7 @@ impl<
             author
         );
 
-        let putter = match self.storage.get_putter::<F>(*from, author, id).await {
+        let putter = match self.storage.get_putter::<Async>(*from, author, id).await {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(
@@ -662,12 +662,12 @@ impl<
         id: SedimentreeId,
         their_fingerprints: &FingerprintSummary,
         req_id: RequestId,
-        conn: &Authenticated<C, F>,
-    ) -> Result<(), ListenError<F, S, C, SyncMessage>> {
+        conn: &Authenticated<Conn, Async>,
+    ) -> Result<(), ListenError<Async, Store, Conn, SyncMessage>> {
         tracing::info!("recv_batch_sync_request for sedimentree {:?}", id);
 
         let peer_id = conn.peer_id();
-        let fetcher = match self.storage.get_fetcher::<F>(peer_id, id).await {
+        let fetcher = match self.storage.get_fetcher::<Async>(peer_id, id).await {
             Ok(f) => f,
             Err(e) => {
                 tracing::debug!(
@@ -815,7 +815,7 @@ impl<
         from: &PeerId,
         id: SedimentreeId,
         diff: SyncDiff,
-    ) -> Result<(), IoError<F, S, C, SyncMessage>> {
+    ) -> Result<(), IoError<Async, Store, Conn, SyncMessage>> {
         ingest::recv_batch_sync_response(&self.sedimentrees, &self.storage, from, id, diff).await?;
         self.minimize_tree(id).await;
         Ok(())
@@ -823,10 +823,10 @@ impl<
 
     async fn recv_blob_request(
         &self,
-        conn: &Authenticated<C, F>,
+        conn: &Authenticated<Conn, Async>,
         id: SedimentreeId,
         digests: &[Digest<Blob>],
-    ) -> Result<(), BlobRequestErr<F, S, C, SyncMessage>> {
+    ) -> Result<(), BlobRequestErr<Async, Store, Conn, SyncMessage>> {
         let mut blobs = Vec::new();
         let mut missing = Vec::new();
         for digest in digests {
@@ -856,23 +856,23 @@ impl<
         &self,
         id: SedimentreeId,
         digest: Digest<Blob>,
-    ) -> Result<Option<Blob>, S::Error> {
+    ) -> Result<Option<Blob>, Store::Error> {
         ingest::get_blob(&self.storage, id, digest).await
     }
 
     async fn insert_commit_locally(
         &self,
-        putter: &Putter<F, S>,
+        putter: &Putter<Async, Store>,
         verified_meta: VerifiedMeta<LooseCommit>,
-    ) -> Result<bool, S::Error> {
+    ) -> Result<bool, Store::Error> {
         ingest::insert_commit_locally(&self.sedimentrees, putter, verified_meta).await
     }
 
     async fn insert_fragment_locally(
         &self,
-        putter: &Putter<F, S>,
+        putter: &Putter<Async, Store>,
         verified_meta: VerifiedMeta<Fragment>,
-    ) -> Result<bool, S::Error> {
+    ) -> Result<bool, Store::Error> {
         ingest::insert_fragment_locally(&self.sedimentrees, putter, verified_meta).await
     }
 
@@ -909,7 +909,7 @@ impl<
         &self,
         sedimentree_id: SedimentreeId,
         exclude_peer: &PeerId,
-    ) -> Vec<Authenticated<C, F>> {
+    ) -> Vec<Authenticated<Conn, Async>> {
         peers::get_authorized_subscriber_conns(
             &self.subscriptions,
             &self.storage,
@@ -920,7 +920,7 @@ impl<
         .await
     }
 
-    async fn remove_connection(&self, conn: &Authenticated<C, F>) -> Option<bool> {
+    async fn remove_connection(&self, conn: &Authenticated<Conn, Async>) -> Option<bool> {
         peers::remove_connection(&self.connections, &self.subscriptions, conn).await
     }
 }

--- a/subduction_core/src/policy/connection.rs
+++ b/subduction_core/src/policy/connection.rs
@@ -7,7 +7,7 @@ use future_form::FutureForm;
 use crate::peer::id::PeerId;
 
 /// A policy for allowing or disallowing connections from peers.
-pub trait ConnectionPolicy<K: FutureForm> {
+pub trait ConnectionPolicy<Async: FutureForm> {
     /// Error type returned when a connection is disallowed.
     type ConnectionDisallowed: Error;
 
@@ -17,5 +17,5 @@ pub trait ConnectionPolicy<K: FutureForm> {
     fn authorize_connect(
         &self,
         peer: PeerId,
-    ) -> K::Future<'_, Result<(), Self::ConnectionDisallowed>>;
+    ) -> Async::Future<'_, Result<(), Self::ConnectionDisallowed>>;
 }

--- a/subduction_core/src/policy/open.rs
+++ b/subduction_core/src/policy/open.rs
@@ -17,19 +17,19 @@ use subduction_crypto::verified_author::VerifiedAuthor;
 pub struct OpenPolicy;
 
 #[future_form(Sendable, Local)]
-impl<K: FutureForm> ConnectionPolicy<K> for OpenPolicy {
+impl<Async: FutureForm> ConnectionPolicy<Async> for OpenPolicy {
     type ConnectionDisallowed = Infallible;
 
     fn authorize_connect(
         &self,
         _peer: PeerId,
-    ) -> K::Future<'_, Result<(), Self::ConnectionDisallowed>> {
-        K::from_future(async { Ok(()) })
+    ) -> Async::Future<'_, Result<(), Self::ConnectionDisallowed>> {
+        Async::from_future(async { Ok(()) })
     }
 }
 
 #[future_form(Sendable, Local)]
-impl<K: FutureForm> StoragePolicy<K> for OpenPolicy {
+impl<Async: FutureForm> StoragePolicy<Async> for OpenPolicy {
     type FetchDisallowed = Infallible;
     type PutDisallowed = Infallible;
 
@@ -37,8 +37,8 @@ impl<K: FutureForm> StoragePolicy<K> for OpenPolicy {
         &self,
         _peer: PeerId,
         _sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::FetchDisallowed>> {
-        K::from_future(async { Ok(()) })
+    ) -> Async::Future<'_, Result<(), Self::FetchDisallowed>> {
+        Async::from_future(async { Ok(()) })
     }
 
     fn authorize_put(
@@ -46,16 +46,16 @@ impl<K: FutureForm> StoragePolicy<K> for OpenPolicy {
         _requestor: PeerId,
         _author: VerifiedAuthor,
         _sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::PutDisallowed>> {
-        K::from_future(async { Ok(()) })
+    ) -> Async::Future<'_, Result<(), Self::PutDisallowed>> {
+        Async::from_future(async { Ok(()) })
     }
 
     fn filter_authorized_fetch(
         &self,
         _peer: PeerId,
         ids: Vec<SedimentreeId>,
-    ) -> K::Future<'_, Vec<SedimentreeId>> {
+    ) -> Async::Future<'_, Vec<SedimentreeId>> {
         // OpenPolicy allows everything
-        K::from_future(async { ids })
+        Async::from_future(async { ids })
     }
 }

--- a/subduction_core/src/policy/storage.rs
+++ b/subduction_core/src/policy/storage.rs
@@ -15,7 +15,7 @@ use crate::peer::id::PeerId;
 /// This trait performs authorization checks. To get a capability that bundles
 /// authorization with storage access, use [`Subduction::authorize_fetch`] or
 /// [`Subduction::authorize_put`].
-pub trait StoragePolicy<K: FutureForm> {
+pub trait StoragePolicy<Async: FutureForm> {
     /// Error type returned when fetch is disallowed.
     type FetchDisallowed: Error;
 
@@ -29,7 +29,7 @@ pub trait StoragePolicy<K: FutureForm> {
         &self,
         peer: PeerId,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::FetchDisallowed>>;
+    ) -> Async::Future<'_, Result<(), Self::FetchDisallowed>>;
 
     /// Authorize putting data for the given sedimentree.
     ///
@@ -43,7 +43,7 @@ pub trait StoragePolicy<K: FutureForm> {
         requestor: PeerId,
         author: VerifiedAuthor,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::PutDisallowed>>;
+    ) -> Async::Future<'_, Result<(), Self::PutDisallowed>>;
 
     /// Filter a list of sedimentree IDs to only those the peer is authorized to fetch.
     ///
@@ -56,5 +56,5 @@ pub trait StoragePolicy<K: FutureForm> {
         &self,
         peer: PeerId,
         ids: Vec<SedimentreeId>,
-    ) -> K::Future<'_, Vec<SedimentreeId>>;
+    ) -> Async::Future<'_, Vec<SedimentreeId>>;
 }

--- a/subduction_core/src/storage/destroyer.rs
+++ b/subduction_core/src/storage/destroyer.rs
@@ -23,17 +23,17 @@ use super::traits::Storage;
 /// - Administrative cleanup
 ///
 /// Created via [`StoragePowerbox::local_destroyer`][crate::storage::powerbox::StoragePowerbox::local_destroyer].
-pub struct Destroyer<K: FutureForm, S: Storage<K>> {
-    storage: Arc<S>,
+pub struct Destroyer<Async: FutureForm, Store: Storage<Async>> {
+    storage: Arc<Store>,
     sedimentree_id: SedimentreeId,
-    _marker: PhantomData<K>,
+    _marker: PhantomData<Async>,
 }
 
-impl<K: FutureForm, S: Storage<K>> Destroyer<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> Destroyer<Async, Store> {
     /// Create a new destroyer capability.
     ///
     /// This should only be called for local operations, never for peer requests.
-    pub(crate) const fn new(storage: Arc<S>, sedimentree_id: SedimentreeId) -> Self {
+    pub(crate) const fn new(storage: Arc<Store>, sedimentree_id: SedimentreeId) -> Self {
         Self {
             storage,
             sedimentree_id,
@@ -49,32 +49,32 @@ impl<K: FutureForm, S: Storage<K>> Destroyer<K, S> {
 
     /// Delete a single loose commit and its blob by [`CommitId`].
     #[must_use]
-    pub fn delete_loose_commit(&self, commit_id: CommitId) -> K::Future<'_, Result<(), S::Error>> {
+    pub fn delete_loose_commit(&self, commit_id: CommitId) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage
             .delete_loose_commit(self.sedimentree_id, commit_id)
     }
 
     /// Delete all loose commits and their blobs for this sedimentree.
     #[must_use]
-    pub fn delete_loose_commits(&self) -> K::Future<'_, Result<(), S::Error>> {
+    pub fn delete_loose_commits(&self) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage.delete_loose_commits(self.sedimentree_id)
     }
 
     /// Delete a fragment and its blob by fragment head [`CommitId`].
     #[must_use]
-    pub fn delete_fragment(&self, fragment_head: CommitId) -> K::Future<'_, Result<(), S::Error>> {
+    pub fn delete_fragment(&self, fragment_head: CommitId) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage
             .delete_fragment(self.sedimentree_id, fragment_head)
     }
 
     /// Delete all fragments and their blobs for this sedimentree.
     #[must_use]
-    pub fn delete_fragments(&self) -> K::Future<'_, Result<(), S::Error>> {
+    pub fn delete_fragments(&self) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage.delete_fragments(self.sedimentree_id)
     }
 }
 
-impl<K: FutureForm, S: Storage<K>> Clone for Destroyer<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> Clone for Destroyer<Async, Store> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),
@@ -84,7 +84,7 @@ impl<K: FutureForm, S: Storage<K>> Clone for Destroyer<K, S> {
     }
 }
 
-impl<K: FutureForm, S: Storage<K>> core::fmt::Debug for Destroyer<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> core::fmt::Debug for Destroyer<Async, Store> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Destroyer")
             .field("sedimentree_id", &self.sedimentree_id)

--- a/subduction_core/src/storage/destroyer.rs
+++ b/subduction_core/src/storage/destroyer.rs
@@ -49,7 +49,10 @@ impl<Async: FutureForm, Store: Storage<Async>> Destroyer<Async, Store> {
 
     /// Delete a single loose commit and its blob by [`CommitId`].
     #[must_use]
-    pub fn delete_loose_commit(&self, commit_id: CommitId) -> Async::Future<'_, Result<(), Store::Error>> {
+    pub fn delete_loose_commit(
+        &self,
+        commit_id: CommitId,
+    ) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage
             .delete_loose_commit(self.sedimentree_id, commit_id)
     }
@@ -62,7 +65,10 @@ impl<Async: FutureForm, Store: Storage<Async>> Destroyer<Async, Store> {
 
     /// Delete a fragment and its blob by fragment head [`CommitId`].
     #[must_use]
-    pub fn delete_fragment(&self, fragment_head: CommitId) -> Async::Future<'_, Result<(), Store::Error>> {
+    pub fn delete_fragment(
+        &self,
+        fragment_head: CommitId,
+    ) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage
             .delete_fragment(self.sedimentree_id, fragment_head)
     }

--- a/subduction_core/src/storage/fetcher.rs
+++ b/subduction_core/src/storage/fetcher.rs
@@ -94,7 +94,9 @@ impl<Async: FutureForm, Store: Storage<Async>> Fetcher<Async, Store> {
 
     /// Load all fragments with their blobs for this sedimentree.
     #[must_use]
-    pub fn load_fragments(&self) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Store::Error>> {
+    pub fn load_fragments(
+        &self,
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Store::Error>> {
         self.storage.load_fragments(self.sedimentree_id)
     }
 }

--- a/subduction_core/src/storage/fetcher.rs
+++ b/subduction_core/src/storage/fetcher.rs
@@ -22,17 +22,17 @@ use super::traits::Storage;
 /// - The storage backend to fetch from
 ///
 /// Created via [`Subduction::authorize_fetch`][crate::subduction::Subduction].
-pub struct Fetcher<K: FutureForm, S: Storage<K>> {
-    storage: Arc<S>,
+pub struct Fetcher<Async: FutureForm, Store: Storage<Async>> {
+    storage: Arc<Store>,
     sedimentree_id: SedimentreeId,
-    _marker: PhantomData<K>,
+    _marker: PhantomData<Async>,
 }
 
-impl<K: FutureForm, S: Storage<K>> Fetcher<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> Fetcher<Async, Store> {
     /// Create a new fetcher capability.
     ///
     /// This should only be called after authorization has been verified.
-    pub(super) const fn new(storage: Arc<S>, sedimentree_id: SedimentreeId) -> Self {
+    pub(super) const fn new(storage: Arc<Store>, sedimentree_id: SedimentreeId) -> Self {
         Self {
             storage,
             sedimentree_id,
@@ -50,7 +50,7 @@ impl<K: FutureForm, S: Storage<K>> Fetcher<K, S> {
 
     /// List all commit IDs for this sedimentree.
     #[must_use]
-    pub fn list_commit_ids(&self) -> K::Future<'_, Result<Set<CommitId>, S::Error>> {
+    pub fn list_commit_ids(&self) -> Async::Future<'_, Result<Set<CommitId>, Store::Error>> {
         self.storage.list_commit_ids(self.sedimentree_id)
     }
 
@@ -58,7 +58,7 @@ impl<K: FutureForm, S: Storage<K>> Fetcher<K, S> {
     #[must_use]
     pub fn load_loose_commits(
         &self,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, S::Error>> {
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Store::Error>> {
         self.storage.load_loose_commits(self.sedimentree_id)
     }
 
@@ -67,7 +67,7 @@ impl<K: FutureForm, S: Storage<K>> Fetcher<K, S> {
     pub fn load_loose_commit(
         &self,
         commit_id: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, S::Error>> {
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, Store::Error>> {
         self.storage
             .load_loose_commit(self.sedimentree_id, commit_id)
     }
@@ -81,25 +81,25 @@ impl<K: FutureForm, S: Storage<K>> Fetcher<K, S> {
     pub fn load_fragment(
         &self,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<Fragment>>, S::Error>> {
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Store::Error>> {
         self.storage
             .load_fragment(self.sedimentree_id, fragment_head)
     }
 
     /// List all fragment head [`CommitId`] values for this sedimentree.
     #[must_use]
-    pub fn list_fragment_ids(&self) -> K::Future<'_, Result<Set<CommitId>, S::Error>> {
+    pub fn list_fragment_ids(&self) -> Async::Future<'_, Result<Set<CommitId>, Store::Error>> {
         self.storage.list_fragment_ids(self.sedimentree_id)
     }
 
     /// Load all fragments with their blobs for this sedimentree.
     #[must_use]
-    pub fn load_fragments(&self) -> K::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, S::Error>> {
+    pub fn load_fragments(&self) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Store::Error>> {
         self.storage.load_fragments(self.sedimentree_id)
     }
 }
 
-impl<K: FutureForm, S: Storage<K>> Clone for Fetcher<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> Clone for Fetcher<Async, Store> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),
@@ -109,7 +109,7 @@ impl<K: FutureForm, S: Storage<K>> Clone for Fetcher<K, S> {
     }
 }
 
-impl<K: FutureForm, S: Storage<K>> core::fmt::Debug for Fetcher<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> core::fmt::Debug for Fetcher<Async, Store> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Fetcher")
             .field("sedimentree_id", &self.sedimentree_id)

--- a/subduction_core/src/storage/local_access.rs
+++ b/subduction_core/src/storage/local_access.rs
@@ -26,13 +26,13 @@ use super::traits::Storage;
 ///
 /// This bypasses the capability model — only use from trusted code paths.
 #[derive(Debug)]
-pub struct LocalStorageAccess<S> {
-    storage: Arc<S>,
+pub struct LocalStorageAccess<Store> {
+    storage: Arc<Store>,
 }
 
-impl<S> LocalStorageAccess<S> {
+impl<Store> LocalStorageAccess<Store> {
     /// Create a new local storage access wrapper.
-    pub const fn new(storage: Arc<S>) -> Self {
+    pub const fn new(storage: Arc<Store>) -> Self {
         Self { storage }
     }
 
@@ -40,7 +40,7 @@ impl<S> LocalStorageAccess<S> {
     ///
     /// This is useful when you need to pass the storage to other components.
     #[must_use]
-    pub const fn storage(&self) -> &Arc<S> {
+    pub const fn storage(&self) -> &Arc<Store> {
         &self.storage
     }
 
@@ -48,11 +48,11 @@ impl<S> LocalStorageAccess<S> {
 
     /// Load all sedimentree IDs from storage.
     #[must_use]
-    pub fn load_all_sedimentree_ids<K: FutureForm>(
+    pub fn load_all_sedimentree_ids<Async: FutureForm>(
         &self,
-    ) -> K::Future<'_, Result<Set<SedimentreeId>, S::Error>>
+    ) -> Async::Future<'_, Result<Set<SedimentreeId>, Store::Error>>
     where
-        S: Storage<K>,
+        Store: Storage<Async>,
     {
         self.storage.load_all_sedimentree_ids()
     }
@@ -61,12 +61,12 @@ impl<S> LocalStorageAccess<S> {
     ///
     /// Used for hydration at startup.
     #[must_use]
-    pub fn load_loose_commits<K: FutureForm>(
+    pub fn load_loose_commits<Async: FutureForm>(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, S::Error>>
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Store::Error>>
     where
-        S: Storage<K>,
+        Store: Storage<Async>,
     {
         self.storage.load_loose_commits(sedimentree_id)
     }
@@ -75,18 +75,18 @@ impl<S> LocalStorageAccess<S> {
     ///
     /// Used for hydration at startup.
     #[must_use]
-    pub fn load_fragments<K: FutureForm>(
+    pub fn load_fragments<Async: FutureForm>(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, S::Error>>
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Store::Error>>
     where
-        S: Storage<K>,
+        Store: Storage<Async>,
     {
         self.storage.load_fragments(sedimentree_id)
     }
 }
 
-impl<S> Clone for LocalStorageAccess<S> {
+impl<Store> Clone for LocalStorageAccess<Store> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),

--- a/subduction_core/src/storage/memory.rs
+++ b/subduction_core/src/storage/memory.rs
@@ -87,7 +87,9 @@ impl<Async: FutureForm> Storage<Async> for MemoryStorage {
         })
     }
 
-    fn load_all_sedimentree_ids(&self) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
+    fn load_all_sedimentree_ids(
+        &self,
+    ) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
         Async::from_future(async move {
             tracing::debug!("MemoryStorage::load_all_sedimentree_ids");
             Ok(self.ids.lock().await.iter().copied().collect())

--- a/subduction_core/src/storage/memory.rs
+++ b/subduction_core/src/storage/memory.rs
@@ -60,7 +60,7 @@ impl MemoryStorage {
 pub struct MemoryStorageError(#[from] sedimentree_core::codec::error::DecodeError);
 
 #[future_form(Sendable, Local)]
-impl<K: FutureForm> Storage<K> for MemoryStorage {
+impl<Async: FutureForm> Storage<Async> for MemoryStorage {
     type Error = MemoryStorageError;
 
     // ==================== Sedimentree IDs ====================
@@ -68,8 +68,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn save_sedimentree_id(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::save_sedimentree_id");
             self.ids.lock().await.insert(sedimentree_id);
             Ok(())
@@ -79,16 +79,16 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn delete_sedimentree_id(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::delete_sedimentree_id");
             self.ids.lock().await.remove(&sedimentree_id);
             Ok(())
         })
     }
 
-    fn load_all_sedimentree_ids(&self) -> K::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
-        K::from_future(async move {
+    fn load_all_sedimentree_ids(&self) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!("MemoryStorage::load_all_sedimentree_ids");
             Ok(self.ids.lock().await.iter().copied().collect())
         })
@@ -100,8 +100,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
         &self,
         sedimentree_id: SedimentreeId,
         verified: VerifiedMeta<LooseCommit>,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let commit_id = verified.payload().head();
             let digest = Digest::hash(verified.payload());
             tracing::debug!(?sedimentree_id, ?digest, "MemoryStorage::save_loose_commit");
@@ -121,8 +121,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn list_commit_ids(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Set<CommitId>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Set<CommitId>, Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::list_commit_ids");
             let locked = self.commits.lock().await;
             Ok(locked
@@ -135,8 +135,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn load_loose_commits(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::load_loose_commits");
             let locked = self.commits.lock().await;
             locked
@@ -158,8 +158,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
         &self,
         sedimentree_id: SedimentreeId,
         commit_id: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(
                 ?sedimentree_id,
                 ?commit_id,
@@ -184,8 +184,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
         &self,
         sedimentree_id: SedimentreeId,
         commit_id: CommitId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(
                 ?sedimentree_id,
                 ?commit_id,
@@ -201,8 +201,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn delete_loose_commits(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::delete_loose_commits");
             self.commits.lock().await.remove(&sedimentree_id);
             Ok(())
@@ -215,8 +215,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
         &self,
         sedimentree_id: SedimentreeId,
         verified: VerifiedMeta<Fragment>,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let fragment_head = verified.payload().head();
             let digest = Digest::hash(verified.payload());
             tracing::debug!(?sedimentree_id, ?digest, "MemoryStorage::save_fragment");
@@ -237,8 +237,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
         &self,
         sedimentree_id: SedimentreeId,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(
                 ?sedimentree_id,
                 ?fragment_head,
@@ -262,8 +262,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn list_fragment_ids(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Set<CommitId>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Set<CommitId>, Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::list_fragment_ids");
             let locked = self.fragments.lock().await;
             Ok(locked
@@ -276,8 +276,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn load_fragments(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::load_fragments");
             let locked = self.fragments.lock().await;
             locked
@@ -299,8 +299,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
         &self,
         sedimentree_id: SedimentreeId,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(
                 ?sedimentree_id,
                 ?fragment_head,
@@ -316,8 +316,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
     fn delete_fragments(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             tracing::debug!(?sedimentree_id, "MemoryStorage::delete_fragments");
             self.fragments.lock().await.remove(&sedimentree_id);
             Ok(())
@@ -331,8 +331,8 @@ impl<K: FutureForm> Storage<K> for MemoryStorage {
         sedimentree_id: SedimentreeId,
         commits: Vec<VerifiedMeta<LooseCommit>>,
         fragments: Vec<VerifiedMeta<Fragment>>,
-    ) -> K::Future<'_, Result<usize, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<usize, Self::Error>> {
+        Async::from_future(async move {
             let num_commits = commits.len();
             let num_fragments = fragments.len();
             tracing::debug!(

--- a/subduction_core/src/storage/metrics.rs
+++ b/subduction_core/src/storage/metrics.rs
@@ -140,7 +140,9 @@ impl<Async: FutureForm, Store> Storage<Async> for MetricsStorage<Store> {
         })
     }
 
-    fn load_all_sedimentree_ids(&self) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
+    fn load_all_sedimentree_ids(
+        &self,
+    ) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
         Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.load_all_sedimentree_ids().await;

--- a/subduction_core/src/storage/metrics.rs
+++ b/subduction_core/src/storage/metrics.rs
@@ -23,32 +23,32 @@ use crate::{metrics, storage::traits::Storage};
 /// This wrapper delegates all storage operations to an inner storage implementation
 /// while recording metrics for each operation.
 #[derive(Debug, Clone)]
-pub struct MetricsStorage<S> {
-    inner: S,
+pub struct MetricsStorage<Store> {
+    inner: Store,
 }
 
-impl<S> MetricsStorage<S> {
+impl<Store> MetricsStorage<Store> {
     /// Create a new `MetricsStorage` wrapper around the given storage.
     #[must_use]
-    pub const fn new(inner: S) -> Self {
+    pub const fn new(inner: Store) -> Self {
         Self { inner }
     }
 
     /// Get a reference to the inner storage.
     #[must_use]
-    pub const fn inner(&self) -> &S {
+    pub const fn inner(&self) -> &Store {
         &self.inner
     }
 
     /// Get a mutable reference to the inner storage.
     #[must_use]
-    pub const fn inner_mut(&mut self) -> &mut S {
+    pub const fn inner_mut(&mut self) -> &mut Store {
         &mut self.inner
     }
 
     /// Unwrap this wrapper and return the inner storage.
     #[must_use]
-    pub fn into_inner(self) -> S {
+    pub fn into_inner(self) -> Store {
         self.inner
     }
 }
@@ -66,8 +66,8 @@ pub trait RefreshMetrics {
     fn refresh_metrics(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
-impl<S: Storage<Sendable> + Send + Sync> RefreshMetrics for MetricsStorage<S> {
-    type Error = S::Error;
+impl<Store: Storage<Sendable> + Send + Sync> RefreshMetrics for MetricsStorage<Store> {
+    type Error = Store::Error;
 
     async fn refresh_metrics(&self) -> Result<(), Self::Error> {
         let sedimentree_ids = Storage::<Sendable>::load_all_sedimentree_ids(&self.inner).await?;
@@ -104,17 +104,17 @@ impl<S: Storage<Sendable> + Send + Sync> RefreshMetrics for MetricsStorage<S> {
     }
 }
 
-#[future_form(Sendable where S: Storage<Sendable> + Send + Sync, Local where S: Storage<Local>)]
-impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
-    type Error = S::Error;
+#[future_form(Sendable where Store: Storage<Sendable> + Send + Sync, Local where Store: Storage<Local>)]
+impl<Async: FutureForm, Store> Storage<Async> for MetricsStorage<Store> {
+    type Error = Store::Error;
 
     // ==================== Sedimentree IDs ====================
 
     fn save_sedimentree_id(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.save_sedimentree_id(sedimentree_id).await;
             metrics::storage_operation_duration(
@@ -128,8 +128,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
     fn delete_sedimentree_id(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.delete_sedimentree_id(sedimentree_id).await;
             metrics::storage_operation_duration(
@@ -140,8 +140,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         })
     }
 
-    fn load_all_sedimentree_ids(&self) -> K::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
-        K::from_future(async move {
+    fn load_all_sedimentree_ids(&self) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.load_all_sedimentree_ids().await;
             metrics::storage_operation_duration(
@@ -158,8 +158,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         &self,
         sedimentree_id: SedimentreeId,
         verified: VerifiedMeta<LooseCommit>,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.save_loose_commit(sedimentree_id, verified).await;
             metrics::storage_operation_duration("save_loose_commit", start.elapsed().as_secs_f64());
@@ -170,8 +170,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
     fn list_commit_ids(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Set<CommitId>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Set<CommitId>, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.list_commit_ids(sedimentree_id).await;
             metrics::storage_operation_duration("list_commit_ids", start.elapsed().as_secs_f64());
@@ -182,8 +182,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
     fn load_loose_commits(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.load_loose_commits(sedimentree_id).await;
             metrics::storage_operation_duration(
@@ -198,8 +198,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         &self,
         sedimentree_id: SedimentreeId,
         commit_id: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self
                 .inner
@@ -214,8 +214,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         &self,
         sedimentree_id: SedimentreeId,
         commit_id: CommitId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self
                 .inner
@@ -232,8 +232,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
     fn delete_loose_commits(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.delete_loose_commits(sedimentree_id).await;
             metrics::storage_operation_duration(
@@ -250,8 +250,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         &self,
         sedimentree_id: SedimentreeId,
         verified: VerifiedMeta<Fragment>,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.save_fragment(sedimentree_id, verified).await;
             metrics::storage_operation_duration("save_fragment", start.elapsed().as_secs_f64());
@@ -263,8 +263,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         &self,
         sedimentree_id: SedimentreeId,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self
                 .inner
@@ -278,8 +278,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
     fn list_fragment_ids(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Set<CommitId>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Set<CommitId>, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.list_fragment_ids(sedimentree_id).await;
             metrics::storage_operation_duration("list_fragment_ids", start.elapsed().as_secs_f64());
@@ -290,8 +290,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
     fn load_fragments(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.load_fragments(sedimentree_id).await;
             metrics::storage_operation_duration("load_fragments", start.elapsed().as_secs_f64());
@@ -303,8 +303,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         &self,
         sedimentree_id: SedimentreeId,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self
                 .inner
@@ -318,8 +318,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
     fn delete_fragments(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self.inner.delete_fragments(sedimentree_id).await;
             metrics::storage_operation_duration("delete_fragments", start.elapsed().as_secs_f64());
@@ -334,8 +334,8 @@ impl<K: FutureForm, S> Storage<K> for MetricsStorage<S> {
         sedimentree_id: SedimentreeId,
         commits: Vec<VerifiedMeta<LooseCommit>>,
         fragments: Vec<VerifiedMeta<Fragment>>,
-    ) -> K::Future<'_, Result<usize, Self::Error>> {
-        K::from_future(async move {
+    ) -> Async::Future<'_, Result<usize, Self::Error>> {
+        Async::from_future(async move {
             let start = Instant::now();
             let result = self
                 .inner

--- a/subduction_core/src/storage/powerbox.rs
+++ b/subduction_core/src/storage/powerbox.rs
@@ -30,14 +30,14 @@ use subduction_crypto::verified_author::VerifiedAuthor;
 /// The powerbox holds both the storage backend and the authorization policy,
 /// making it the single trust boundary for capability minting.
 #[derive(Debug)]
-pub struct StoragePowerbox<S, P> {
-    storage: Arc<S>,
-    policy: Arc<P>,
+pub struct StoragePowerbox<Store, Auth> {
+    storage: Arc<Store>,
+    policy: Arc<Auth>,
 }
 
-impl<S, P> StoragePowerbox<S, P> {
+impl<Store, Auth> StoragePowerbox<Store, Auth> {
     /// Create a new powerbox wrapping the given storage and policy.
-    pub fn new(storage: S, policy: Arc<P>) -> Self {
+    pub fn new(storage: Store, policy: Arc<Auth>) -> Self {
         Self {
             storage: Arc::new(storage),
             policy,
@@ -48,7 +48,7 @@ impl<S, P> StoragePowerbox<S, P> {
     ///
     /// This is useful for connection policy decisions outside of storage access.
     #[must_use]
-    pub fn policy(&self) -> &P {
+    pub fn policy(&self) -> &Auth {
         &self.policy
     }
 
@@ -56,7 +56,7 @@ impl<S, P> StoragePowerbox<S, P> {
     ///
     /// This is useful when you need shared ownership of the policy.
     #[must_use]
-    pub fn policy_arc(&self) -> Arc<P> {
+    pub fn policy_arc(&self) -> Arc<Auth> {
         self.policy.clone()
     }
 
@@ -65,9 +65,12 @@ impl<S, P> StoragePowerbox<S, P> {
     /// Use this for compaction, garbage collection, and other local-only
     /// delete operations. Never hand this capability to peers.
     #[must_use]
-    pub fn local_destroyer<K: FutureForm>(&self, sedimentree_id: SedimentreeId) -> Destroyer<K, S>
+    pub fn local_destroyer<Async: FutureForm>(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> Destroyer<Async, Store>
     where
-        S: Storage<K>,
+        Store: Storage<Async>,
     {
         Destroyer::new(self.storage.clone(), sedimentree_id)
     }
@@ -79,14 +82,14 @@ impl<S, P> StoragePowerbox<S, P> {
     /// # Errors
     ///
     /// Returns the policy's `FetchDisallowed` error if authorization fails.
-    pub async fn get_fetcher<K: FutureForm>(
+    pub async fn get_fetcher<Async: FutureForm>(
         &self,
         peer: PeerId,
         sedimentree_id: SedimentreeId,
-    ) -> Result<Fetcher<K, S>, P::FetchDisallowed>
+    ) -> Result<Fetcher<Async, Store>, Auth::FetchDisallowed>
     where
-        S: Storage<K>,
-        P: StoragePolicy<K>,
+        Store: Storage<Async>,
+        Auth: StoragePolicy<Async>,
     {
         self.policy.authorize_fetch(peer, sedimentree_id).await?;
         Ok(Fetcher::new(self.storage.clone(), sedimentree_id))
@@ -104,15 +107,15 @@ impl<S, P> StoragePowerbox<S, P> {
     /// # Errors
     ///
     /// Returns the policy's `PutDisallowed` error if authorization fails.
-    pub async fn get_putter<K: FutureForm>(
+    pub async fn get_putter<Async: FutureForm>(
         &self,
         requestor: PeerId,
         author: VerifiedAuthor,
         sedimentree_id: SedimentreeId,
-    ) -> Result<Putter<K, S>, P::PutDisallowed>
+    ) -> Result<Putter<Async, Store>, Auth::PutDisallowed>
     where
-        S: Storage<K>,
-        P: StoragePolicy<K>,
+        Store: Storage<Async>,
+        Auth: StoragePolicy<Async>,
     {
         self.policy
             .authorize_put(requestor, author, sedimentree_id)
@@ -131,9 +134,12 @@ impl<S, P> StoragePowerbox<S, P> {
     /// [`add_commit`]: crate::subduction::Subduction::add_commit
     /// [`add_fragment`]: crate::subduction::Subduction::add_fragment
     #[must_use]
-    pub(crate) fn local_putter<K: FutureForm>(&self, sedimentree_id: SedimentreeId) -> Putter<K, S>
+    pub(crate) fn local_putter<Async: FutureForm>(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> Putter<Async, Store>
     where
-        S: Storage<K>,
+        Store: Storage<Async>,
     {
         Putter::new(self.storage.clone(), sedimentree_id)
     }
@@ -147,12 +153,12 @@ impl<S, P> StoragePowerbox<S, P> {
     /// All other access should go through [`get_fetcher`](Self::get_fetcher)
     /// or [`get_putter`](Self::get_putter).
     #[must_use]
-    pub(crate) fn hydration_access(&self) -> LocalStorageAccess<S> {
+    pub(crate) fn hydration_access(&self) -> LocalStorageAccess<Store> {
         LocalStorageAccess::new(self.storage.clone())
     }
 }
 
-impl<S, P> Clone for StoragePowerbox<S, P> {
+impl<Store, Auth> Clone for StoragePowerbox<Store, Auth> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),

--- a/subduction_core/src/storage/putter.rs
+++ b/subduction_core/src/storage/putter.rs
@@ -125,7 +125,9 @@ impl<Async: FutureForm, Store: Storage<Async>> Putter<Async, Store> {
 
     /// Load all fragments with their blobs for this sedimentree.
     #[must_use]
-    pub fn load_fragments(&self) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Store::Error>> {
+    pub fn load_fragments(
+        &self,
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Store::Error>> {
         self.storage.load_fragments(self.sedimentree_id)
     }
 

--- a/subduction_core/src/storage/putter.rs
+++ b/subduction_core/src/storage/putter.rs
@@ -24,17 +24,17 @@ use super::{fetcher::Fetcher, traits::Storage};
 /// Created via [`Subduction::authorize_put`][crate::subduction::Subduction].
 ///
 /// A `Putter` also grants fetch access (put implies fetch).
-pub struct Putter<K: FutureForm, S: Storage<K>> {
-    storage: Arc<S>,
+pub struct Putter<Async: FutureForm, Store: Storage<Async>> {
+    storage: Arc<Store>,
     sedimentree_id: SedimentreeId,
-    _marker: PhantomData<K>,
+    _marker: PhantomData<Async>,
 }
 
-impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> Putter<Async, Store> {
     /// Create a new putter capability.
     ///
     /// This should only be called after authorization has been verified.
-    pub(super) const fn new(storage: Arc<S>, sedimentree_id: SedimentreeId) -> Self {
+    pub(super) const fn new(storage: Arc<Store>, sedimentree_id: SedimentreeId) -> Self {
         Self {
             storage,
             sedimentree_id,
@@ -52,7 +52,7 @@ impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
     ///
     /// This is useful when you have put access but only need to fetch.
     #[must_use]
-    pub fn as_fetcher(&self) -> Fetcher<K, S> {
+    pub fn as_fetcher(&self) -> Fetcher<Async, Store> {
         Fetcher::new(self.storage.clone(), self.sedimentree_id)
     }
 
@@ -69,14 +69,14 @@ impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
     pub fn save_commit(
         &self,
         verified: VerifiedMeta<LooseCommit>,
-    ) -> K::Future<'_, Result<(), S::Error>> {
+    ) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage
             .save_loose_commit(self.sedimentree_id, verified)
     }
 
     /// List all commit IDs for this sedimentree.
     #[must_use]
-    pub fn list_commit_ids(&self) -> K::Future<'_, Result<Set<CommitId>, S::Error>> {
+    pub fn list_commit_ids(&self) -> Async::Future<'_, Result<Set<CommitId>, Store::Error>> {
         self.storage.list_commit_ids(self.sedimentree_id)
     }
 
@@ -84,7 +84,7 @@ impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
     #[must_use]
     pub fn load_loose_commits(
         &self,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, S::Error>> {
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Store::Error>> {
         self.storage.load_loose_commits(self.sedimentree_id)
     }
 
@@ -101,7 +101,7 @@ impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
     pub fn save_fragment(
         &self,
         verified: VerifiedMeta<Fragment>,
-    ) -> K::Future<'_, Result<(), S::Error>> {
+    ) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage.save_fragment(self.sedimentree_id, verified)
     }
 
@@ -112,20 +112,20 @@ impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
     pub fn load_fragment(
         &self,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<Fragment>>, S::Error>> {
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Store::Error>> {
         self.storage
             .load_fragment(self.sedimentree_id, fragment_head)
     }
 
     /// List all fragment head [`CommitId`] values for this sedimentree.
     #[must_use]
-    pub fn list_fragment_ids(&self) -> K::Future<'_, Result<Set<CommitId>, S::Error>> {
+    pub fn list_fragment_ids(&self) -> Async::Future<'_, Result<Set<CommitId>, Store::Error>> {
         self.storage.list_fragment_ids(self.sedimentree_id)
     }
 
     /// Load all fragments with their blobs for this sedimentree.
     #[must_use]
-    pub fn load_fragments(&self) -> K::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, S::Error>> {
+    pub fn load_fragments(&self) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Store::Error>> {
         self.storage.load_fragments(self.sedimentree_id)
     }
 
@@ -139,7 +139,7 @@ impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
         &self,
         commits: Vec<VerifiedMeta<LooseCommit>>,
         fragments: Vec<VerifiedMeta<Fragment>>,
-    ) -> K::Future<'_, Result<usize, S::Error>> {
+    ) -> Async::Future<'_, Result<usize, Store::Error>> {
         self.storage
             .save_batch(self.sedimentree_id, commits, fragments)
     }
@@ -150,12 +150,12 @@ impl<K: FutureForm, S: Storage<K>> Putter<K, S> {
     ///
     /// This is bookkeeping to track which sedimentrees exist.
     #[must_use]
-    pub fn save_sedimentree_id(&self) -> K::Future<'_, Result<(), S::Error>> {
+    pub fn save_sedimentree_id(&self) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage.save_sedimentree_id(self.sedimentree_id)
     }
 }
 
-impl<K: FutureForm, S: Storage<K>> Clone for Putter<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> Clone for Putter<Async, Store> {
     fn clone(&self) -> Self {
         Self {
             storage: self.storage.clone(),
@@ -165,7 +165,7 @@ impl<K: FutureForm, S: Storage<K>> Clone for Putter<K, S> {
     }
 }
 
-impl<K: FutureForm, S: Storage<K>> core::fmt::Debug for Putter<K, S> {
+impl<Async: FutureForm, Store: Storage<Async>> core::fmt::Debug for Putter<Async, Store> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Putter")
             .field("sedimentree_id", &self.sedimentree_id)

--- a/subduction_core/src/storage/traits.rs
+++ b/subduction_core/src/storage/traits.rs
@@ -87,7 +87,9 @@ pub trait Storage<Async: FutureForm + ?Sized> {
     ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Get all sedimentree IDs that have data stored.
-    fn load_all_sedimentree_ids(&self) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>>;
+    fn load_all_sedimentree_ids(
+        &self,
+    ) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>>;
 
     // ==================== Loose Commits (compound with blob) ====================
 

--- a/subduction_core/src/storage/traits.rs
+++ b/subduction_core/src/storage/traits.rs
@@ -68,7 +68,7 @@ use subduction_crypto::verified_meta::VerifiedMeta;
 /// [`load_fragment`](Storage::load_fragment)) are available for targeted
 /// lookups (e.g., fetching a specific blob).
 #[allow(clippy::type_complexity)]
-pub trait Storage<K: FutureForm + ?Sized> {
+pub trait Storage<Async: FutureForm + ?Sized> {
     /// The error type for storage operations.
     type Error: core::error::Error;
 
@@ -78,16 +78,16 @@ pub trait Storage<K: FutureForm + ?Sized> {
     fn save_sedimentree_id(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Delete a sedimentree ID.
     fn delete_sedimentree_id(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Get all sedimentree IDs that have data stored.
-    fn load_all_sedimentree_ids(&self) -> K::Future<'_, Result<Set<SedimentreeId>, Self::Error>>;
+    fn load_all_sedimentree_ids(&self) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>>;
 
     // ==================== Loose Commits (compound with blob) ====================
 
@@ -100,7 +100,7 @@ pub trait Storage<K: FutureForm + ?Sized> {
         &self,
         sedimentree_id: SedimentreeId,
         verified: VerifiedMeta<LooseCommit>,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// List all [`CommitId`] values for a sedimentree.
     ///
@@ -110,7 +110,7 @@ pub trait Storage<K: FutureForm + ?Sized> {
     fn list_commit_ids(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Set<CommitId>, Self::Error>>;
+    ) -> Async::Future<'_, Result<Set<CommitId>, Self::Error>>;
 
     /// Load all loose commits with their blobs for a sedimentree.
     ///
@@ -123,7 +123,7 @@ pub trait Storage<K: FutureForm + ?Sized> {
     fn load_loose_commits(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Self::Error>>;
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Self::Error>>;
 
     /// Load a single loose commit by [`CommitId`].
     ///
@@ -134,20 +134,20 @@ pub trait Storage<K: FutureForm + ?Sized> {
         &self,
         sedimentree_id: SedimentreeId,
         commit_id: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, Self::Error>>;
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<LooseCommit>>, Self::Error>>;
 
     /// Delete a single loose commit and its blob by [`CommitId`].
     fn delete_loose_commit(
         &self,
         sedimentree_id: SedimentreeId,
         commit_id: CommitId,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Delete all loose commits and their blobs for a sedimentree.
     fn delete_loose_commits(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     // ==================== Fragments (compound with blob) ====================
 
@@ -159,7 +159,7 @@ pub trait Storage<K: FutureForm + ?Sized> {
         &self,
         sedimentree_id: SedimentreeId,
         verified: VerifiedMeta<Fragment>,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Load a fragment with its blob by fragment head [`CommitId`].
     ///
@@ -170,7 +170,7 @@ pub trait Storage<K: FutureForm + ?Sized> {
         &self,
         sedimentree_id: SedimentreeId,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Self::Error>>;
+    ) -> Async::Future<'_, Result<Option<VerifiedMeta<Fragment>>, Self::Error>>;
 
     /// List all fragment head [`CommitId`] values for a sedimentree.
     ///
@@ -179,7 +179,7 @@ pub trait Storage<K: FutureForm + ?Sized> {
     fn list_fragment_ids(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Set<CommitId>, Self::Error>>;
+    ) -> Async::Future<'_, Result<Set<CommitId>, Self::Error>>;
 
     /// Load all fragments with their blobs for a sedimentree.
     ///
@@ -188,20 +188,20 @@ pub trait Storage<K: FutureForm + ?Sized> {
     fn load_fragments(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Self::Error>>;
+    ) -> Async::Future<'_, Result<Vec<VerifiedMeta<Fragment>>, Self::Error>>;
 
     /// Delete a fragment and its blob by fragment head [`CommitId`].
     fn delete_fragment(
         &self,
         sedimentree_id: SedimentreeId,
         fragment_head: CommitId,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Delete all fragments and their blobs for a sedimentree.
     fn delete_fragments(
         &self,
         sedimentree_id: SedimentreeId,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     // ==================== Batch Operations ====================
 
@@ -235,5 +235,5 @@ pub trait Storage<K: FutureForm + ?Sized> {
         sedimentree_id: SedimentreeId,
         commits: Vec<VerifiedMeta<LooseCommit>>,
         fragments: Vec<VerifiedMeta<Fragment>>,
-    ) -> K::Future<'_, Result<usize, Self::Error>>;
+    ) -> Async::Future<'_, Result<usize, Self::Error>>;
 }

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -135,26 +135,26 @@ use pending_blob_requests::PendingBlobRequests;
 #[allow(clippy::type_complexity)]
 pub struct Subduction<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + Clone + 'static,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric = CountLeadingZeroBytes,
-    const N: usize = 256,
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + Clone + 'static,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric = CountLeadingZeroBytes,
+    const SHARDS: usize = 256,
 > {
-    handler: Arc<H>,
-    signer: Sig,
+    handler: Arc<Hdl>,
+    signer: Sign,
     discovery_id: Option<DiscoveryId>,
 
-    timer: O,
-    depth_metric: M,
-    sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, N>>,
-    storage: StoragePowerbox<S, P>,
+    timer: Timer,
+    depth_metric: Metric,
+    sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>,
+    storage: StoragePowerbox<Store, Auth>,
 
-    connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>>,
+    connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
 
     /// Per-connection multiplexers for request-response correlation.
     ///
@@ -193,15 +193,15 @@ pub struct Subduction<
     /// produced it.
     send_counter: PeerCounter,
 
-    manager_channel: Sender<Command<Authenticated<C, F>>>,
-    msg_queue: async_channel::Receiver<(Authenticated<C, F>, H::Message)>,
-    response_queue: async_channel::Receiver<(Authenticated<C, F>, H::Message)>,
-    connection_closed: async_channel::Receiver<(ConnectionId, Authenticated<C, F>)>,
+    manager_channel: Sender<Command<Authenticated<Conn, Async>>>,
+    msg_queue: async_channel::Receiver<(Authenticated<Conn, Async>, Hdl::Message)>,
+    response_queue: async_channel::Receiver<(Authenticated<Conn, Async>, Hdl::Message)>,
+    connection_closed: async_channel::Receiver<(ConnectionId, Authenticated<Conn, Async>)>,
 
     abort_manager_handle: AbortHandle,
     abort_listener_handle: AbortHandle,
 
-    _phantom: core::marker::PhantomData<&'a F>,
+    _phantom: core::marker::PhantomData<&'a Async>,
 }
 
 /// A single fragment for [`Subduction::add_fragments_batch`].
@@ -219,21 +219,21 @@ pub struct FragmentBatchItem {
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N> + 'static,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> Subduction<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS> + 'static,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 where
-    H::Message: From<SyncMessage>,
-    H::HandlerError: Into<ListenError<F, S, C, H::Message>>,
-    ManagedConnection<C, F, O>:
-        ManagedCall<F, H::Message, SendError = <C as Connection<F, H::Message>>::SendError>,
+    Hdl::Message: From<SyncMessage>,
+    Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
+    ManagedConnection<Conn, Async, Timer>:
+        ManagedCall<Async, Hdl::Message, SendError = <Conn as Connection<Async, Hdl::Message>>::SendError>,
 {
     /// Initialize a new `Subduction` instance.
     ///
@@ -278,29 +278,29 @@ where
     /// );
     /// ```
     #[allow(clippy::type_complexity, clippy::too_many_arguments)]
-    pub fn new<Sp: Spawn<F> + Send + Sync + 'static>(
-        handler: Arc<H>,
+    pub fn new<Sp: Spawn<Async> + Send + Sync + 'static>(
+        handler: Arc<Hdl>,
         discovery_id: Option<DiscoveryId>,
-        signer: Sig,
-        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, N>>,
-        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>>,
+        signer: Sign,
+        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>,
+        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
-        storage: StoragePowerbox<S, P>,
+        storage: StoragePowerbox<Store, Auth>,
         pending_blob_requests: Arc<Mutex<PendingBlobRequests>>,
         send_counter: PeerCounter,
         nonce_cache: NonceCache,
-        timer: O,
+        timer: Timer,
         default_call_timeout: Duration,
-        depth_metric: M,
+        depth_metric: Metric,
         spawner: Sp,
     ) -> (
         Arc<Self>,
-        ListenerFuture<'a, F, S, C, H, P, Sig, O, M, N>,
-        crate::connection::manager::ManagerFuture<F>,
+        ListenerFuture<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>,
+        crate::connection::manager::ManagerFuture<Async>,
     )
     where
-        F: StartListener<'a, S, C, H::Message, H, P, Sig, M, N>,
-        O: Send + Sync + 'a,
+        Async: StartListener<'a, Store, Conn, Hdl::Message, Hdl, Auth, Sign, Metric, SHARDS>,
+        Timer: Send + Sync + 'a,
     {
         tracing::info!("initializing Subduction instance");
 
@@ -308,12 +308,12 @@ where
         let (queue_sender, queue_receiver) = async_channel::bounded(2048);
         let (response_sender, response_receiver) = async_channel::bounded(8192);
         let (closed_sender, closed_receiver) = async_channel::bounded(32);
-        let manager = ConnectionManager::<F, Authenticated<C, F>, H::Message, Sp>::new(
+        let manager = ConnectionManager::<Async, Authenticated<Conn, Async>, Hdl::Message, Sp>::new(
             spawner,
             manager_receiver,
             queue_sender,
             response_sender,
-            H::is_batch_sync_response_msg,
+            Hdl::is_batch_sync_response_msg,
             closed_sender,
         );
 
@@ -351,7 +351,7 @@ where
 
         (
             sd.clone(),
-            ListenerFuture::<'a, F, S, C, H, P, Sig, O, M, N>::new(F::start_listener(
+            ListenerFuture::<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>::new(Async::start_listener(
                 sd,
                 abort_listener_reg,
             )),
@@ -371,7 +371,7 @@ where
     ///
     /// Use this for signing handshake challenges/responses.
     #[must_use]
-    pub const fn signer(&self) -> &Sig {
+    pub const fn signer(&self) -> &Sign {
         &self.signer
     }
 
@@ -403,7 +403,7 @@ where
     /// This is only available with the `test_utils` feature or in tests.
     #[cfg(any(feature = "test_utils", test))]
     #[must_use]
-    pub const fn sedimentrees(&self) -> &Arc<ShardedMap<SedimentreeId, Sedimentree, N>> {
+    pub const fn sedimentrees(&self) -> &Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>> {
         &self.sedimentrees
     }
 
@@ -412,7 +412,7 @@ where
     /// Returns the first available connection to the peer. Use this to get a
     /// connection once and reuse it for multiple operations, avoiding repeated
     /// lock acquisition on the connections map.
-    pub async fn get_connection(&self, peer_id: &PeerId) -> Option<Authenticated<C, F>> {
+    pub async fn get_connection(&self, peer_id: &PeerId) -> Option<Authenticated<Conn, Async>> {
         self.connections
             .lock()
             .await
@@ -455,7 +455,7 @@ where
     pub async fn on_reconnect_success(
         &self,
         conn_id: ConnectionId,
-        conn: Authenticated<C, F>,
+        conn: Authenticated<Conn, Async>,
     ) -> Result<(), ()> {
         tracing::info!(
             %conn_id,
@@ -534,7 +534,7 @@ where
     ///
     /// * Returns `ListenError` if a handler error signals a broken connection.
     #[allow(clippy::too_many_lines)]
-    pub async fn listen(self: Arc<Self>) -> Result<(), ListenError<F, S, C, H::Message>> {
+    pub async fn listen(self: Arc<Self>) -> Result<(), ListenError<Async, Store, Conn, Hdl::Message>> {
         tracing::info!("starting Subduction listener with concurrent dispatch");
 
         let handler = &self.handler;
@@ -545,7 +545,7 @@ where
                 // 1st priority: drain completed handler tasks
                 result = in_flight.select_next_some() => {
                     #[allow(clippy::type_complexity)]
-                    let (conn, dispatch_result): (Authenticated<C, F>, Result<(), H::HandlerError>) = result;
+                    let (conn, dispatch_result): (Authenticated<Conn, Async>, Result<(), Hdl::HandlerError>) = result;
                     if let Err(e) = dispatch_result {
                         let peer_id = conn.peer_id();
                         tracing::error!(
@@ -568,7 +568,7 @@ where
                 resp_result = self.response_queue.recv().fuse() => {
                     if let Ok((conn, msg)) = resp_result {
                         let peer_id = conn.peer_id();
-                        if let Some(resp) = H::as_batch_sync_response(&msg) {
+                        if let Some(resp) = Hdl::as_batch_sync_response(&msg) {
                             let muxes_for_peer = {
                                 let multiplexers = self.multiplexers.lock().await;
                                 multiplexers.get(&peer_id).cloned()
@@ -621,7 +621,7 @@ where
                         // Safety net: if a BatchSyncResponse ended up in the
                         // request queue (should go through response_queue),
                         // route it to the multiplexer rather than the handler.
-                        if let Some(resp) = H::as_batch_sync_response(&msg) {
+                        if let Some(resp) = Hdl::as_batch_sync_response(&msg) {
                             tracing::debug!(
                                 "BatchSyncResponse from peer {peer_id} arrived via msg_queue \
                                  (expected response_queue) — routing to multiplexer"
@@ -706,11 +706,11 @@ where
     ///
     /// # Errors
     ///
-    /// * Returns `C::DisconnectionError` if disconnect fails or it occurs ungracefully.
+    /// * Returns `Conn::DisconnectionError` if disconnect fails or it occurs ungracefully.
     pub async fn disconnect(
         &self,
-        conn: &Authenticated<C, F>,
-    ) -> Result<bool, C::DisconnectionError> {
+        conn: &Authenticated<Conn, Async>,
+    ) -> Result<bool, Conn::DisconnectionError> {
         let peer_id = conn.peer_id();
         tracing::info!("Disconnecting connection from peer {}", peer_id);
 
@@ -750,9 +750,9 @@ where
     ///
     /// # Errors
     ///
-    /// * Returns [`C::DisconnectionError`] if disconnect fails or it occurs ungracefully.
-    pub async fn disconnect_all(&self) -> Result<(), C::DisconnectionError> {
-        let all_conns: Vec<Authenticated<C, F>> = {
+    /// * Returns [`Conn::DisconnectionError`] if disconnect fails or it occurs ungracefully.
+    pub async fn disconnect_all(&self) -> Result<(), Conn::DisconnectionError> {
+        let all_conns: Vec<Authenticated<Conn, Async>> = {
             let mut guard = self.connections.lock().await;
             core::mem::take(&mut *guard)
                 .into_values()
@@ -787,11 +787,11 @@ where
     ///
     /// # Errors
     ///
-    /// * Returns `C::DisconnectionError` if disconnect fails or it occurs ungracefully.
+    /// * Returns `Conn::DisconnectionError` if disconnect fails or it occurs ungracefully.
     pub async fn disconnect_from_peer(
         &self,
         peer_id: &PeerId,
-    ) -> Result<bool, C::DisconnectionError> {
+    ) -> Result<bool, Conn::DisconnectionError> {
         let peer_conns = { self.connections.lock().await.remove(peer_id) };
         self.multiplexers.lock().await.remove(peer_id);
 
@@ -830,8 +830,8 @@ where
     /// * Returns `ConnectionDisallowed` if the connection is not allowed by the policy.
     pub async fn add_connection(
         &self,
-        conn: Authenticated<C, F>,
-    ) -> Result<bool, AddConnectionError<P::ConnectionDisallowed>> {
+        conn: Authenticated<Conn, Async>,
+    ) -> Result<bool, AddConnectionError<Auth::ConnectionDisallowed>> {
         let peer_id = conn.peer_id();
         tracing::info!("adding connection from peer {}", peer_id);
 
@@ -899,14 +899,14 @@ where
     /// Returns `Some(true)` if this was the last connection for the peer,
     /// `Some(false)` if the peer still has connections,
     /// `None` if the connection wasn't found.
-    pub async fn remove_connection(&self, conn: &Authenticated<C, F>) -> Option<bool> {
+    pub async fn remove_connection(&self, conn: &Authenticated<Conn, Async>) -> Option<bool> {
         peers::remove_connection(&self.connections, &self.subscriptions, conn).await
     }
 
     /// Get all connections as a flat list.
     ///
     /// This is useful for iterating over all connections to send messages.
-    async fn all_connections(&self) -> Vec<Authenticated<C, F>> {
+    async fn all_connections(&self) -> Vec<Authenticated<Conn, Async>> {
         self.connections
             .lock()
             .await
@@ -927,7 +927,7 @@ where
         &self,
         sedimentree_id: SedimentreeId,
         exclude_peer: &PeerId,
-    ) -> Vec<Authenticated<C, F>> {
+    ) -> Vec<Authenticated<Conn, Async>> {
         peers::get_authorized_subscriber_conns(
             &self.subscriptions,
             &self.storage,
@@ -951,12 +951,12 @@ where
     ///
     /// # Errors
     ///
-    /// * Returns `S::Error` if the storage backend encounters an error.
+    /// * Returns `Store::Error` if the storage backend encounters an error.
     pub async fn get_blob(
         &self,
         id: SedimentreeId,
         digest: Digest<Blob>,
-    ) -> Result<Option<Blob>, S::Error> {
+    ) -> Result<Option<Blob>, Store::Error> {
         tracing::debug!(?id, ?digest, "Looking for blob");
         ingest::get_blob(&self.storage, id, digest).await
     }
@@ -970,8 +970,8 @@ where
     ///
     /// # Errors
     ///
-    /// * Returns `S::Error` if the storage backend encounters an error.
-    pub async fn get_blobs(&self, id: SedimentreeId) -> Result<Option<NonEmpty<Blob>>, S::Error> {
+    /// * Returns `Store::Error` if the storage backend encounters an error.
+    pub async fn get_blobs(&self, id: SedimentreeId) -> Result<Option<NonEmpty<Blob>>, Store::Error> {
         tracing::debug!("Getting local blobs for sedimentree with id {:?}", id);
         let tree = self.sedimentrees.get_cloned(&id).await;
         if tree.is_none() {
@@ -983,11 +983,11 @@ where
         let mut results = Vec::new();
 
         // With compound storage, blobs are stored with their commits/fragments
-        for verified in local_access.load_loose_commits::<F>(id).await? {
+        for verified in local_access.load_loose_commits::<Async>(id).await? {
             results.push(verified.blob().clone());
         }
 
-        for verified in local_access.load_fragments::<F>(id).await? {
+        for verified in local_access.load_fragments::<Async>(id).await? {
             results.push(verified.blob().clone());
         }
 
@@ -1015,7 +1015,7 @@ where
         &self,
         id: SedimentreeId,
         timeout: Option<Duration>,
-    ) -> Result<Option<NonEmpty<Blob>>, IoError<F, S, C, H::Message>> {
+    ) -> Result<Option<NonEmpty<Blob>>, IoError<Async, Store, Conn, Hdl::Message>> {
         tracing::debug!("Fetching blobs for sedimentree with id {:?}", id);
         if let Some(maybe_blobs) = self.get_blobs(id).await.map_err(IoError::Storage)? {
             Ok(Some(maybe_blobs))
@@ -1045,7 +1045,7 @@ where
                         result,
                         req_id: resp_batch_id,
                         ..
-                    } = ManagedCall::<F, H::Message>::call(
+                    } = ManagedCall::<Async, Hdl::Message>::call(
                         &managed,
                         BatchSyncRequest {
                             id,
@@ -1085,7 +1085,7 @@ where
                             .await
                     {
                         if matches!(e, SendRequestedDataError::Unauthorized(_)) {
-                            let msg: H::Message =
+                            let msg: Hdl::Message =
                                 SyncMessage::from(DataRequestRejected { id }).into();
                             if let Err(send_err) = conn.send(&msg).await {
                                 tracing::info!(
@@ -1127,7 +1127,7 @@ where
     pub async fn remove_sedimentree(
         &self,
         id: SedimentreeId,
-    ) -> Result<(), IoError<F, S, C, H::Message>> {
+    ) -> Result<(), IoError<Async, Store, Conn, Hdl::Message>> {
         let maybe_sedimentree = self.sedimentrees.remove(&id).await;
 
         if maybe_sedimentree.is_some() {
@@ -1175,13 +1175,13 @@ where
         head: CommitId,
         parents: BTreeSet<CommitId>,
         blob: Blob,
-    ) -> Result<Option<FragmentRequested>, WriteError<F, S, C, H::Message, P::PutDisallowed>> {
+    ) -> Result<Option<FragmentRequested>, WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
         let self_id = self.peer_id();
-        let putter = self.storage.local_putter::<F>(id);
+        let putter = self.storage.local_putter::<Async>(id);
 
         let verified_blob = VerifiedBlobMeta::new(blob);
         let verified_meta: VerifiedMeta<LooseCommit> =
-            VerifiedMeta::seal::<F, _>(&self.signer, (id, head, parents), verified_blob).await;
+            VerifiedMeta::seal::<Async, _>(&self.signer, (id, head, parents), verified_blob).await;
 
         let commit_head = verified_meta.payload().head();
         tracing::debug!("adding commit {:?} to sedimentree {:?}", commit_head, id);
@@ -1220,7 +1220,7 @@ where
                 let peer_id = conn.peer_id();
                 tracing::debug!("Propagating commit for sedimentree {:?} to {}", id, peer_id);
 
-                let msg: H::Message = SyncMessage::LooseCommit {
+                let msg: Hdl::Message = SyncMessage::LooseCommit {
                     id,
                     commit: signed_for_wire.clone(),
                     blob: blob.clone(),
@@ -1235,7 +1235,7 @@ where
                     tracing::warn!(
                         "peer {} disconnected: {}",
                         peer_id,
-                        IoError::<F, S, C, H::Message>::ConnSend(e)
+                        IoError::<Async, Store, Conn, Hdl::Message>::ConnSend(e)
                     );
                     if self.remove_connection(&conn).await == Some(true) {
                         self.send_counter.clear_peer(&peer_id).await;
@@ -1271,13 +1271,13 @@ where
         boundary: BTreeSet<CommitId>,
         checkpoints: &[CommitId],
         blob: Blob,
-    ) -> Result<(), WriteError<F, S, C, H::Message, P::PutDisallowed>> {
+    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
         let verified_blob = VerifiedBlobMeta::new(blob);
 
         let self_id = self.peer_id();
-        let putter = self.storage.local_putter::<F>(id);
+        let putter = self.storage.local_putter::<Async>(id);
 
-        let verified_meta: VerifiedMeta<Fragment> = VerifiedMeta::seal::<F, _>(
+        let verified_meta: VerifiedMeta<Fragment> = VerifiedMeta::seal::<Async, _>(
             &self.signer,
             (id, head, boundary, checkpoints.to_vec()),
             verified_blob,
@@ -1329,7 +1329,7 @@ where
                 peer_id
             );
 
-            let msg: H::Message = SyncMessage::Fragment {
+            let msg: Hdl::Message = SyncMessage::Fragment {
                 id,
                 fragment: signed_for_wire.clone(),
                 blob: blob.clone(),
@@ -1344,7 +1344,7 @@ where
                 tracing::warn!(
                     "peer {} disconnected: {}",
                     peer_id,
-                    IoError::<F, S, C, H::Message>::ConnSend(e)
+                    IoError::<Async, Store, Conn, Hdl::Message>::ConnSend(e)
                 );
                 if self.remove_connection(&conn).await == Some(true) {
                     self.send_counter.clear_peer(&peer_id).await;
@@ -1381,12 +1381,12 @@ where
         &self,
         id: SedimentreeId,
         commits: Vec<(CommitId, BTreeSet<CommitId>, Blob)>,
-    ) -> Result<(), WriteError<F, S, C, H::Message, P::PutDisallowed>> {
+    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
         if commits.is_empty() {
             return Ok(());
         }
 
-        let putter = self.storage.local_putter::<F>(id);
+        let putter = self.storage.local_putter::<Async>(id);
         let count = commits.len();
         tracing::info!("bulk-inserting {count} commits into sedimentree {id:?}");
 
@@ -1397,7 +1397,7 @@ where
         for (head, parents, blob) in commits {
             let verified_blob = VerifiedBlobMeta::new(blob);
             let verified_meta: VerifiedMeta<LooseCommit> =
-                VerifiedMeta::seal::<F, _>(&self.signer, (id, head, parents), verified_blob).await;
+                VerifiedMeta::seal::<Async, _>(&self.signer, (id, head, parents), verified_blob).await;
             commit_payloads.push(verified_meta.payload().clone());
             verified_commits.push(verified_meta);
         }
@@ -1443,12 +1443,12 @@ where
         &self,
         id: SedimentreeId,
         fragments: Vec<FragmentBatchItem>,
-    ) -> Result<(), WriteError<F, S, C, H::Message, P::PutDisallowed>> {
+    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
         if fragments.is_empty() {
             return Ok(());
         }
 
-        let putter = self.storage.local_putter::<F>(id);
+        let putter = self.storage.local_putter::<Async>(id);
         let count = fragments.len();
         tracing::info!("bulk-inserting {count} fragments into sedimentree {id:?}");
 
@@ -1464,7 +1464,7 @@ where
                 blob,
             } = item;
             let verified_blob = VerifiedBlobMeta::new(blob);
-            let verified_meta: VerifiedMeta<Fragment> = VerifiedMeta::seal::<F, _>(
+            let verified_meta: VerifiedMeta<Fragment> = VerifiedMeta::seal::<Async, _>(
                 &self.signer,
                 (id, head, boundary, checkpoints),
                 verified_blob,
@@ -1523,12 +1523,12 @@ where
         id: SedimentreeId,
         commits: Vec<(LooseCommit, Blob)>,
         fragments: Vec<(Fragment, Blob)>,
-    ) -> Result<(), WriteError<F, S, C, H::Message, P::PutDisallowed>> {
+    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
         if commits.is_empty() && fragments.is_empty() {
             return Ok(());
         }
 
-        let putter = self.storage.local_putter::<F>(id);
+        let putter = self.storage.local_putter::<Async>(id);
         let commit_count = commits.len();
         let fragment_count = fragments.len();
         tracing::info!(
@@ -1541,7 +1541,7 @@ where
         let mut verified_commits: Vec<VerifiedMeta<LooseCommit>> = Vec::with_capacity(commit_count);
         let mut commit_payloads: Vec<LooseCommit> = Vec::with_capacity(commit_count);
         for (commit, blob) in commits {
-            let verified_sig = Signed::seal::<F, _>(&self.signer, commit).await;
+            let verified_sig = Signed::seal::<Async, _>(&self.signer, commit).await;
             let verified_meta = VerifiedMeta::new(verified_sig, blob)
                 .map_err(|e| WriteError::Io(IoError::BlobMismatch(e)))?;
             commit_payloads.push(verified_meta.payload().clone());
@@ -1552,7 +1552,7 @@ where
             Vec::with_capacity(fragment_count);
         let mut fragment_payloads: Vec<Fragment> = Vec::with_capacity(fragment_count);
         for (fragment, blob) in fragments {
-            let verified_sig = Signed::seal::<F, _>(&self.signer, fragment).await;
+            let verified_sig = Signed::seal::<Async, _>(&self.signer, fragment).await;
             let verified_meta = VerifiedMeta::new(verified_sig, blob)
                 .map_err(|e| WriteError::Io(IoError::BlobMismatch(e)))?;
             fragment_payloads.push(verified_meta.payload().clone());
@@ -1596,7 +1596,7 @@ where
         from: &PeerId,
         id: SedimentreeId,
         diff: SyncDiff,
-    ) -> Result<(), IoError<F, S, C, H::Message>> {
+    ) -> Result<(), IoError<Async, Store, Conn, Hdl::Message>> {
         ingest::recv_batch_sync_response(&self.sedimentrees, &self.storage, from, id, diff).await?;
         self.minimize_tree(id).await;
         Ok(())
@@ -1611,7 +1611,7 @@ where
             }
         }
 
-        let msg: H::Message = SyncMessage::BlobsRequest { id, digests }.into();
+        let msg: Hdl::Message = SyncMessage::BlobsRequest { id, digests }.into();
         let conns = self.all_connections().await;
         for conn in conns {
             let peer_id = conn.peer_id();
@@ -1632,21 +1632,21 @@ where
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N> + 'static,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C> + RemoteHeadsNotifier,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> Subduction<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS> + 'static,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn> + RemoteHeadsNotifier,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 where
-    H::Message: From<SyncMessage>,
-    H::HandlerError: Into<ListenError<F, S, C, H::Message>>,
-    ManagedConnection<C, F, O>:
-        ManagedCall<F, H::Message, SendError = <C as Connection<F, H::Message>>::SendError>,
+    Hdl::Message: From<SyncMessage>,
+    Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
+    ManagedConnection<Conn, Async, Timer>:
+        ManagedCall<Async, Hdl::Message, SendError = <Conn as Connection<Async, Hdl::Message>>::SendError>,
 {
     /// Add a new sedimentree locally and propagate it to all connected peers.
     ///
@@ -1661,10 +1661,10 @@ where
         id: SedimentreeId,
         sedimentree: Sedimentree,
         blobs: Vec<Blob>,
-    ) -> Result<(), WriteError<F, S, C, H::Message, P::PutDisallowed>> {
+    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
         use sedimentree_core::collections::Map;
 
-        let putter = self.storage.local_putter::<F>(id);
+        let putter = self.storage.local_putter::<Async>(id);
 
         // Index blobs by digest for matching with commits/fragments
         let blobs_by_digest: Map<Digest<Blob>, Blob> =
@@ -1678,7 +1678,7 @@ where
                 .get(&blob_digest)
                 .cloned()
                 .ok_or_else(|| WriteError::MissingBlob(blob_digest))?;
-            let verified_sig = Signed::seal::<F, _>(&self.signer, commit.clone()).await;
+            let verified_sig = Signed::seal::<Async, _>(&self.signer, commit.clone()).await;
             let verified_meta = VerifiedMeta::new(verified_sig, blob)
                 .map_err(|e| WriteError::Io(IoError::BlobMismatch(e)))?;
             verified_commits.push(verified_meta);
@@ -1692,7 +1692,7 @@ where
                 .get(&blob_digest)
                 .cloned()
                 .ok_or_else(|| WriteError::MissingBlob(blob_digest))?;
-            let verified_sig = Signed::seal::<F, _>(&self.signer, fragment.clone()).await;
+            let verified_sig = Signed::seal::<Async, _>(&self.signer, fragment.clone()).await;
             let verified_meta = VerifiedMeta::new(verified_sig, blob)
                 .map_err(|e| WriteError::Io(IoError::BlobMismatch(e)))?;
             verified_fragments.push(verified_meta);
@@ -1751,7 +1751,7 @@ where
         id: SedimentreeId,
         commits: Vec<(LooseCommit, Blob)>,
         fragments: Vec<(Fragment, Blob)>,
-    ) -> Result<(), WriteError<F, S, C, H::Message, P::PutDisallowed>> {
+    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
         if commits.is_empty() && fragments.is_empty() {
             return Ok(());
         }
@@ -1790,11 +1790,11 @@ where
             bool,
             SyncStats,
             Vec<(
-                Authenticated<C, F>,
-                crate::connection::managed::CallError<<C as Connection<F, H::Message>>::SendError>,
+                Authenticated<Conn, Async>,
+                crate::connection::managed::CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
             )>,
         ),
-        IoError<F, S, C, H::Message>,
+        IoError<Async, Store, Conn, Hdl::Message>,
     > {
         tracing::info!(
             "Requesting batch sync for sedimentree {:?} from peer {:?}",
@@ -1805,7 +1805,7 @@ where
         let mut stats = SyncStats::new();
         let mut had_success = false;
 
-        let peer_conns: Vec<Authenticated<C, F>> = {
+        let peer_conns: Vec<Authenticated<Conn, Async>> = {
             self.connections
                 .lock()
                 .await
@@ -1844,7 +1844,7 @@ where
             let managed = ManagedConnection::new(conn.clone(), mux, self.timer.clone());
             let req_id = managed.next_request_id();
 
-            let result = ManagedCall::<F, H::Message>::call(
+            let result = ManagedCall::<Async, Hdl::Message>::call(
                 &managed,
                 BatchSyncRequest {
                     id,
@@ -1889,7 +1889,7 @@ where
                     let fragments_to_receive = missing_fragments.len();
 
                     // Cache putters by author to avoid redundant policy checks.
-                    let mut putter_cache: Map<PeerId, Putter<F, S>> = Map::new();
+                    let mut putter_cache: Map<PeerId, Putter<Async, Store>> = Map::new();
 
                     for (signed_commit, blob) in missing_commits {
                         let verified = match signed_commit.try_verify() {
@@ -1911,7 +1911,7 @@ where
                         let putter = match putter_cache.entry(author_id) {
                             Entry::Occupied(e) => e.into_mut(),
                             Entry::Vacant(e) => {
-                                match self.storage.get_putter::<F>(*to_ask, author, id).await {
+                                match self.storage.get_putter::<Async>(*to_ask, author, id).await {
                                     Ok(p) => e.insert(p),
                                     Err(err) => {
                                         tracing::warn!(
@@ -1950,7 +1950,7 @@ where
                         let putter = match putter_cache.entry(author_id) {
                             Entry::Occupied(e) => e.into_mut(),
                             Entry::Vacant(e) => {
-                                match self.storage.get_putter::<F>(*to_ask, author, id).await {
+                                match self.storage.get_putter::<Async>(*to_ask, author, id).await {
                                     Ok(p) => e.insert(p),
                                     Err(err) => {
                                         tracing::warn!(
@@ -2055,20 +2055,20 @@ where
                 bool,
                 SyncStats,
                 Vec<(
-                    Authenticated<C, F>,
+                    Authenticated<Conn, Async>,
                     crate::connection::managed::CallError<
-                        <C as Connection<F, H::Message>>::SendError,
+                        <Conn as Connection<Async, Hdl::Message>>::SendError,
                     >,
                 )>,
             ),
         >,
-        IoError<F, S, C, H::Message>,
+        IoError<Async, Store, Conn, Hdl::Message>,
     > {
         tracing::info!(
             "Requesting batch sync for sedimentree {:?} from all peers",
             id
         );
-        let peers: Map<PeerId, Vec<Authenticated<C, F>>> = {
+        let peers: Map<PeerId, Vec<Authenticated<Conn, Async>>> = {
             self.connections
                 .lock()
                 .await
@@ -2115,7 +2115,7 @@ where
                         let managed = ManagedConnection::new(conn.clone(), mux, self.timer.clone());
                         let req_id = managed.next_request_id();
 
-                        let result = ManagedCall::<F, H::Message>::call(
+                        let result = ManagedCall::<Async, Hdl::Message>::call(
                                 &managed,
                                 BatchSyncRequest {
                                     id,
@@ -2174,7 +2174,7 @@ where
                                 );
 
                                 // Cache putters by author to avoid redundant policy checks.
-                                let mut putter_cache: Map<PeerId, Putter<F, S>> = Map::new();
+                                let mut putter_cache: Map<PeerId, Putter<Async, Store>> = Map::new();
 
                                 for (signed_commit, blob) in missing_commits {
                                     let verified = match signed_commit.try_verify() {
@@ -2198,7 +2198,7 @@ where
                                     let putter = match putter_cache.entry(author_id) {
                                         Entry::Occupied(e) => e.into_mut(),
                                         Entry::Vacant(e) => {
-                                            match self.storage.get_putter::<F>(*peer_id, author, id).await {
+                                            match self.storage.get_putter::<Async>(*peer_id, author, id).await {
                                                 Ok(p) => e.insert(p),
                                                 Err(err) => {
                                                     tracing::warn!(
@@ -2237,7 +2237,7 @@ where
                                     let putter = match putter_cache.entry(author_id) {
                                         Entry::Occupied(e) => e.into_mut(),
                                         Entry::Vacant(e) => {
-                                            match self.storage.get_putter::<F>(*peer_id, author, id).await {
+                                            match self.storage.get_putter::<Async>(*peer_id, author, id).await {
                                                 Ok(p) => e.insert(p),
                                                 Err(err) => {
                                                     tracing::warn!(
@@ -2268,7 +2268,7 @@ where
                                             stats.fragments_sent += sent.fragments;
                                         }
                                         Err(ref e @ SendRequestedDataError::Unauthorized(_)) => {
-                                            let msg: H::Message = SyncMessage::from(DataRequestRejected { id }).into();
+                                            let msg: Hdl::Message = SyncMessage::from(DataRequestRejected { id }).into();
                                             if let Err(send_err) = conn.send(&msg).await {
                                                 tracing::warn!("peer {peer_id} disconnected while sending DataRequestRejected: {send_err}");
                                             }
@@ -2302,7 +2302,7 @@ where
                         }
                     }
 
-                    Ok::<(PeerId, bool, SyncStats, Vec<(Authenticated<C, F>, _)>), IoError<F, S, C, H::Message>>((
+                    Ok::<(PeerId, bool, SyncStats, Vec<(Authenticated<Conn, Async>, _)>), IoError<Async, Store, Conn, Hdl::Message>>((
                         *peer_id,
                         had_success,
                         stats,
@@ -2345,10 +2345,10 @@ where
         bool,
         SyncStats,
         Vec<(
-            Authenticated<C, F>,
-            crate::connection::managed::CallError<<C as Connection<F, H::Message>>::SendError>,
+            Authenticated<Conn, Async>,
+            crate::connection::managed::CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
         )>,
-        Vec<(SedimentreeId, IoError<F, S, C, H::Message>)>,
+        Vec<(SedimentreeId, IoError<Async, Store, Conn, Hdl::Message>)>,
     ) {
         tracing::info!(
             "Requesting batch sync for all sedimentrees with peer {}",
@@ -2404,10 +2404,10 @@ where
         bool,
         SyncStats,
         Vec<(
-            Authenticated<C, F>,
-            crate::connection::managed::CallError<<C as Connection<F, H::Message>>::SendError>,
+            Authenticated<Conn, Async>,
+            crate::connection::managed::CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
         )>,
-        Vec<(SedimentreeId, IoError<F, S, C, H::Message>)>,
+        Vec<(SedimentreeId, IoError<Async, Store, Conn, Hdl::Message>)>,
     ) {
         tracing::info!("Requesting batch sync for all sedimentrees from all peers");
         let tree_ids = self.sedimentrees.into_keys().await;
@@ -2461,21 +2461,21 @@ where
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N> + 'static,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> Subduction<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS> + 'static,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 where
-    H::Message: From<SyncMessage>,
-    H::HandlerError: Into<ListenError<F, S, C, H::Message>>,
-    ManagedConnection<C, F, O>:
-        ManagedCall<F, H::Message, SendError = <C as Connection<F, H::Message>>::SendError>,
+    Hdl::Message: From<SyncMessage>,
+    Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
+    ManagedConnection<Conn, Async, Timer>:
+        ManagedCall<Async, Hdl::Message, SendError = <Conn as Connection<Async, Hdl::Message>>::SendError>,
 {
     /********************
      * PUBLIC UTILITIES *
@@ -2533,10 +2533,10 @@ where
 
     async fn insert_sedimentree_locally(
         &self,
-        putter: &Putter<F, S>,
+        putter: &Putter<Async, Store>,
         verified_commits: Vec<VerifiedMeta<LooseCommit>>,
         verified_fragments: Vec<VerifiedMeta<Fragment>>,
-    ) -> Result<(), S::Error> {
+    ) -> Result<(), Store::Error> {
         let id = putter.sedimentree_id();
         tracing::debug!("adding sedimentree with id {:?}", id);
 
@@ -2583,11 +2583,11 @@ where
     #[allow(clippy::too_many_lines)]
     pub async fn send_requested_data(
         &self,
-        conn: &Authenticated<C, F>,
+        conn: &Authenticated<Conn, Async>,
         id: SedimentreeId,
         resolver: &FingerprintResolver,
         requesting: &RequestedData,
-    ) -> Result<SendCount, SendRequestedDataError<F, S, C, H::Message>> {
+    ) -> Result<SendCount, SendRequestedDataError<Async, Store, Conn, Hdl::Message>> {
         if requesting.is_empty() {
             return Ok(SendCount::default());
         }
@@ -2600,7 +2600,7 @@ where
             peer_id
         );
 
-        let fetcher = match self.storage.get_fetcher::<F>(peer_id, id).await {
+        let fetcher = match self.storage.get_fetcher::<Async>(peer_id, id).await {
             Ok(f) => f,
             Err(e) => {
                 tracing::debug!(
@@ -2701,7 +2701,7 @@ where
             let mut commit_msgs = Vec::new();
             for commit_id in &requested_commit_ids {
                 if let Some(verified) = commit_by_id.get(commit_id) {
-                    let msg: H::Message = SyncMessage::LooseCommit {
+                    let msg: Hdl::Message = SyncMessage::LooseCommit {
                         id,
                         commit: verified.signed().clone(),
                         blob: verified.blob().clone(),
@@ -2718,7 +2718,7 @@ where
             let mut fragment_msgs = Vec::new();
             for frag_id in &requested_fragment_ids {
                 if let Some(verified) = fragment_by_id.get(frag_id) {
-                    let msg: H::Message = SyncMessage::Fragment {
+                    let msg: Hdl::Message = SyncMessage::Fragment {
                         id,
                         fragment: verified.signed().clone(),
                         blob: verified.blob().clone(),
@@ -2782,9 +2782,9 @@ where
     /// Returns a storage error if persistence fails.
     async fn insert_commit_locally(
         &self,
-        putter: &Putter<F, S>,
+        putter: &Putter<Async, Store>,
         verified_meta: VerifiedMeta<LooseCommit>,
-    ) -> Result<bool, S::Error> {
+    ) -> Result<bool, Store::Error> {
         ingest::insert_commit_locally(&self.sedimentrees, putter, verified_meta).await
     }
 
@@ -2797,9 +2797,9 @@ where
     /// Returns a storage error if persistence fails.
     async fn insert_fragment_locally(
         &self,
-        putter: &Putter<F, S>,
+        putter: &Putter<Async, Store>,
         verified_meta: VerifiedMeta<Fragment>,
-    ) -> Result<bool, S::Error> {
+    ) -> Result<bool, Store::Error> {
         ingest::insert_fragment_locally(&self.sedimentrees, putter, verified_meta).await
     }
 
@@ -2814,16 +2814,16 @@ where
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> Drop for Subduction<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> Drop for Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
     fn drop(&mut self) {
         self.abort_manager_handle.abort();
@@ -2833,48 +2833,48 @@ impl<
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> ConnectionPolicy<F> for Subduction<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> ConnectionPolicy<Async> for Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
-    type ConnectionDisallowed = P::ConnectionDisallowed;
+    type ConnectionDisallowed = Auth::ConnectionDisallowed;
 
     fn authorize_connect(
         &self,
         peer_id: PeerId,
-    ) -> F::Future<'_, Result<(), Self::ConnectionDisallowed>> {
+    ) -> Async::Future<'_, Result<(), Self::ConnectionDisallowed>> {
         self.storage.policy().authorize_connect(peer_id)
     }
 }
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> StoragePolicy<F> for Subduction<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> StoragePolicy<Async> for Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
-    type FetchDisallowed = P::FetchDisallowed;
-    type PutDisallowed = P::PutDisallowed;
+    type FetchDisallowed = Auth::FetchDisallowed;
+    type PutDisallowed = Auth::PutDisallowed;
 
     fn authorize_fetch(
         &self,
         peer: PeerId,
         sedimentree_id: SedimentreeId,
-    ) -> F::Future<'_, Result<(), Self::FetchDisallowed>> {
+    ) -> Async::Future<'_, Result<(), Self::FetchDisallowed>> {
         self.storage.policy().authorize_fetch(peer, sedimentree_id)
     }
 
@@ -2883,7 +2883,7 @@ impl<
         requestor: PeerId,
         author: VerifiedAuthor,
         sedimentree_id: SedimentreeId,
-    ) -> F::Future<'_, Result<(), Self::PutDisallowed>> {
+    ) -> Async::Future<'_, Result<(), Self::PutDisallowed>> {
         self.storage
             .policy()
             .authorize_put(requestor, author, sedimentree_id)
@@ -2893,7 +2893,7 @@ impl<
         &self,
         peer: PeerId,
         ids: Vec<SedimentreeId>,
-    ) -> F::Future<'_, Vec<SedimentreeId>> {
+    ) -> Async::Future<'_, Vec<SedimentreeId>> {
         self.storage.policy().filter_authorized_fetch(peer, ids)
     }
 }
@@ -2908,59 +2908,59 @@ impl<
 ///
 /// Note: [`StartListener`] is _not_ a supertrait here — it is only required
 /// on the constructor methods that build the listener future, keeping the
-/// handler type `H` out of the main `Subduction` struct definition.
+/// handler type `Hdl` out of the main `Subduction` struct definition.
 pub trait SubductionFutureForm<
     'a,
-    S: Storage<Self>,
-    C: Connection<Self, W> + PartialEq + 'a,
-    W: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
-    P: ConnectionPolicy<Self> + StoragePolicy<Self>,
-    Sig: Signer<Self>,
-    M: DepthMetric,
-    const N: usize,
->: FutureForm + RunManager<Authenticated<C, Self>, W> + Sized
+    Store: Storage<Self>,
+    Conn: Connection<Self, WireMsg> + PartialEq + 'a,
+    WireMsg: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
+    Auth: ConnectionPolicy<Self> + StoragePolicy<Self>,
+    Sign: Signer<Self>,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+>: FutureForm + RunManager<Authenticated<Conn, Self>, WireMsg> + Sized
 {
 }
 
 impl<
     'a,
-    S: Storage<Self>,
-    C: Connection<Self, W> + PartialEq + 'a,
-    W: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
-    P: ConnectionPolicy<Self> + StoragePolicy<Self>,
-    Sig: Signer<Self>,
-    M: DepthMetric,
-    const N: usize,
-    U: FutureForm + RunManager<Authenticated<C, U>, W> + Sized,
-> SubductionFutureForm<'a, S, C, W, P, Sig, M, N> for U
+    Store: Storage<Self>,
+    Conn: Connection<Self, WireMsg> + PartialEq + 'a,
+    WireMsg: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
+    Auth: ConnectionPolicy<Self> + StoragePolicy<Self>,
+    Sign: Signer<Self>,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+    Async: FutureForm + RunManager<Authenticated<Conn, Async>, WireMsg> + Sized,
+> SubductionFutureForm<'a, Store, Conn, WireMsg, Auth, Sign, Metric, SHARDS> for Async
 {
 }
 
 /// A trait for starting the listener task for Subduction.
 ///
 /// This lets us abstract over `Send` and `!Send` futures while keeping
-/// the handler type `H` available for the `#[future_form]` macro to
+/// the handler type `Hdl` available for the `#[future_form]` macro to
 /// generate correct `Send` bounds.
 ///
-/// `H` is a trait-level (not method-level) generic so the macro can
-/// emit the required `H: Send + Sync` bounds for the `Sendable` impl.
+/// `Hdl` is a trait-level (not method-level) generic so the macro can
+/// emit the required `Hdl: Send + Sync` bounds for the `Sendable` impl.
 pub trait StartListener<
     'a,
-    S: Storage<Self>,
-    C: Connection<Self, W> + PartialEq + 'a,
-    W: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
-    H: Handler<Self, C, Message = W>,
-    P: ConnectionPolicy<Self> + StoragePolicy<Self>,
-    Sig: Signer<Self>,
-    M: DepthMetric,
-    const N: usize,
->: FutureForm + RunManager<Authenticated<C, Self>, W> + Sized where
-    H::HandlerError: Into<ListenError<Self, S, C, W>>,
+    Store: Storage<Self>,
+    Conn: Connection<Self, WireMsg> + PartialEq + 'a,
+    WireMsg: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
+    Hdl: Handler<Self, Conn, Message = WireMsg>,
+    Auth: ConnectionPolicy<Self> + StoragePolicy<Self>,
+    Sign: Signer<Self>,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+>: FutureForm + RunManager<Authenticated<Conn, Self>, WireMsg> + Sized where
+    Hdl::HandlerError: Into<ListenError<Self, Store, Conn, WireMsg>>,
 {
     /// Start the listener task for Subduction.
     #[allow(clippy::type_complexity)]
-    fn start_listener<O: Timeout<Self> + Clone + Send + Sync + 'a>(
-        subduction: Arc<Subduction<'a, Self, S, C, H, P, Sig, O, M, N>>,
+    fn start_listener<Timer: Timeout<Self> + Clone + Send + Sync + 'a>(
+        subduction: Arc<Subduction<'a, Self, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>>,
         abort_reg: AbortRegistration,
     ) -> Abortable<Self::Future<'a, ()>>
     where
@@ -2969,43 +2969,43 @@ pub trait StartListener<
 
 #[future_form(
     Sendable where
-        C: Connection<Sendable, W> + PartialEq + Clone + Send + Sync + 'static,
-        W: Encode + Decode + Clone + Send + Sync + core::fmt::Debug + 'static,
-        S: Storage<Sendable> + Send + Sync + 'a,
-        P: ConnectionPolicy<Sendable> + StoragePolicy<Sendable> + Send + Sync + 'a,
-        P::PutDisallowed: Send + 'static,
-        P::FetchDisallowed: Send + 'static,
-        Sig: Signer<Sendable> + Send + Sync + 'a,
-        M: DepthMetric + Send + Sync + 'a,
-        H: Handler<Sendable, C, Message = W> + Send + Sync + 'a,
-        H::HandlerError: Into<ListenError<Sendable, S, C, W>> + Send + 'static,
-        S::Error: Send + 'static,
-        C::DisconnectionError: Send + 'static,
-        C::RecvError: Send + 'static,
-        C::SendError: Send + 'static,
+        Conn: Connection<Sendable, WireMsg> + PartialEq + Clone + Send + Sync + 'static,
+        WireMsg: Encode + Decode + Clone + Send + Sync + core::fmt::Debug + 'static,
+        Store: Storage<Sendable> + Send + Sync + 'a,
+        Auth: ConnectionPolicy<Sendable> + StoragePolicy<Sendable> + Send + Sync + 'a,
+        Auth::PutDisallowed: Send + 'static,
+        Auth::FetchDisallowed: Send + 'static,
+        Sign: Signer<Sendable> + Send + Sync + 'a,
+        Metric: DepthMetric + Send + Sync + 'a,
+        Hdl: Handler<Sendable, Conn, Message = WireMsg> + Send + Sync + 'a,
+        Hdl::HandlerError: Into<ListenError<Sendable, Store, Conn, WireMsg>> + Send + 'static,
+        Store::Error: Send + 'static,
+        Conn::DisconnectionError: Send + 'static,
+        Conn::RecvError: Send + 'static,
+        Conn::SendError: Send + 'static,
     Local where
-        C: Connection<Local, W> + PartialEq + Clone + 'static,
-        W: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
-        S: Storage<Local> + 'a,
-        P: ConnectionPolicy<Local> + StoragePolicy<Local> + 'a,
-        Sig: Signer<Local> + 'a,
-        M: DepthMetric + 'a,
-        H: Handler<Local, C, Message = W> + 'a,
-        H::HandlerError: Into<ListenError<Local, S, C, W>>
+        Conn: Connection<Local, WireMsg> + PartialEq + Clone + 'static,
+        WireMsg: Encode + Decode + Clone + Send + core::fmt::Debug + 'static,
+        Store: Storage<Local> + 'a,
+        Auth: ConnectionPolicy<Local> + StoragePolicy<Local> + 'a,
+        Sign: Signer<Local> + 'a,
+        Metric: DepthMetric + 'a,
+        Hdl: Handler<Local, Conn, Message = WireMsg> + 'a,
+        Hdl::HandlerError: Into<ListenError<Local, Store, Conn, WireMsg>>
 )]
-impl<'a, K: FutureForm, C, S, W, H, P, Sig, M, const N: usize>
-    StartListener<'a, S, C, W, H, P, Sig, M, N> for K
+impl<'a, Async: FutureForm, Conn, Store, WireMsg, Hdl, Auth, Sign, Metric, const SHARDS: usize>
+    StartListener<'a, Store, Conn, WireMsg, Hdl, Auth, Sign, Metric, SHARDS> for Async
 where
-    H: Handler<K, C, Message = W>,
-    H::HandlerError: Into<ListenError<K, S, C, W>>,
-    W: Encode + Decode + Clone + Send + core::fmt::Debug + From<SyncMessage> + 'static,
+    Hdl: Handler<Async, Conn, Message = WireMsg>,
+    Hdl::HandlerError: Into<ListenError<Async, Store, Conn, WireMsg>>,
+    WireMsg: Encode + Decode + Clone + Send + core::fmt::Debug + From<SyncMessage> + 'static,
 {
-    fn start_listener<O: Timeout<Self> + Clone + Send + Sync + 'a>(
-        subduction: Arc<Subduction<'a, Self, S, C, H, P, Sig, O, M, N>>,
+    fn start_listener<Timer: Timeout<Self> + Clone + Send + Sync + 'a>(
+        subduction: Arc<Subduction<'a, Self, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>>,
         abort_reg: AbortRegistration,
     ) -> Abortable<Self::Future<'a, ()>> {
         Abortable::new(
-            K::from_future(async move {
+            Async::from_future(async move {
                 if let Err(e) = subduction.listen().await {
                     tracing::info!("Subduction listener disconnected: {}", e.to_string());
                 }
@@ -3022,35 +3022,35 @@ where
 #[derive(Debug)]
 pub struct ListenerFuture<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric = CountLeadingZeroBytes,
-    const N: usize = 256,
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric = CountLeadingZeroBytes,
+    const SHARDS: usize = 256,
 > {
-    fut: Pin<Box<Abortable<F::Future<'a, ()>>>>,
-    _phantom: PhantomData<(S, C, H, P, Sig, O, M)>,
+    fut: Pin<Box<Abortable<Async::Future<'a, ()>>>>,
+    _phantom: PhantomData<(Store, Conn, Hdl, Auth, Sign, Timer, Metric)>,
 }
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> ListenerFuture<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> ListenerFuture<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
     /// Create a new [`ListenerFuture`] wrapping the given abortable future.
-    pub(crate) fn new(fut: Abortable<F::Future<'a, ()>>) -> Self {
+    pub(crate) fn new(fut: Abortable<Async::Future<'a, ()>>) -> Self {
         Self {
             fut: Box::pin(fut),
             _phantom: PhantomData,
@@ -3066,18 +3066,18 @@ impl<
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> Deref for ListenerFuture<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> Deref for ListenerFuture<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
-    type Target = Abortable<F::Future<'a, ()>>;
+    type Target = Abortable<Async::Future<'a, ()>>;
 
     fn deref(&self) -> &Self::Target {
         &self.fut
@@ -3086,16 +3086,16 @@ impl<
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> Future for ListenerFuture<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> Future for ListenerFuture<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
     type Output = Result<(), Aborted>;
 
@@ -3106,16 +3106,16 @@ impl<
 
 impl<
     'a,
-    F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N>,
-    S: Storage<F>,
-    C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
-    P: ConnectionPolicy<F> + StoragePolicy<F>,
-    Sig: Signer<F>,
-    O: Timeout<F> + Clone,
-    M: DepthMetric,
-    const N: usize,
-> Unpin for ListenerFuture<'a, F, S, C, H, P, Sig, O, M, N>
+    Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>,
+    Store: Storage<Async>,
+    Conn: Connection<Async, Hdl::Message> + PartialEq + 'a,
+    Hdl: Handler<Async, Conn>,
+    Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+    Sign: Signer<Async>,
+    Timer: Timeout<Async> + Clone,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+> Unpin for ListenerFuture<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
 }
 

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -232,8 +232,11 @@ impl<
 where
     Hdl::Message: From<SyncMessage>,
     Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
-    ManagedConnection<Conn, Async, Timer>:
-        ManagedCall<Async, Hdl::Message, SendError = <Conn as Connection<Async, Hdl::Message>>::SendError>,
+    ManagedConnection<Conn, Async, Timer>: ManagedCall<
+            Async,
+            Hdl::Message,
+            SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
+        >,
 {
     /// Initialize a new `Subduction` instance.
     ///
@@ -351,10 +354,9 @@ where
 
         (
             sd.clone(),
-            ListenerFuture::<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>::new(Async::start_listener(
-                sd,
-                abort_listener_reg,
-            )),
+            ListenerFuture::<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>::new(
+                Async::start_listener(sd, abort_listener_reg),
+            ),
             crate::connection::manager::ManagerFuture::new(abortable_manager),
         )
     }
@@ -534,7 +536,9 @@ where
     ///
     /// * Returns `ListenError` if a handler error signals a broken connection.
     #[allow(clippy::too_many_lines)]
-    pub async fn listen(self: Arc<Self>) -> Result<(), ListenError<Async, Store, Conn, Hdl::Message>> {
+    pub async fn listen(
+        self: Arc<Self>,
+    ) -> Result<(), ListenError<Async, Store, Conn, Hdl::Message>> {
         tracing::info!("starting Subduction listener with concurrent dispatch");
 
         let handler = &self.handler;
@@ -971,7 +975,10 @@ where
     /// # Errors
     ///
     /// * Returns `Store::Error` if the storage backend encounters an error.
-    pub async fn get_blobs(&self, id: SedimentreeId) -> Result<Option<NonEmpty<Blob>>, Store::Error> {
+    pub async fn get_blobs(
+        &self,
+        id: SedimentreeId,
+    ) -> Result<Option<NonEmpty<Blob>>, Store::Error> {
         tracing::debug!("Getting local blobs for sedimentree with id {:?}", id);
         let tree = self.sedimentrees.get_cloned(&id).await;
         if tree.is_none() {
@@ -1175,7 +1182,10 @@ where
         head: CommitId,
         parents: BTreeSet<CommitId>,
         blob: Blob,
-    ) -> Result<Option<FragmentRequested>, WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
+    ) -> Result<
+        Option<FragmentRequested>,
+        WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>,
+    > {
         let self_id = self.peer_id();
         let putter = self.storage.local_putter::<Async>(id);
 
@@ -1397,7 +1407,8 @@ where
         for (head, parents, blob) in commits {
             let verified_blob = VerifiedBlobMeta::new(blob);
             let verified_meta: VerifiedMeta<LooseCommit> =
-                VerifiedMeta::seal::<Async, _>(&self.signer, (id, head, parents), verified_blob).await;
+                VerifiedMeta::seal::<Async, _>(&self.signer, (id, head, parents), verified_blob)
+                    .await;
             commit_payloads.push(verified_meta.payload().clone());
             verified_commits.push(verified_meta);
         }
@@ -1645,8 +1656,11 @@ impl<
 where
     Hdl::Message: From<SyncMessage>,
     Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
-    ManagedConnection<Conn, Async, Timer>:
-        ManagedCall<Async, Hdl::Message, SendError = <Conn as Connection<Async, Hdl::Message>>::SendError>,
+    ManagedConnection<Conn, Async, Timer>: ManagedCall<
+            Async,
+            Hdl::Message,
+            SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
+        >,
 {
     /// Add a new sedimentree locally and propagate it to all connected peers.
     ///
@@ -1791,7 +1805,9 @@ where
             SyncStats,
             Vec<(
                 Authenticated<Conn, Async>,
-                crate::connection::managed::CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
+                crate::connection::managed::CallError<
+                    <Conn as Connection<Async, Hdl::Message>>::SendError,
+                >,
             )>,
         ),
         IoError<Async, Store, Conn, Hdl::Message>,
@@ -2346,7 +2362,9 @@ where
         SyncStats,
         Vec<(
             Authenticated<Conn, Async>,
-            crate::connection::managed::CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
+            crate::connection::managed::CallError<
+                <Conn as Connection<Async, Hdl::Message>>::SendError,
+            >,
         )>,
         Vec<(SedimentreeId, IoError<Async, Store, Conn, Hdl::Message>)>,
     ) {
@@ -2405,7 +2423,9 @@ where
         SyncStats,
         Vec<(
             Authenticated<Conn, Async>,
-            crate::connection::managed::CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
+            crate::connection::managed::CallError<
+                <Conn as Connection<Async, Hdl::Message>>::SendError,
+            >,
         )>,
         Vec<(SedimentreeId, IoError<Async, Store, Conn, Hdl::Message>)>,
     ) {
@@ -2474,8 +2494,11 @@ impl<
 where
     Hdl::Message: From<SyncMessage>,
     Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
-    ManagedConnection<Conn, Async, Timer>:
-        ManagedCall<Async, Hdl::Message, SendError = <Conn as Connection<Async, Hdl::Message>>::SendError>,
+    ManagedConnection<Conn, Async, Timer>: ManagedCall<
+            Async,
+            Hdl::Message,
+            SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
+        >,
 {
     /********************
      * PUBLIC UTILITIES *
@@ -2842,7 +2865,8 @@ impl<
     Timer: Timeout<Async> + Clone,
     Metric: DepthMetric,
     const SHARDS: usize,
-> ConnectionPolicy<Async> for Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
+> ConnectionPolicy<Async>
+    for Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
     type ConnectionDisallowed = Auth::ConnectionDisallowed;
 
@@ -2865,7 +2889,8 @@ impl<
     Timer: Timeout<Async> + Clone,
     Metric: DepthMetric,
     const SHARDS: usize,
-> StoragePolicy<Async> for Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
+> StoragePolicy<Async>
+    for Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>
 {
     type FetchDisallowed = Auth::FetchDisallowed;
     type PutDisallowed = Auth::PutDisallowed;

--- a/subduction_core/src/subduction/builder.rs
+++ b/subduction_core/src/subduction/builder.rs
@@ -128,7 +128,7 @@ pub struct SubductionBuilder<
 
 /// Internal helper: stores an optional pre-populated `ShardedMap`.
 ///
-/// Using a wrapper struct avoids placing the const generic `N` on
+/// Using a wrapper struct avoids placing the const generic `SHARDS` on
 /// fields that don't otherwise need it.
 #[derive(Debug)]
 struct SedimentreesOption<const SHARDS: usize>(
@@ -154,7 +154,7 @@ impl<const SHARDS: usize>
     /// `timer` — must be set via their respective methods before
     /// calling [`build`](SubductionBuilder::build).
     ///
-    /// The const generic `N` controls the number of shards in the
+    /// The const generic `SHARDS` controls the number of shards in the
     /// internal [`ShardedMap`]. Defaults to 256 if not specified.
     #[must_use]
     pub fn new() -> Self {

--- a/subduction_core/src/subduction/builder.rs
+++ b/subduction_core/src/subduction/builder.rs
@@ -284,8 +284,8 @@ impl<Sign, Sp, Store, Metric, const SHARDS: usize>
     }
 }
 
-impl<Sign, Sp, Store, Timer, Metric, const SHARDS: usize>
-    SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS>
+impl<Sign, Sp, Store, Timer, Met, const SHARDS: usize>
+    SubductionBuilder<Sign, Sp, Store, Timer, Met, SHARDS>
 {
     /// Set the discovery ID for discovery-mode connections.
     ///
@@ -310,10 +310,10 @@ impl<Sign, Sp, Store, Timer, Metric, const SHARDS: usize>
     /// Override the depth metric used to assign commit depths.
     ///
     /// Defaults to [`CountLeadingZeroBytes`].
-    pub fn depth_metric<Metric2: DepthMetric>(
+    pub fn depth_metric<Metric: DepthMetric>(
         self,
-        metric: Metric2,
-    ) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric2, SHARDS> {
+        metric: Metric,
+    ) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
         SubductionBuilder {
             signer: self.signer,
             spawner: self.spawner,

--- a/subduction_core/src/subduction/builder.rs
+++ b/subduction_core/src/subduction/builder.rs
@@ -131,7 +131,9 @@ pub struct SubductionBuilder<
 /// Using a wrapper struct avoids placing the const generic `N` on
 /// fields that don't otherwise need it.
 #[derive(Debug)]
-struct SedimentreesOption<const SHARDS: usize>(Option<Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>>);
+struct SedimentreesOption<const SHARDS: usize>(
+    Option<Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>>,
+);
 
 impl<const SHARDS: usize> Default for SedimentreesOption<SHARDS> {
     fn default() -> Self {
@@ -143,7 +145,9 @@ impl<const SHARDS: usize> Default for SedimentreesOption<SHARDS> {
 // Constructor
 // -----------------------------------------------------------------------
 
-impl<const SHARDS: usize> SubductionBuilder<Unset, Unset, Unset, Unset, CountLeadingZeroBytes, SHARDS> {
+impl<const SHARDS: usize>
+    SubductionBuilder<Unset, Unset, Unset, Unset, CountLeadingZeroBytes, SHARDS>
+{
     /// Create a new builder with all defaults.
     ///
     /// The four required fields — `signer`, `spawner`, `storage`, and
@@ -177,11 +181,16 @@ impl<const SHARDS: usize> Default
     }
 }
 
-impl<Sp, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Unset, Sp, Store, Timer, Metric, SHARDS> {
+impl<Sp, Store, Timer, Metric, const SHARDS: usize>
+    SubductionBuilder<Unset, Sp, Store, Timer, Metric, SHARDS>
+{
     /// Set the signer for peer identity and handshake authentication.
     ///
     /// This is a required field.
-    pub fn signer<Sign>(self, signer: Sign) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
+    pub fn signer<Sign>(
+        self,
+        signer: Sign,
+    ) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
         SubductionBuilder {
             signer,
             spawner: self.spawner,
@@ -197,13 +206,18 @@ impl<Sp, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Unset, Sp,
     }
 }
 
-impl<Sign, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Unset, Store, Timer, Metric, SHARDS> {
+impl<Sign, Store, Timer, Metric, const SHARDS: usize>
+    SubductionBuilder<Sign, Unset, Store, Timer, Metric, SHARDS>
+{
     /// Set the task spawner for background work.
     ///
     /// This is a required field. Common implementations:
     /// - `TokioSpawn` for native async (requires `Sendable`)
     /// - `WasmSpawn` for browser environments (requires `Local`)
-    pub fn spawner<Sp>(self, spawner: Sp) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
+    pub fn spawner<Sp>(
+        self,
+        spawner: Sp,
+    ) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
         SubductionBuilder {
             signer: self.signer,
             spawner,
@@ -219,7 +233,9 @@ impl<Sign, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Un
     }
 }
 
-impl<Sign, Sp, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, Unset, Timer, Metric, SHARDS> {
+impl<Sign, Sp, Timer, Metric, const SHARDS: usize>
+    SubductionBuilder<Sign, Sp, Unset, Timer, Metric, SHARDS>
+{
     /// Set the storage backend and authorization policy.
     ///
     /// This is a required field. The `storage` backend provides
@@ -244,7 +260,9 @@ impl<Sign, Sp, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, U
     }
 }
 
-impl<Sign, Sp, Store, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, Store, Unset, Metric, SHARDS> {
+impl<Sign, Sp, Store, Metric, const SHARDS: usize>
+    SubductionBuilder<Sign, Sp, Store, Unset, Metric, SHARDS>
+{
     /// Set the timeout strategy for roundtrip calls.
     ///
     /// This is a required field. Common implementations:
@@ -266,7 +284,9 @@ impl<Sign, Sp, Store, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, S
     }
 }
 
-impl<Sign, Sp, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
+impl<Sign, Sp, Store, Timer, Metric, const SHARDS: usize>
+    SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS>
+{
     /// Set the discovery ID for discovery-mode connections.
     ///
     /// Defaults to `None` (peer-to-peer mode only).
@@ -485,7 +505,8 @@ impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
         crate::connection::manager::ManagerFuture<Async>,
     )
     where
-        Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS> + 'static,
+        Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS>
+            + 'static,
         Async: StartListener<'a, Store, Conn, Hdl::Message, Hdl, Auth, Sign, Metric, SHARDS>,
         Store: Storage<Async>,
         Conn: Connection<Async, Hdl::Message> + PartialEq + Clone + 'a,

--- a/subduction_core/src/subduction/builder.rs
+++ b/subduction_core/src/subduction/builder.rs
@@ -106,24 +106,24 @@ pub struct Unset;
 /// See the [module documentation](self) for a full example.
 #[derive(Debug)]
 pub struct SubductionBuilder<
-    Sig = Unset,
+    Sign = Unset,
     Sp = Unset,
-    Sto = Unset,
-    Tmr = Unset,
-    M = CountLeadingZeroBytes,
-    const N: usize = 256,
+    Store = Unset,
+    Timer = Unset,
+    Metric = CountLeadingZeroBytes,
+    const SHARDS: usize = 256,
 > {
-    signer: Sig,
+    signer: Sign,
     spawner: Sp,
-    storage: Sto,
-    timer: Tmr,
+    storage: Store,
+    timer: Timer,
 
     discovery_id: Option<DiscoveryId>,
     default_call_timeout: Option<Duration>,
-    depth_metric: M,
+    depth_metric: Metric,
     nonce_cache: Option<NonceCache>,
     max_pending_blob_requests: usize,
-    sedimentrees: SedimentreesOption<N>,
+    sedimentrees: SedimentreesOption<SHARDS>,
 }
 
 /// Internal helper: stores an optional pre-populated `ShardedMap`.
@@ -131,9 +131,9 @@ pub struct SubductionBuilder<
 /// Using a wrapper struct avoids placing the const generic `N` on
 /// fields that don't otherwise need it.
 #[derive(Debug)]
-struct SedimentreesOption<const N: usize>(Option<Arc<ShardedMap<SedimentreeId, Sedimentree, N>>>);
+struct SedimentreesOption<const SHARDS: usize>(Option<Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>>);
 
-impl<const N: usize> Default for SedimentreesOption<N> {
+impl<const SHARDS: usize> Default for SedimentreesOption<SHARDS> {
     fn default() -> Self {
         Self(None)
     }
@@ -143,7 +143,7 @@ impl<const N: usize> Default for SedimentreesOption<N> {
 // Constructor
 // -----------------------------------------------------------------------
 
-impl<const N: usize> SubductionBuilder<Unset, Unset, Unset, Unset, CountLeadingZeroBytes, N> {
+impl<const SHARDS: usize> SubductionBuilder<Unset, Unset, Unset, Unset, CountLeadingZeroBytes, SHARDS> {
     /// Create a new builder with all defaults.
     ///
     /// The four required fields — `signer`, `spawner`, `storage`, and
@@ -169,19 +169,19 @@ impl<const N: usize> SubductionBuilder<Unset, Unset, Unset, Unset, CountLeadingZ
     }
 }
 
-impl<const N: usize> Default
-    for SubductionBuilder<Unset, Unset, Unset, Unset, CountLeadingZeroBytes, N>
+impl<const SHARDS: usize> Default
+    for SubductionBuilder<Unset, Unset, Unset, Unset, CountLeadingZeroBytes, SHARDS>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Sp, Sto, Tmr, M, const N: usize> SubductionBuilder<Unset, Sp, Sto, Tmr, M, N> {
+impl<Sp, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Unset, Sp, Store, Timer, Metric, SHARDS> {
     /// Set the signer for peer identity and handshake authentication.
     ///
     /// This is a required field.
-    pub fn signer<Sig>(self, signer: Sig) -> SubductionBuilder<Sig, Sp, Sto, Tmr, M, N> {
+    pub fn signer<Sign>(self, signer: Sign) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
         SubductionBuilder {
             signer,
             spawner: self.spawner,
@@ -197,13 +197,13 @@ impl<Sp, Sto, Tmr, M, const N: usize> SubductionBuilder<Unset, Sp, Sto, Tmr, M, 
     }
 }
 
-impl<Sig, Sto, Tmr, M, const N: usize> SubductionBuilder<Sig, Unset, Sto, Tmr, M, N> {
+impl<Sign, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Unset, Store, Timer, Metric, SHARDS> {
     /// Set the task spawner for background work.
     ///
     /// This is a required field. Common implementations:
     /// - `TokioSpawn` for native async (requires `Sendable`)
     /// - `WasmSpawn` for browser environments (requires `Local`)
-    pub fn spawner<Sp>(self, spawner: Sp) -> SubductionBuilder<Sig, Sp, Sto, Tmr, M, N> {
+    pub fn spawner<Sp>(self, spawner: Sp) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
         SubductionBuilder {
             signer: self.signer,
             spawner,
@@ -219,16 +219,16 @@ impl<Sig, Sto, Tmr, M, const N: usize> SubductionBuilder<Sig, Unset, Sto, Tmr, M
     }
 }
 
-impl<Sig, Sp, Tmr, M, const N: usize> SubductionBuilder<Sig, Sp, Unset, Tmr, M, N> {
+impl<Sign, Sp, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, Unset, Timer, Metric, SHARDS> {
     /// Set the storage backend and authorization policy.
     ///
     /// This is a required field. The `storage` backend provides
     /// persistence, and the `policy` controls per-peer access.
-    pub fn storage<S, P>(
+    pub fn storage<Store, Auth>(
         self,
-        storage: S,
-        policy: Arc<P>,
-    ) -> SubductionBuilder<Sig, Sp, StoragePowerbox<S, P>, Tmr, M, N> {
+        storage: Store,
+        policy: Arc<Auth>,
+    ) -> SubductionBuilder<Sign, Sp, StoragePowerbox<Store, Auth>, Timer, Metric, SHARDS> {
         SubductionBuilder {
             signer: self.signer,
             spawner: self.spawner,
@@ -244,13 +244,13 @@ impl<Sig, Sp, Tmr, M, const N: usize> SubductionBuilder<Sig, Sp, Unset, Tmr, M, 
     }
 }
 
-impl<Sig, Sp, Sto, M, const N: usize> SubductionBuilder<Sig, Sp, Sto, Unset, M, N> {
+impl<Sign, Sp, Store, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, Store, Unset, Metric, SHARDS> {
     /// Set the timeout strategy for roundtrip calls.
     ///
     /// This is a required field. Common implementations:
     /// - `TokioTimeout` for native async
     /// - `JsTimeout` for browser environments
-    pub fn timer<O>(self, timer: O) -> SubductionBuilder<Sig, Sp, Sto, O, M, N> {
+    pub fn timer<O>(self, timer: O) -> SubductionBuilder<Sign, Sp, Store, O, Metric, SHARDS> {
         SubductionBuilder {
             signer: self.signer,
             spawner: self.spawner,
@@ -266,7 +266,7 @@ impl<Sig, Sp, Sto, M, const N: usize> SubductionBuilder<Sig, Sp, Sto, Unset, M, 
     }
 }
 
-impl<Sig, Sp, Sto, Tmr, M, const N: usize> SubductionBuilder<Sig, Sp, Sto, Tmr, M, N> {
+impl<Sign, Sp, Store, Timer, Metric, const SHARDS: usize> SubductionBuilder<Sign, Sp, Store, Timer, Metric, SHARDS> {
     /// Set the discovery ID for discovery-mode connections.
     ///
     /// Defaults to `None` (peer-to-peer mode only).
@@ -290,10 +290,10 @@ impl<Sig, Sp, Sto, Tmr, M, const N: usize> SubductionBuilder<Sig, Sp, Sto, Tmr, 
     /// Override the depth metric used to assign commit depths.
     ///
     /// Defaults to [`CountLeadingZeroBytes`].
-    pub fn depth_metric<M2: DepthMetric>(
+    pub fn depth_metric<Metric2: DepthMetric>(
         self,
-        metric: M2,
-    ) -> SubductionBuilder<Sig, Sp, Sto, Tmr, M2, N> {
+        metric: Metric2,
+    ) -> SubductionBuilder<Sign, Sp, Store, Timer, Metric2, SHARDS> {
         SubductionBuilder {
             signer: self.signer,
             spawner: self.spawner,
@@ -334,7 +334,7 @@ impl<Sig, Sp, Sto, Tmr, M, const N: usize> SubductionBuilder<Sig, Sp, Sto, Tmr, 
     #[must_use]
     pub fn sedimentrees(
         mut self,
-        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, N>>,
+        sedimentrees: Arc<ShardedMap<SedimentreeId, Sedimentree, SHARDS>>,
     ) -> Self {
         self.sedimentrees = SedimentreesOption(Some(sedimentrees));
         self
@@ -345,8 +345,8 @@ impl<Sig, Sp, Sto, Tmr, M, const N: usize> SubductionBuilder<Sig, Sp, Sto, Tmr, 
 // Build methods (only available when all required fields are set)
 // -----------------------------------------------------------------------
 
-impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
-    SubductionBuilder<Sig, Sp, StoragePowerbox<S, P>, Tmr, M, N>
+impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
+    SubductionBuilder<Sign, Sp, StoragePowerbox<Store, Auth>, Timer, Metric, SHARDS>
 {
     /// Build a [`Subduction`] instance with the default [`SyncHandler`].
     ///
@@ -374,32 +374,32 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
     ///     .build::<Sendable, MyConnection>();
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn build<'a, F, C>(
+    pub fn build<'a, Async, Conn>(
         self,
     ) -> (
-        Arc<Subduction<'a, F, S, C, SyncHandler<F, S, C, P, M, N>, P, Sig, Tmr, M, N>>,
-        Arc<SyncHandler<F, S, C, P, M, N>>,
-        ListenerFuture<'a, F, S, C, SyncHandler<F, S, C, P, M, N>, P, Sig, Tmr, M, N>,
-        crate::connection::manager::ManagerFuture<F>,
+        Arc<Subduction<'a, Async, Store, Conn, SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS>, Auth, Sign, Timer, Metric, SHARDS>>,
+        Arc<SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS>>,
+        ListenerFuture<'a, Async, Store, Conn, SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS>, Auth, Sign, Timer, Metric, SHARDS>,
+        crate::connection::manager::ManagerFuture<Async>,
     )
     where
-        F: SubductionFutureForm<'a, S, C, SyncMessage, P, Sig, M, N> + 'static,
-        F: StartListener<'a, S, C, SyncMessage, SyncHandler<F, S, C, P, M, N>, P, Sig, M, N>,
-        S: Storage<F>,
-        C: Connection<F, SyncMessage> + PartialEq + Clone + 'a,
-        P: ConnectionPolicy<F> + StoragePolicy<F>,
-        Sig: Signer<F>,
-        Tmr: Timeout<F> + Clone + Send + Sync + 'a,
-        Sp: Spawn<F> + Send + Sync + 'static,
-        M: Clone,
-        SyncHandler<F, S, C, P, M, N>: Handler<F, C, Message = SyncMessage>,
-        <SyncHandler<F, S, C, P, M, N> as Handler<F, C>>::HandlerError:
-            Into<ListenError<F, S, C, SyncMessage>>,
-        crate::connection::managed::ManagedConnection<C, F, Tmr>:
+        Async: SubductionFutureForm<'a, Store, Conn, SyncMessage, Auth, Sign, Metric, SHARDS> + 'static,
+        Async: StartListener<'a, Store, Conn, SyncMessage, SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS>, Auth, Sign, Metric, SHARDS>,
+        Store: Storage<Async>,
+        Conn: Connection<Async, SyncMessage> + PartialEq + Clone + 'a,
+        Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+        Sign: Signer<Async>,
+        Timer: Timeout<Async> + Clone + Send + Sync + 'a,
+        Sp: Spawn<Async> + Send + Sync + 'static,
+        Metric: Clone,
+        SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS>: Handler<Async, Conn, Message = SyncMessage>,
+        <SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS> as Handler<Async, Conn>>::HandlerError:
+            Into<ListenError<Async, Store, Conn, SyncMessage>>,
+        crate::connection::managed::ManagedConnection<Conn, Async, Timer>:
             crate::connection::managed::ManagedCall<
-                    F,
+                    Async,
                     SyncMessage,
-                    SendError = <C as Connection<F, SyncMessage>>::SendError,
+                    SendError = <Conn as Connection<Async, SyncMessage>>::SendError,
                 >,
     {
         let sedimentrees = self
@@ -407,7 +407,7 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
             .0
             .unwrap_or_else(|| Arc::new(ShardedMap::new()));
 
-        let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>> =
+        let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>> =
             Arc::new(Mutex::new(Map::new()));
         let subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>> =
             Arc::new(Mutex::new(Map::new()));
@@ -476,31 +476,31 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
     ///     .build_with_handler::<Sendable, MyConnection, _>(handler);
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn build_with_handler<'a, F, C, H>(
+    pub fn build_with_handler<'a, Async, Conn, Hdl>(
         self,
-        handler: Arc<H>,
+        handler: Arc<Hdl>,
     ) -> (
-        Arc<Subduction<'a, F, S, C, H, P, Sig, Tmr, M, N>>,
-        ListenerFuture<'a, F, S, C, H, P, Sig, Tmr, M, N>,
-        crate::connection::manager::ManagerFuture<F>,
+        Arc<Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>>,
+        ListenerFuture<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>,
+        crate::connection::manager::ManagerFuture<Async>,
     )
     where
-        F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N> + 'static,
-        F: StartListener<'a, S, C, H::Message, H, P, Sig, M, N>,
-        S: Storage<F>,
-        C: Connection<F, H::Message> + PartialEq + Clone + 'a,
-        P: ConnectionPolicy<F> + StoragePolicy<F>,
-        Sig: Signer<F>,
-        Tmr: Timeout<F> + Clone + Send + Sync + 'a,
-        Sp: Spawn<F> + Send + Sync + 'static,
-        H: Handler<F, C>,
-        H::Message: From<SyncMessage>,
-        H::HandlerError: Into<ListenError<F, S, C, H::Message>>,
-        crate::connection::managed::ManagedConnection<C, F, Tmr>:
+        Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS> + 'static,
+        Async: StartListener<'a, Store, Conn, Hdl::Message, Hdl, Auth, Sign, Metric, SHARDS>,
+        Store: Storage<Async>,
+        Conn: Connection<Async, Hdl::Message> + PartialEq + Clone + 'a,
+        Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+        Sign: Signer<Async>,
+        Timer: Timeout<Async> + Clone + Send + Sync + 'a,
+        Sp: Spawn<Async> + Send + Sync + 'static,
+        Hdl: Handler<Async, Conn>,
+        Hdl::Message: From<SyncMessage>,
+        Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
+        crate::connection::managed::ManagedConnection<Conn, Async, Timer>:
             crate::connection::managed::ManagedCall<
-                    F,
-                    H::Message,
-                    SendError = <C as Connection<F, H::Message>>::SendError,
+                    Async,
+                    Hdl::Message,
+                    SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
                 >,
     {
         let sedimentrees = self
@@ -508,7 +508,7 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
             .0
             .unwrap_or_else(|| Arc::new(ShardedMap::new()));
 
-        let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>> =
+        let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>> =
             Arc::new(Mutex::new(Map::new()));
         let subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>> =
             Arc::new(Mutex::new(Map::new()));
@@ -542,7 +542,7 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
     /// the `compose` closure. This lets you wrap the `SyncHandler` in a
     /// composed handler that also handles other message types.
     ///
-    /// The closure returns `(Arc<H>, X)` where `X` is any extra data
+    /// The closure returns `(Arc<Hdl>, X)` where `X` is any extra data
     /// the caller wants to extract from the composition step (e.g.,
     /// an [`EphemeralHandler`] that shares the same `connections` map).
     ///
@@ -559,36 +559,36 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
     ///     });
     /// ```
     #[allow(clippy::type_complexity)]
-    pub fn build_composed<'a, F, C, H, X>(
+    pub fn build_composed<'a, Async, Conn, Hdl, X>(
         self,
-        compose: impl FnOnce(Arc<SyncHandler<F, S, C, P, M, N>>) -> (Arc<H>, X),
+        compose: impl FnOnce(Arc<SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS>>) -> (Arc<Hdl>, X),
     ) -> (
-        Arc<Subduction<'a, F, S, C, H, P, Sig, Tmr, M, N>>,
-        ListenerFuture<'a, F, S, C, H, P, Sig, Tmr, M, N>,
-        crate::connection::manager::ManagerFuture<F>,
+        Arc<Subduction<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>>,
+        ListenerFuture<'a, Async, Store, Conn, Hdl, Auth, Sign, Timer, Metric, SHARDS>,
+        crate::connection::manager::ManagerFuture<Async>,
         X,
     )
     where
-        F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N> + 'static,
-        F: StartListener<'a, S, C, H::Message, H, P, Sig, M, N>,
-        S: Storage<F>,
-        C: Connection<F, H::Message> + Connection<F, SyncMessage> + PartialEq + Clone + 'a,
-        P: ConnectionPolicy<F> + StoragePolicy<F>,
-        Sig: Signer<F>,
-        Tmr: Timeout<F> + Clone + Send + Sync + 'a,
-        Sp: Spawn<F> + Send + Sync + 'static,
-        H: Handler<F, C>,
-        H::Message: From<SyncMessage>,
-        H::HandlerError: Into<ListenError<F, S, C, H::Message>>,
-        M: Clone,
-        SyncHandler<F, S, C, P, M, N>: Handler<F, C, Message = SyncMessage>,
-        <SyncHandler<F, S, C, P, M, N> as Handler<F, C>>::HandlerError:
-            Into<ListenError<F, S, C, SyncMessage>>,
-        crate::connection::managed::ManagedConnection<C, F, Tmr>:
+        Async: SubductionFutureForm<'a, Store, Conn, Hdl::Message, Auth, Sign, Metric, SHARDS> + 'static,
+        Async: StartListener<'a, Store, Conn, Hdl::Message, Hdl, Auth, Sign, Metric, SHARDS>,
+        Store: Storage<Async>,
+        Conn: Connection<Async, Hdl::Message> + Connection<Async, SyncMessage> + PartialEq + Clone + 'a,
+        Auth: ConnectionPolicy<Async> + StoragePolicy<Async>,
+        Sign: Signer<Async>,
+        Timer: Timeout<Async> + Clone + Send + Sync + 'a,
+        Sp: Spawn<Async> + Send + Sync + 'static,
+        Hdl: Handler<Async, Conn>,
+        Hdl::Message: From<SyncMessage>,
+        Hdl::HandlerError: Into<ListenError<Async, Store, Conn, Hdl::Message>>,
+        Metric: Clone,
+        SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS>: Handler<Async, Conn, Message = SyncMessage>,
+        <SyncHandler<Async, Store, Conn, Auth, Metric, SHARDS> as Handler<Async, Conn>>::HandlerError:
+            Into<ListenError<Async, Store, Conn, SyncMessage>>,
+        crate::connection::managed::ManagedConnection<Conn, Async, Timer>:
             crate::connection::managed::ManagedCall<
-                    F,
-                    H::Message,
-                    SendError = <C as Connection<F, H::Message>>::SendError,
+                    Async,
+                    Hdl::Message,
+                    SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
                 >,
     {
         let sedimentrees = self
@@ -596,7 +596,7 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
             .0
             .unwrap_or_else(|| Arc::new(ShardedMap::new()));
 
-        let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>> =
+        let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>> =
             Arc::new(Mutex::new(Map::new()));
         let subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>> =
             Arc::new(Mutex::new(Map::new()));

--- a/subduction_core/src/subduction/error.rs
+++ b/subduction_core/src/subduction/error.rs
@@ -30,40 +30,45 @@ pub struct Unauthorized {
 
 /// An error indicating that a [`Sedimentree`] could not be hydrated from storage.
 #[derive(Debug, Clone, Copy, Error)]
-pub enum HydrationError<F: FutureForm, S: Storage<F>> {
+pub enum HydrationError<Async: FutureForm, Store: Storage<Async>> {
     /// An error occurred while loading all sedimentree IDs.
     #[error("hydration error when loading all sedimentree IDs: {0}")]
-    LoadAllIdsError(#[source] S::Error),
+    LoadAllIdsError(#[source] Store::Error),
 
     /// An error occurred while loading loose commits.
     #[error("hydration error when loading loose commits: {0}")]
-    LoadLooseCommitsError(#[source] S::Error),
+    LoadLooseCommitsError(#[source] Store::Error),
 
     /// An error occurred while loading fragments.
     #[error("hydration error when loading fragments: {0}")]
-    LoadFragmentsError(#[source] S::Error),
+    LoadFragmentsError(#[source] Store::Error),
 }
 
 /// An error that can occur during I/O operations.
 ///
 /// This covers storage and network connection errors.
 #[derive(Debug, Error)]
-pub enum IoError<F: FutureForm + ?Sized, S: Storage<F>, C: Connection<F, M>, M: Encode + Decode> {
+pub enum IoError<
+    Async: FutureForm + ?Sized,
+    Store: Storage<Async>,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
+> {
     /// An error occurred while using storage.
     #[error(transparent)]
-    Storage(S::Error),
+    Storage(Store::Error),
 
     /// An error occurred while sending data on the connection.
     #[error(transparent)]
-    ConnSend(C::SendError),
+    ConnSend(Conn::SendError),
 
     /// An error occurred while receiving data from the connection.
     #[error(transparent)]
-    ConnRecv(C::RecvError),
+    ConnRecv(Conn::RecvError),
 
     /// An error occurred during a roundtrip call on the connection.
     #[error(transparent)]
-    ConnCall(CallError<C::SendError>),
+    ConnCall(CallError<Conn::SendError>),
 
     /// The blob content doesn't match the claimed metadata.
     #[error(transparent)]
@@ -72,10 +77,15 @@ pub enum IoError<F: FutureForm + ?Sized, S: Storage<F>, C: Connection<F, M>, M: 
 
 /// An error that can occur while handling a blob request.
 #[derive(Debug, Error)]
-pub enum BlobRequestErr<F: FutureForm, S: Storage<F>, C: Connection<F, M>, M: Encode + Decode> {
+pub enum BlobRequestErr<
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
+> {
     /// An IO error occurred while handling the blob request.
     #[error("IO error: {0}")]
-    IoError(#[from] IoError<F, S, C, M>),
+    IoError(#[from] IoError<Async, Store, Conn, WireMsg>),
 
     /// Some requested blobs were missing locally.
     #[error("Missing blobs: {0:?}")]
@@ -84,11 +94,15 @@ pub enum BlobRequestErr<F: FutureForm, S: Storage<F>, C: Connection<F, M>, M: En
 
 /// An error that can occur while handling a batch sync request.
 #[derive(Debug, Error)]
-pub enum ListenError<F: FutureForm + ?Sized, S: Storage<F>, C: Connection<F, M>, M: Encode + Decode>
-{
+pub enum ListenError<
+    Async: FutureForm + ?Sized,
+    Store: Storage<Async>,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
+> {
     /// An IO error occurred while handling the batch sync request.
     #[error(transparent)]
-    IoError(#[from] IoError<F, S, C, M>),
+    IoError(#[from] IoError<Async, Store, Conn, WireMsg>),
 
     /// Tried to send a message to a closed channel.
     #[error("tried to send to closed channel")]
@@ -112,15 +126,15 @@ pub enum AddConnectionError<D> {
 /// An error that can occur during local write operations.
 #[derive(Debug, Error)]
 pub enum WriteError<
-    F: FutureForm + ?Sized,
-    S: Storage<F>,
-    C: Connection<F, M>,
-    M: Encode + Decode,
+    Async: FutureForm + ?Sized,
+    Store: Storage<Async>,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
     PutErr = core::convert::Infallible,
 > {
     /// An I/O error occurred.
     #[error(transparent)]
-    Io(#[from] IoError<F, S, C, M>),
+    Io(#[from] IoError<Async, Store, Conn, WireMsg>),
 
     /// The storage policy rejected the write.
     #[error("put disallowed: {0}")]
@@ -134,14 +148,14 @@ pub enum WriteError<
 /// An error that can occur when sending requested data to a peer.
 #[derive(Debug, Error)]
 pub enum SendRequestedDataError<
-    F: FutureForm + ?Sized,
-    S: Storage<F>,
-    C: Connection<F, M>,
-    M: Encode + Decode,
+    Async: FutureForm + ?Sized,
+    Store: Storage<Async>,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
 > {
     /// An I/O error occurred.
     #[error(transparent)]
-    Io(#[from] IoError<F, S, C, M>),
+    Io(#[from] IoError<Async, Store, Conn, WireMsg>),
 
     /// The peer is not authorized to access the requested sedimentree.
     #[error(transparent)]

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -276,7 +276,11 @@ pub(crate) async fn minimize_tree<Metric: DepthMetric, const SHARDS: usize>(
 ///
 /// Searches through both loose commits and fragments for the given
 /// sedimentree, returning the first blob whose digest matches.
-pub(crate) async fn get_blob<Async: FutureForm, Store: Storage<Async>, Auth: StoragePolicy<Async>>(
+pub(crate) async fn get_blob<
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Auth: StoragePolicy<Async>,
+>(
     storage: &StoragePowerbox<Store, Auth>,
     id: SedimentreeId,
     digest: Digest<Blob>,

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -40,19 +40,19 @@ use super::error::IoError;
 /// Policy-rejected diffs are logged and silently ignored (returns `Ok(())`).
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn recv_batch_sync_response<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, M>,
-    M: Encode + Decode,
-    P: StoragePolicy<F>,
-    const N: usize,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, WireMsg>,
+    WireMsg: Encode + Decode,
+    Auth: StoragePolicy<Async>,
+    const SHARDS: usize,
 >(
-    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, N>,
-    storage: &StoragePowerbox<S, P>,
+    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, SHARDS>,
+    storage: &StoragePowerbox<Store, Auth>,
     from: &PeerId,
     id: SedimentreeId,
     diff: SyncDiff,
-) -> Result<(), IoError<F, S, C, M>> {
+) -> Result<(), IoError<Async, Store, Conn, WireMsg>> {
     tracing::info!(
         "received batch sync response for sedimentree {:?} from peer {:?} with {} missing commits and {} missing fragments",
         id,
@@ -61,7 +61,7 @@ pub(crate) async fn recv_batch_sync_response<
         diff.missing_fragments.len()
     );
 
-    let mut putter_cache: Map<PeerId, Putter<F, S>> = Map::new();
+    let mut putter_cache: Map<PeerId, Putter<Async, Store>> = Map::new();
 
     // Collect verified commits and fragments grouped by author,
     // so we can call save_batch once per author instead of once per item.
@@ -90,7 +90,7 @@ pub(crate) async fn recv_batch_sync_response<
 
         #[allow(clippy::map_entry)]
         if !putter_cache.contains_key(&author_id) {
-            match storage.get_putter::<F>(*from, author, id).await {
+            match storage.get_putter::<Async>(*from, author, id).await {
                 Ok(p) => {
                     putter_cache.insert(author_id, p);
                 }
@@ -134,7 +134,7 @@ pub(crate) async fn recv_batch_sync_response<
 
         #[allow(clippy::map_entry)]
         if !putter_cache.contains_key(&author_id) {
-            match storage.get_putter::<F>(*from, author, id).await {
+            match storage.get_putter::<Async>(*from, author, id).await {
                 Ok(p) => {
                     putter_cache.insert(author_id, p);
                 }
@@ -207,11 +207,15 @@ pub(crate) async fn recv_batch_sync_response<
 /// Persists to storage first (cancel-safe: idempotent CAS writes),
 /// then updates the in-memory tree. Returns whether the commit was
 /// newly added (`false` if already present).
-pub(crate) async fn insert_commit_locally<F: FutureForm, S: Storage<F>, const N: usize>(
-    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, N>,
-    putter: &Putter<F, S>,
+pub(crate) async fn insert_commit_locally<
+    Async: FutureForm,
+    Store: Storage<Async>,
+    const SHARDS: usize,
+>(
+    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, SHARDS>,
+    putter: &Putter<Async, Store>,
     verified_meta: VerifiedMeta<LooseCommit>,
-) -> Result<bool, S::Error> {
+) -> Result<bool, Store::Error> {
     let id = putter.sedimentree_id();
     let commit = verified_meta.payload().clone();
 
@@ -230,11 +234,15 @@ pub(crate) async fn insert_commit_locally<F: FutureForm, S: Storage<F>, const N:
 /// Insert a verified fragment into storage and the in-memory tree.
 ///
 /// See [`insert_commit_locally`] for cancel-safety rationale.
-pub(crate) async fn insert_fragment_locally<F: FutureForm, S: Storage<F>, const N: usize>(
-    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, N>,
-    putter: &Putter<F, S>,
+pub(crate) async fn insert_fragment_locally<
+    Async: FutureForm,
+    Store: Storage<Async>,
+    const SHARDS: usize,
+>(
+    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, SHARDS>,
+    putter: &Putter<Async, Store>,
     verified_meta: VerifiedMeta<Fragment>,
-) -> Result<bool, S::Error> {
+) -> Result<bool, Store::Error> {
     let id = putter.sedimentree_id();
     let fragment = verified_meta.payload().clone();
 
@@ -252,9 +260,9 @@ pub(crate) async fn insert_fragment_locally<F: FutureForm, S: Storage<F>, const 
 ///
 /// Prunes dominated fragments and loose commits covered by fragments,
 /// keeping only the minimal covering set. Storage retains the full history.
-pub(crate) async fn minimize_tree<M: DepthMetric, const N: usize>(
-    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, N>,
-    depth_metric: &M,
+pub(crate) async fn minimize_tree<Metric: DepthMetric, const SHARDS: usize>(
+    sedimentrees: &ShardedMap<SedimentreeId, Sedimentree, SHARDS>,
+    depth_metric: &Metric,
     id: SedimentreeId,
 ) {
     sedimentrees
@@ -268,20 +276,20 @@ pub(crate) async fn minimize_tree<M: DepthMetric, const N: usize>(
 ///
 /// Searches through both loose commits and fragments for the given
 /// sedimentree, returning the first blob whose digest matches.
-pub(crate) async fn get_blob<F: FutureForm, S: Storage<F>, P: StoragePolicy<F>>(
-    storage: &StoragePowerbox<S, P>,
+pub(crate) async fn get_blob<Async: FutureForm, Store: Storage<Async>, Auth: StoragePolicy<Async>>(
+    storage: &StoragePowerbox<Store, Auth>,
     id: SedimentreeId,
     digest: Digest<Blob>,
-) -> Result<Option<Blob>, S::Error> {
+) -> Result<Option<Blob>, Store::Error> {
     let local_access = storage.hydration_access();
 
-    for verified in local_access.load_loose_commits::<F>(id).await? {
+    for verified in local_access.load_loose_commits::<Async>(id).await? {
         if verified.payload().blob_meta().digest() == digest {
             return Ok(Some(verified.blob().clone()));
         }
     }
 
-    for verified in local_access.load_fragments::<F>(id).await? {
+    for verified in local_access.load_fragments::<Async>(id).await? {
         if verified.payload().summary().blob_meta().digest() == digest {
             return Ok(Some(verified.blob().clone()));
         }

--- a/subduction_core/src/subduction/peers.rs
+++ b/subduction_core/src/subduction/peers.rs
@@ -60,18 +60,18 @@ pub(crate) async fn remove_peer_from_subscriptions(
 /// For each subscriber, checks policy to confirm they are allowed to
 /// fetch this sedimentree before including their connections.
 pub(crate) async fn get_authorized_subscriber_conns<
-    F: FutureForm,
-    S: Storage<F>,
-    C: Connection<F, M> + PartialEq + Clone + 'static,
-    M: Encode + Decode,
-    P: StoragePolicy<F>,
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Conn: Connection<Async, WireMsg> + PartialEq + Clone + 'static,
+    WireMsg: Encode + Decode,
+    Auth: StoragePolicy<Async>,
 >(
     subscriptions: &Mutex<Map<SedimentreeId, Set<PeerId>>>,
-    storage: &StoragePowerbox<S, P>,
-    connections: &Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>,
+    storage: &StoragePowerbox<Store, Auth>,
+    connections: &Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>,
     sedimentree_id: SedimentreeId,
     exclude_peer: &PeerId,
-) -> Vec<Authenticated<C, F>> {
+) -> Vec<Authenticated<Conn, Async>> {
     let subscriber_ids: Vec<PeerId> = {
         let guard = subscriptions.lock().await;
         guard
@@ -118,13 +118,13 @@ pub(crate) async fn get_authorized_subscriber_conns<
 /// - `Some(true)` — connection removed, was the peer's last connection
 /// - `None` — connection was not found
 pub(crate) async fn remove_connection<
-    F: FutureForm,
-    C: Connection<F, M> + PartialEq + Clone + 'static,
-    M: Encode + Decode,
+    Async: FutureForm,
+    Conn: Connection<Async, WireMsg> + PartialEq + Clone + 'static,
+    WireMsg: Encode + Decode,
 >(
-    connections: &Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>,
+    connections: &Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>,
     subscriptions: &Mutex<Map<SedimentreeId, Set<PeerId>>>,
-    conn: &Authenticated<C, F>,
+    conn: &Authenticated<Conn, Async>,
 ) -> Option<bool> {
     let peer_id = conn.peer_id();
     let mut guard = connections.lock().await;

--- a/subduction_core/src/timeout.rs
+++ b/subduction_core/src/timeout.rs
@@ -22,13 +22,13 @@ use thiserror::Error;
 ///     Err(TimedOut) => { /* deadline exceeded */ }
 /// }
 /// ```
-pub trait Timeout<K: FutureForm + ?Sized>: Clone {
+pub trait Timeout<Async: FutureForm + ?Sized>: Clone {
     /// Wrap a future with a timeout.
     fn timeout<'a, T: 'a>(
         &'a self,
         dur: Duration,
-        fut: K::Future<'a, T>,
-    ) -> K::Future<'a, Result<T, TimedOut>>;
+        fut: Async::Future<'a, T>,
+    ) -> Async::Future<'a, Result<T, TimedOut>>;
 }
 
 /// An error indicating that an operation has timed out.

--- a/subduction_core/src/transport.rs
+++ b/subduction_core/src/transport.rs
@@ -31,7 +31,7 @@ use future_form::FutureForm;
 ///
 /// - `send_bytes` must deliver the entire byte slice atomically (no partial sends).
 /// - `recv_bytes` must return a complete message frame (no fragmentation).
-pub trait Transport<K: FutureForm + ?Sized>: Clone + PartialEq {
+pub trait Transport<Async: FutureForm + ?Sized>: Clone + PartialEq {
     /// A problem when sending bytes.
     type SendError: core::error::Error;
 
@@ -42,35 +42,35 @@ pub trait Transport<K: FutureForm + ?Sized>: Clone + PartialEq {
     type DisconnectionError: core::error::Error;
 
     /// Send raw bytes over the transport.
-    fn send_bytes(&self, bytes: &[u8]) -> K::Future<'_, Result<(), Self::SendError>>;
+    fn send_bytes(&self, bytes: &[u8]) -> Async::Future<'_, Result<(), Self::SendError>>;
 
     /// Receive the next complete message frame as raw bytes.
-    fn recv_bytes(&self) -> K::Future<'_, Result<Vec<u8>, Self::RecvError>>;
+    fn recv_bytes(&self) -> Async::Future<'_, Result<Vec<u8>, Self::RecvError>>;
 
     /// Disconnect from the peer gracefully.
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>>;
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>>;
 }
 
 // ── Arc impl ────────────────────────────────────────────────────────────
 
-impl<T, K> Transport<K> for Arc<T>
+impl<T, Async> Transport<Async> for Arc<T>
 where
-    T: Transport<K>,
-    K: FutureForm,
+    T: Transport<Async>,
+    Async: FutureForm,
 {
     type SendError = T::SendError;
     type RecvError = T::RecvError;
     type DisconnectionError = T::DisconnectionError;
 
-    fn send_bytes(&self, bytes: &[u8]) -> K::Future<'_, Result<(), Self::SendError>> {
+    fn send_bytes(&self, bytes: &[u8]) -> Async::Future<'_, Result<(), Self::SendError>> {
         T::send_bytes(self, bytes)
     }
 
-    fn recv_bytes(&self) -> K::Future<'_, Result<Vec<u8>, Self::RecvError>> {
+    fn recv_bytes(&self) -> Async::Future<'_, Result<Vec<u8>, Self::RecvError>> {
         T::recv_bytes(self)
     }
 
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>> {
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>> {
         T::disconnect(self)
     }
 }

--- a/subduction_core/src/transport.rs
+++ b/subduction_core/src/transport.rs
@@ -9,7 +9,7 @@
 //!
 //! ```text
 //! Transport (one impl per backend)
-//!   └── MessageTransport<T>   — adds Connection<K, M> for any M
+//!   └── MessageTransport<T>   — adds Connection<Async, WireMsg> for any WireMsg
 //! ```
 //!
 //! Each backend (WebSocket, iroh, HTTP long-poll, `MessagePort`)
@@ -25,7 +25,8 @@ use future_form::FutureForm;
 ///
 /// Implement this for transport backends (WebSocket, QUIC, HTTP long-poll,
 /// `MessagePort`, etc). Wrap in [`MessageTransport`] to get a typed
-/// [`Connection<K, M>`](crate::connection::Connection) for any message type.
+/// [`Connection<Async, WireMsg>`](crate::connection::Connection) for any
+/// message type.
 ///
 /// # Contract
 ///

--- a/subduction_core/src/transport/message.rs
+++ b/subduction_core/src/transport/message.rs
@@ -72,33 +72,33 @@ pub enum RecvDecodeError<R: core::error::Error> {
         T::SendError: Send + 'static,
         T::RecvError: Send + 'static,
         T::DisconnectionError: Send + 'static,
-        M: Encode + Decode + Send + 'static,
+        WireMsg: Encode + Decode + Send + 'static,
     Local where
         T: Transport<Local>,
-        M: Encode + Decode + 'static
+        WireMsg: Encode + Decode + 'static
 )]
-impl<K: FutureForm, T, M> Connection<K, M> for MessageTransport<T> {
+impl<Async: FutureForm, T, WireMsg> Connection<Async, WireMsg> for MessageTransport<T> {
     type DisconnectionError = T::DisconnectionError;
     type SendError = T::SendError;
     type RecvError = RecvDecodeError<T::RecvError>;
 
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>> {
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>> {
         self.inner.disconnect()
     }
 
-    fn send(&self, message: &M) -> K::Future<'_, Result<(), Self::SendError>> {
+    fn send(&self, message: &WireMsg) -> Async::Future<'_, Result<(), Self::SendError>> {
         let bytes = message.encode();
-        K::from_future(async move { self.inner.send_bytes(&bytes).await })
+        Async::from_future(async move { self.inner.send_bytes(&bytes).await })
     }
 
-    fn recv(&self) -> K::Future<'_, Result<M, Self::RecvError>> {
-        K::from_future(async move {
+    fn recv(&self) -> Async::Future<'_, Result<WireMsg, Self::RecvError>> {
+        Async::from_future(async move {
             let bytes = self
                 .inner
                 .recv_bytes()
                 .await
                 .map_err(RecvDecodeError::Recv)?;
-            M::try_decode(&bytes).map_err(RecvDecodeError::from)
+            WireMsg::try_decode(&bytes).map_err(RecvDecodeError::from)
         })
     }
 }

--- a/subduction_core/tests/metrics_storage.rs
+++ b/subduction_core/tests/metrics_storage.rs
@@ -194,8 +194,7 @@ async fn delete_fragment_removes_from_inner() -> TestResult {
     let ms = MetricsStorage::new(inner);
     Storage::<Sendable>::delete_fragment(&ms, sed_id, head).await?;
 
-    let loaded =
-        Storage::<Sendable>::load_fragment(ms.inner(), sed_id, head).await?;
+    let loaded = Storage::<Sendable>::load_fragment(ms.inner(), sed_id, head).await?;
     assert!(
         loaded.is_none(),
         "fragment should be gone from inner storage after delete"

--- a/subduction_core/tests/metrics_storage.rs
+++ b/subduction_core/tests/metrics_storage.rs
@@ -1,0 +1,284 @@
+//! Tests for [`MetricsStorage`], the metrics-recording storage wrapper.
+//!
+//! These tests verify that each [`Storage`] method on `MetricsStorage`
+//! actually delegates to the inner storage, not just records timing
+//! metrics. They guard against `cargo mutants` survivors that replace
+//! wrapper bodies with `Future::from(Ok(()))`, `Future::from(Ok(vec![...]))`,
+//! and similar fabricated-success returns.
+//!
+//! The pattern is identical for every test: wrap a [`MemoryStorage`] in
+//! [`MetricsStorage`], invoke a method through the wrapper, then read
+//! through the inner storage to confirm the operation actually happened.
+//! A wholesale wrapper-body mutation breaks the post-condition because
+//! the inner storage is unchanged (for writes) or returns its true state
+//! instead of the fabricated value (for reads).
+//!
+//! Feature-gated on `metrics`; runs under `cargo test --all-features`
+//! and (with `--features metrics`) under `cargo mutants`.
+
+#![cfg(feature = "metrics")]
+
+use std::collections::BTreeSet;
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    collections::Set,
+    fragment::Fragment,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+};
+use subduction_core::{
+    connection::test_utils::test_signer,
+    storage::{memory::MemoryStorage, metrics::MetricsStorage, traits::Storage},
+};
+use subduction_crypto::{signed::Signed, verified_meta::VerifiedMeta};
+use testresult::TestResult;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Build a verified loose commit for the given sedimentree from a unique
+/// data seed. Each call with a different `data` produces a distinct
+/// commit identity (so callers can distinguish them after a round-trip).
+async fn make_verified_commit(
+    sed_id: SedimentreeId,
+    data: &[u8],
+) -> Result<VerifiedMeta<LooseCommit>, Box<dyn std::error::Error>> {
+    let blob = Blob::new(data.to_vec());
+    let blob_meta = BlobMeta::new(&blob);
+    #[allow(clippy::indexing_slicing)]
+    let head = CommitId::new({
+        let mut bytes = [0u8; 32];
+        let n = data.len().min(32);
+        bytes[..n].copy_from_slice(&data[..n]);
+        bytes
+    });
+    let commit = LooseCommit::new(sed_id, head, BTreeSet::new(), blob_meta);
+    let sealed = Signed::seal::<Sendable, _>(&test_signer(), commit).await;
+    let verified_sig = sealed.into_signed().try_verify()?;
+    Ok(VerifiedMeta::new(verified_sig, blob)?)
+}
+
+/// Build a verified fragment for the given sedimentree from a unique
+/// data seed. See [`make_verified_commit`] for the identity convention.
+async fn make_verified_fragment(
+    sed_id: SedimentreeId,
+    head_byte: u8,
+    data: &[u8],
+) -> Result<VerifiedMeta<Fragment>, Box<dyn std::error::Error>> {
+    let blob = Blob::new(data.to_vec());
+    let blob_meta = BlobMeta::new(&blob);
+    let head = CommitId::new([head_byte; 32]);
+    let fragment = Fragment::new(sed_id, head, BTreeSet::new(), &[], blob_meta);
+    let sealed = Signed::seal::<Sendable, _>(&test_signer(), fragment).await;
+    let verified_sig = sealed.into_signed().try_verify()?;
+    Ok(VerifiedMeta::new(verified_sig, blob)?)
+}
+
+// ============================================================================
+// Sedimentree-ID methods
+// ============================================================================
+
+/// `save_sedimentree_id` must register the ID with the inner storage.
+///
+/// Catches `cargo mutants` survivors on `storage/metrics.rs:113-126` such
+/// as `Future::from(Ok(()))` — the wrapper returns success without
+/// invoking the inner store, so the ID never lands.
+#[tokio::test]
+async fn save_sedimentree_id_delegates_to_inner() -> TestResult {
+    let inner = MemoryStorage::new();
+    let ms = MetricsStorage::new(inner);
+    let id = SedimentreeId::new([1u8; 32]);
+
+    Storage::<Sendable>::save_sedimentree_id(&ms, id).await?;
+
+    let ids = Storage::<Sendable>::load_all_sedimentree_ids(ms.inner()).await?;
+    assert!(
+        ids.contains(&id),
+        "inner storage should contain the saved id, got {ids:?}"
+    );
+    Ok(())
+}
+
+/// `delete_sedimentree_id` must remove the ID from the inner storage.
+///
+/// Catches mutants on `storage/metrics.rs:128-141` (`Future::from(Ok(()))`
+/// would leave the id in place).
+#[tokio::test]
+async fn delete_sedimentree_id_delegates_to_inner() -> TestResult {
+    let inner = MemoryStorage::new();
+    let id = SedimentreeId::new([2u8; 32]);
+    Storage::<Sendable>::save_sedimentree_id(&inner, id).await?;
+
+    let ms = MetricsStorage::new(inner);
+    Storage::<Sendable>::delete_sedimentree_id(&ms, id).await?;
+
+    let ids = Storage::<Sendable>::load_all_sedimentree_ids(ms.inner()).await?;
+    assert!(
+        !ids.contains(&id),
+        "inner storage should no longer contain the deleted id, got {ids:?}"
+    );
+    Ok(())
+}
+
+/// `load_all_sedimentree_ids` must reflect the inner storage's actual
+/// state, not a fabricated `Set::new()` or `Set::from_iter([Default])`.
+///
+/// Catches mutants on `storage/metrics.rs:143-155`. Asserts on both
+/// length and membership so `Set::from_iter([Default::default()])`
+/// (a single zero-valued id) is also caught — we use two non-zero ids.
+#[tokio::test]
+async fn load_all_sedimentree_ids_reflects_inner_state() -> TestResult {
+    let inner = MemoryStorage::new();
+    let id1 = SedimentreeId::new([3u8; 32]);
+    let id2 = SedimentreeId::new([4u8; 32]);
+    Storage::<Sendable>::save_sedimentree_id(&inner, id1).await?;
+    Storage::<Sendable>::save_sedimentree_id(&inner, id2).await?;
+
+    let ms = MetricsStorage::new(inner);
+    let loaded = Storage::<Sendable>::load_all_sedimentree_ids(&ms).await?;
+
+    let expected: Set<SedimentreeId> = [id1, id2].into_iter().collect();
+    assert_eq!(
+        loaded, expected,
+        "wrapper should return exactly the inner's id set"
+    );
+    Ok(())
+}
+
+// ============================================================================
+// Fragment methods
+// ============================================================================
+
+/// `load_fragments` must return whatever the inner storage holds, not a
+/// fabricated empty or default-valued vec.
+///
+/// Catches mutants on `storage/metrics.rs:292-302`. Asserts on payload
+/// identity (the fragment's head) so the `vec![VerifiedMeta::new(Default)]`
+/// variants are detected — `Default::default()` would not match our
+/// non-zero head byte.
+#[tokio::test]
+async fn load_fragments_returns_inner_data() -> TestResult {
+    let inner = MemoryStorage::new();
+    let sed_id = SedimentreeId::new([5u8; 32]);
+    let expected_head = CommitId::new([0xAB; 32]);
+    let verified = make_verified_fragment(sed_id, 0xAB, b"load_fragments_payload").await?;
+    Storage::<Sendable>::save_fragment(&inner, sed_id, verified).await?;
+
+    let ms = MetricsStorage::new(inner);
+    let loaded = Storage::<Sendable>::load_fragments(&ms, sed_id).await?;
+
+    let heads: Vec<CommitId> = loaded.iter().map(|v| v.payload().head()).collect();
+    assert_eq!(
+        heads,
+        vec![expected_head],
+        "loaded fragments should be exactly the one we stored"
+    );
+    Ok(())
+}
+
+/// `delete_fragment` must remove the fragment from the inner storage.
+///
+/// Catches mutants on `storage/metrics.rs:304-318`.
+#[tokio::test]
+async fn delete_fragment_removes_from_inner() -> TestResult {
+    let inner = MemoryStorage::new();
+    let sed_id = SedimentreeId::new([6u8; 32]);
+    let head_byte = 0xCD;
+    let head = CommitId::new([head_byte; 32]);
+    let verified = make_verified_fragment(sed_id, head_byte, b"delete_one").await?;
+    Storage::<Sendable>::save_fragment(&inner, sed_id, verified).await?;
+
+    let ms = MetricsStorage::new(inner);
+    Storage::<Sendable>::delete_fragment(&ms, sed_id, head).await?;
+
+    let loaded =
+        Storage::<Sendable>::load_fragment(ms.inner(), sed_id, head).await?;
+    assert!(
+        loaded.is_none(),
+        "fragment should be gone from inner storage after delete"
+    );
+    Ok(())
+}
+
+/// `delete_fragments` must remove all fragments for the sedimentree from
+/// the inner storage.
+///
+/// Catches mutants on `storage/metrics.rs:320-330`. Seeds two fragments
+/// so a partial mutation (deleting one of two by accident) would also be
+/// caught.
+#[tokio::test]
+async fn delete_fragments_clears_all_for_sedimentree() -> TestResult {
+    let inner = MemoryStorage::new();
+    let sed_id = SedimentreeId::new([7u8; 32]);
+    let f1 = make_verified_fragment(sed_id, 0x10, b"frag-one").await?;
+    let f2 = make_verified_fragment(sed_id, 0x20, b"frag-two").await?;
+    Storage::<Sendable>::save_fragment(&inner, sed_id, f1).await?;
+    Storage::<Sendable>::save_fragment(&inner, sed_id, f2).await?;
+
+    let ms = MetricsStorage::new(inner);
+    Storage::<Sendable>::delete_fragments(&ms, sed_id).await?;
+
+    let remaining = Storage::<Sendable>::load_fragments(ms.inner(), sed_id).await?;
+    assert!(
+        remaining.is_empty(),
+        "all fragments for the sedimentree should be gone, got {} remaining",
+        remaining.len()
+    );
+    Ok(())
+}
+
+// ============================================================================
+// Batch operations
+// ============================================================================
+
+/// `save_batch` must write all commits and fragments through to the
+/// inner storage AND register the sedimentree id (per the trait
+/// contract).
+///
+/// Catches mutants on `storage/metrics.rs:334-349`. The most pernicious
+/// surviving variants are `Future::from(Ok(0))` and `Future::from(Ok(1))`
+/// — the wrapper returns a count without persisting anything. We assert
+/// on both the returned count AND the post-state of inner storage so
+/// either bug is detected.
+#[tokio::test]
+async fn save_batch_writes_through_to_inner() -> TestResult {
+    let inner = MemoryStorage::new();
+    let sed_id = SedimentreeId::new([8u8; 32]);
+
+    let commit = make_verified_commit(sed_id, b"batch-commit").await?;
+    let commit_head = commit.payload().head();
+    let fragment = make_verified_fragment(sed_id, 0xEF, b"batch-fragment").await?;
+    let fragment_head = fragment.payload().head();
+
+    let ms = MetricsStorage::new(inner);
+    let count = Storage::<Sendable>::save_batch(&ms, sed_id, vec![commit], vec![fragment]).await?;
+
+    assert_eq!(count, 2, "save_batch should report 2 items written");
+
+    // ID must be registered (trait contract).
+    let ids = Storage::<Sendable>::load_all_sedimentree_ids(ms.inner()).await?;
+    assert!(
+        ids.contains(&sed_id),
+        "save_batch should register the sedimentree id"
+    );
+
+    // Commit must be persisted under its head.
+    let stored_commit =
+        Storage::<Sendable>::load_loose_commit(ms.inner(), sed_id, commit_head).await?;
+    assert!(
+        stored_commit.is_some(),
+        "save_batch should have persisted the commit"
+    );
+
+    // Fragment must be persisted under its head.
+    let stored_fragment =
+        Storage::<Sendable>::load_fragment(ms.inner(), sed_id, fragment_head).await?;
+    assert!(
+        stored_fragment.is_some(),
+        "save_batch should have persisted the fragment"
+    );
+    Ok(())
+}

--- a/subduction_core/tests/recv_batch_sync_response.rs
+++ b/subduction_core/tests/recv_batch_sync_response.rs
@@ -76,6 +76,7 @@ fn make_subduction() -> (
 async fn make_test_commit(id: &SedimentreeId, data: &[u8]) -> (Signed<LooseCommit>, Blob) {
     let blob = Blob::new(data.to_vec());
     let blob_meta = BlobMeta::new(&blob);
+    #[allow(clippy::indexing_slicing)]
     let head = CommitId::new({
         let mut bytes = [0u8; 32];
         let n = data.len().min(32);

--- a/subduction_core/tests/recv_batch_sync_response.rs
+++ b/subduction_core/tests/recv_batch_sync_response.rs
@@ -1,0 +1,258 @@
+//! Tests for [`Subduction::recv_batch_sync_response`].
+//!
+//! These tests directly drive `recv_batch_sync_response` with a populated
+//! [`SyncDiff`] and assert that the missing commits and fragments end up
+//! in local storage. They specifically guard against putter-cache
+//! short-circuit bugs in `subduction_core/src/subduction/ingest.rs` — if
+//! either of the `if !putter_cache.contains_key(...)` branches around
+//! lines 92 and 136 inverts its sense, no data is ingested and these
+//! tests fail.
+//!
+//! `bidirectional_sync.rs` covers the request/response wire shape but
+//! does not assert that the requestor actually persists the response.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use core::{future::Future, time::Duration};
+use std::{collections::BTreeSet, sync::Arc};
+
+use future_form::Sendable;
+use futures::future::Aborted;
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    commit::CountLeadingZeroBytes,
+    fragment::Fragment,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+};
+use subduction_core::{
+    connection::{
+        message::{RequestedData, SyncDiff, SyncMessage},
+        test_utils::{ChannelMockConnection, InstantTimeout, TokioSpawn, test_signer},
+    },
+    handler::sync::SyncHandler,
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    storage::memory::MemoryStorage,
+    subduction::{Subduction, builder::SubductionBuilder},
+};
+use subduction_crypto::signed::Signed;
+use testresult::TestResult;
+
+#[allow(clippy::type_complexity)]
+fn make_subduction() -> (
+    Arc<
+        Subduction<
+            'static,
+            Sendable,
+            MemoryStorage,
+            ChannelMockConnection<SyncMessage>,
+            SyncHandler<
+                Sendable,
+                MemoryStorage,
+                ChannelMockConnection<SyncMessage>,
+                OpenPolicy,
+                CountLeadingZeroBytes,
+            >,
+            OpenPolicy,
+            subduction_crypto::signer::memory::MemorySigner,
+            InstantTimeout,
+            CountLeadingZeroBytes,
+        >,
+    >,
+    impl Future<Output = Result<(), Aborted>>,
+    impl Future<Output = Result<(), Aborted>>,
+) {
+    let (sd, _handler, listener, manager) = SubductionBuilder::new()
+        .signer(test_signer())
+        .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, ChannelMockConnection<SyncMessage>>();
+
+    (sd, listener, manager)
+}
+
+async fn make_test_commit(id: &SedimentreeId, data: &[u8]) -> (Signed<LooseCommit>, Blob) {
+    let blob = Blob::new(data.to_vec());
+    let blob_meta = BlobMeta::new(&blob);
+    let head = CommitId::new({
+        let mut bytes = [0u8; 32];
+        let n = data.len().min(32);
+        bytes[..n].copy_from_slice(&data[..n]);
+        bytes
+    });
+    let commit = LooseCommit::new(*id, head, BTreeSet::new(), blob_meta);
+    let verified = Signed::seal::<Sendable, _>(&test_signer(), commit).await;
+    (verified.into_signed(), blob)
+}
+
+async fn make_test_fragment(id: &SedimentreeId, data: &[u8]) -> (Signed<Fragment>, Blob) {
+    let blob = Blob::new(data.to_vec());
+    let blob_meta = BlobMeta::new(&blob);
+    let head = CommitId::new([data.first().copied().unwrap_or(0); 32]);
+    let fragment = Fragment::new(*id, head, BTreeSet::new(), &[], blob_meta);
+    let verified = Signed::seal::<Sendable, _>(&test_signer(), fragment).await;
+    (verified.into_signed(), blob)
+}
+
+/// `recv_batch_sync_response` must persist `missing_commits` to storage.
+///
+/// Regression test for the putter-cache branch at
+/// `subduction_core/src/subduction/ingest.rs:92`. If the `!` in
+/// `if !putter_cache.contains_key(&author_id)` is removed, the cache is
+/// never populated and the commit is silently dropped.
+#[tokio::test]
+async fn recv_batch_sync_response_persists_missing_commits() -> TestResult {
+    let (sd, listener, manager) = make_subduction();
+    let listener_task = tokio::spawn(listener);
+    let manager_task = tokio::spawn(manager);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let sed_id = SedimentreeId::new([7u8; 32]);
+    let (signed_commit, blob) = make_test_commit(&sed_id, b"recv-batch-commit").await;
+    let from = PeerId::new([42u8; 32]);
+
+    let diff = SyncDiff {
+        missing_commits: vec![(signed_commit, blob)],
+        missing_fragments: Vec::new(),
+        requesting: RequestedData::default(),
+    };
+
+    sd.recv_batch_sync_response(&from, sed_id, diff).await?;
+
+    let stored = sd.get_commits(sed_id).await;
+    assert!(
+        stored.is_some(),
+        "sedimentree should exist after recv_batch_sync_response"
+    );
+    let commits = stored.expect("checked above");
+    assert_eq!(
+        commits.len(),
+        1,
+        "exactly one commit should have been ingested, got {}",
+        commits.len()
+    );
+
+    listener_task.abort();
+    manager_task.abort();
+    Ok(())
+}
+
+/// `recv_batch_sync_response` must persist `missing_fragments` to storage.
+///
+/// Regression test for the putter-cache branch at
+/// `subduction_core/src/subduction/ingest.rs:136`. Symmetric to the
+/// commits test above.
+#[tokio::test]
+async fn recv_batch_sync_response_persists_missing_fragments() -> TestResult {
+    let (sd, listener, manager) = make_subduction();
+    let listener_task = tokio::spawn(listener);
+    let manager_task = tokio::spawn(manager);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let sed_id = SedimentreeId::new([9u8; 32]);
+    let (signed_fragment, blob) = make_test_fragment(&sed_id, b"recv-batch-fragment").await;
+    let from = PeerId::new([42u8; 32]);
+
+    let diff = SyncDiff {
+        missing_commits: Vec::new(),
+        missing_fragments: vec![(signed_fragment, blob)],
+        requesting: RequestedData::default(),
+    };
+
+    sd.recv_batch_sync_response(&from, sed_id, diff).await?;
+
+    // After ingest, `recv_batch_sync_response` re-minimizes the tree. A
+    // single fragment with no covering siblings should still be present.
+    let stored = sd.get_fragments(sed_id).await;
+    assert!(
+        stored.is_some(),
+        "sedimentree should exist after recv_batch_sync_response"
+    );
+    let fragments = stored.expect("checked above");
+    assert_eq!(
+        fragments.len(),
+        1,
+        "exactly one fragment should have been ingested, got {}",
+        fragments.len()
+    );
+
+    listener_task.abort();
+    manager_task.abort();
+    Ok(())
+}
+
+/// Mixed-content diffs must ingest both commits and fragments in one call.
+///
+/// Covers both putter-cache branches simultaneously and the
+/// per-author batching path that flushes via `save_batch`.
+#[tokio::test]
+async fn recv_batch_sync_response_persists_mixed_diff() -> TestResult {
+    let (sd, listener, manager) = make_subduction();
+    let listener_task = tokio::spawn(listener);
+    let manager_task = tokio::spawn(manager);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let sed_id = SedimentreeId::new([11u8; 32]);
+    let (signed_commit, commit_blob) = make_test_commit(&sed_id, b"mixed-commit").await;
+    let (signed_fragment, fragment_blob) = make_test_fragment(&sed_id, b"mixed-fragment").await;
+    let from = PeerId::new([42u8; 32]);
+
+    let diff = SyncDiff {
+        missing_commits: vec![(signed_commit, commit_blob)],
+        missing_fragments: vec![(signed_fragment, fragment_blob)],
+        requesting: RequestedData::default(),
+    };
+
+    sd.recv_batch_sync_response(&from, sed_id, diff).await?;
+
+    let commits = sd
+        .get_commits(sed_id)
+        .await
+        .expect("sedimentree should exist");
+    let fragments = sd
+        .get_fragments(sed_id)
+        .await
+        .expect("sedimentree should exist");
+
+    assert_eq!(commits.len(), 1, "commit should be ingested");
+    assert_eq!(fragments.len(), 1, "fragment should be ingested");
+
+    listener_task.abort();
+    manager_task.abort();
+    Ok(())
+}
+
+/// Empty diffs are no-ops and must not error.
+///
+/// This is the trivial-baseline case; it does not catch the cache
+/// mutants but documents that an empty diff is a valid input.
+#[tokio::test]
+async fn recv_batch_sync_response_empty_diff_is_noop() -> TestResult {
+    let (sd, listener, manager) = make_subduction();
+    let listener_task = tokio::spawn(listener);
+    let manager_task = tokio::spawn(manager);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let sed_id = SedimentreeId::new([13u8; 32]);
+    let from = PeerId::new([42u8; 32]);
+
+    let diff = SyncDiff {
+        missing_commits: Vec::new(),
+        missing_fragments: Vec::new(),
+        requesting: RequestedData::default(),
+    };
+
+    sd.recv_batch_sync_response(&from, sed_id, diff).await?;
+
+    // No data was ingested, so the sedimentree should not be created.
+    assert!(
+        sd.get_commits(sed_id).await.is_none(),
+        "empty diff should not create a sedimentree"
+    );
+
+    listener_task.abort();
+    manager_task.abort();
+    Ok(())
+}

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -307,8 +307,8 @@ impl<T: Schema + EncodeFields + DecodeFields> Signed<T> {
     ///
     /// * `signer` - The signer to use
     /// * `payload` - The payload to sign
-    pub async fn seal<K: future_form::FutureForm, S: Signer<K>>(
-        signer: &S,
+    pub async fn seal<Async: future_form::FutureForm, Sign: Signer<Async>>(
+        signer: &Sign,
         payload: T,
     ) -> VerifiedSignature<T> {
         let issuer = signer.verifying_key();

--- a/subduction_crypto/src/signer.rs
+++ b/subduction_crypto/src/signer.rs
@@ -26,9 +26,9 @@ use future_form::FutureForm;
 /// ```ignore
 /// Signed::seal::<Sendable, _>(&signer, payload).await
 /// ```
-pub trait Signer<K: FutureForm> {
+pub trait Signer<Async: FutureForm> {
     /// Sign the given message bytes.
-    fn sign(&self, message: &[u8]) -> K::Future<'_, Signature>;
+    fn sign(&self, message: &[u8]) -> Async::Future<'_, Signature>;
 
     /// Get the verifying (public) key corresponding to this signer.
     fn verifying_key(&self) -> VerifyingKey;

--- a/subduction_crypto/src/signer/memory.rs
+++ b/subduction_crypto/src/signer/memory.rs
@@ -45,11 +45,11 @@ impl MemorySigner {
 }
 
 #[future_form(Sendable, Local)]
-impl<K: FutureForm> Signer<K> for MemorySigner {
-    fn sign(&self, message: &[u8]) -> K::Future<'_, Signature> {
+impl<Async: FutureForm> Signer<Async> for MemorySigner {
+    fn sign(&self, message: &[u8]) -> Async::Future<'_, Signature> {
         use ed25519_dalek::Signer as _;
         let signature = self.signing_key.sign(message);
-        K::from_future(async move { signature })
+        Async::from_future(async move { signature })
     }
 
     fn verifying_key(&self) -> VerifyingKey {

--- a/subduction_crypto/src/verified_meta.rs
+++ b/subduction_crypto/src/verified_meta.rs
@@ -138,14 +138,14 @@ impl<T: HasBlobMeta + Schema + EncodeFields + DecodeFields> VerifiedMeta<T> {
     ///     verified_blob,
     /// ).await;
     /// ```
-    pub async fn seal<K: FutureForm, S: Signer<K>>(
-        signer: &S,
+    pub async fn seal<Async: FutureForm, Sign: Signer<Async>>(
+        signer: &Sign,
         args: T::Args,
         verified_blob: VerifiedBlobMeta,
     ) -> Self {
         let (blob_meta, blob) = verified_blob.into_parts();
         let meta = T::from_args(args, blob_meta);
-        let verified = Signed::seal::<K, _>(signer, meta).await;
+        let verified = Signed::seal::<Async, _>(signer, meta).await;
         Self { verified, blob }
     }
 

--- a/subduction_ephemeral/src/composed.rs
+++ b/subduction_ephemeral/src/composed.rs
@@ -124,7 +124,8 @@ pub enum ComposedHandlerError<S: core::error::Error, E: core::error::Error> {
 /// types that are independent of the message generic `M`, so
 /// `ListenError<Async,Store,Conn,SyncMessage>` can be retyped to
 /// `ListenError<Async,Store,Conn,WireMsg>` without loss of information.
-impl<Async, Store, Conn, WireMsg, EphErr> From<ComposedHandlerError<ListenError<Async, Store, Conn, SyncMessage>, EphErr>>
+impl<Async, Store, Conn, WireMsg, EphErr>
+    From<ComposedHandlerError<ListenError<Async, Store, Conn, SyncMessage>, EphErr>>
     for ListenError<Async, Store, Conn, WireMsg>
 where
     Async: FutureForm + Debug,
@@ -132,13 +133,17 @@ where
     Conn: Connection<Async, SyncMessage> + Connection<Async, WireMsg> + Debug,
     WireMsg: Encode + Decode,
     Store::Error: Debug,
-    <Conn as Connection<Async, SyncMessage>>::SendError: Debug + Into<<Conn as Connection<Async, WireMsg>>::SendError>,
-    <Conn as Connection<Async, SyncMessage>>::RecvError: Debug + Into<<Conn as Connection<Async, WireMsg>>::RecvError>,
+    <Conn as Connection<Async, SyncMessage>>::SendError:
+        Debug + Into<<Conn as Connection<Async, WireMsg>>::SendError>,
+    <Conn as Connection<Async, SyncMessage>>::RecvError:
+        Debug + Into<<Conn as Connection<Async, WireMsg>>::RecvError>,
     <Conn as Connection<Async, WireMsg>>::SendError: Debug,
     <Conn as Connection<Async, WireMsg>>::RecvError: Debug,
     EphErr: core::error::Error,
 {
-    fn from(err: ComposedHandlerError<ListenError<Async, Store, Conn, SyncMessage>, EphErr>) -> Self {
+    fn from(
+        err: ComposedHandlerError<ListenError<Async, Store, Conn, SyncMessage>, EphErr>,
+    ) -> Self {
         match err {
             ComposedHandlerError::Sync(listen_err) => match listen_err {
                 ListenError::IoError(io_err) => ListenError::IoError(match io_err {

--- a/subduction_ephemeral/src/composed.rs
+++ b/subduction_ephemeral/src/composed.rs
@@ -122,23 +122,23 @@ pub enum ComposedHandlerError<S: core::error::Error, E: core::error::Error> {
 ///
 /// This works because [`MessageTransport`]-based connections have error
 /// types that are independent of the message generic `M`, so
-/// `ListenError<F,S,C,SyncMessage>` can be retyped to
-/// `ListenError<F,S,C,W>` without loss of information.
-impl<F, S, C, W, EphErr> From<ComposedHandlerError<ListenError<F, S, C, SyncMessage>, EphErr>>
-    for ListenError<F, S, C, W>
+/// `ListenError<Async,Store,Conn,SyncMessage>` can be retyped to
+/// `ListenError<Async,Store,Conn,WireMsg>` without loss of information.
+impl<Async, Store, Conn, WireMsg, EphErr> From<ComposedHandlerError<ListenError<Async, Store, Conn, SyncMessage>, EphErr>>
+    for ListenError<Async, Store, Conn, WireMsg>
 where
-    F: FutureForm + Debug,
-    S: Storage<F> + Debug,
-    C: Connection<F, SyncMessage> + Connection<F, W> + Debug,
-    W: Encode + Decode,
-    S::Error: Debug,
-    <C as Connection<F, SyncMessage>>::SendError: Debug + Into<<C as Connection<F, W>>::SendError>,
-    <C as Connection<F, SyncMessage>>::RecvError: Debug + Into<<C as Connection<F, W>>::RecvError>,
-    <C as Connection<F, W>>::SendError: Debug,
-    <C as Connection<F, W>>::RecvError: Debug,
+    Async: FutureForm + Debug,
+    Store: Storage<Async> + Debug,
+    Conn: Connection<Async, SyncMessage> + Connection<Async, WireMsg> + Debug,
+    WireMsg: Encode + Decode,
+    Store::Error: Debug,
+    <Conn as Connection<Async, SyncMessage>>::SendError: Debug + Into<<Conn as Connection<Async, WireMsg>>::SendError>,
+    <Conn as Connection<Async, SyncMessage>>::RecvError: Debug + Into<<Conn as Connection<Async, WireMsg>>::RecvError>,
+    <Conn as Connection<Async, WireMsg>>::SendError: Debug,
+    <Conn as Connection<Async, WireMsg>>::RecvError: Debug,
     EphErr: core::error::Error,
 {
-    fn from(err: ComposedHandlerError<ListenError<F, S, C, SyncMessage>, EphErr>) -> Self {
+    fn from(err: ComposedHandlerError<ListenError<Async, Store, Conn, SyncMessage>, EphErr>) -> Self {
         match err {
             ComposedHandlerError::Sync(listen_err) => match listen_err {
                 ListenError::IoError(io_err) => ListenError::IoError(match io_err {

--- a/subduction_ephemeral/src/handler.rs
+++ b/subduction_ephemeral/src/handler.rs
@@ -47,7 +47,12 @@ use crate::{
 /// Construct via [`new()`](Self::new), which returns both the handler
 /// and a receiver for inbound [`EphemeralEvent`]s.
 #[allow(clippy::type_complexity)]
-pub struct EphemeralHandler<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock> {
+pub struct EphemeralHandler<
+    Async: FutureForm,
+    Conn: Clone + 'static,
+    E: EphemeralPolicy<Async>,
+    Clk: Clock,
+> {
     /// Inbound subscriptions: which peers are subscribed to receive ephemeral messages from us.
     ephemeral_subscriptions: Arc<Mutex<Map<Topic, Set<PeerId>>>>,
     /// Outbound subscriptions: sedimentree IDs we want to receive ephemeral messages for.
@@ -79,8 +84,8 @@ impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async> + Clone
     }
 }
 
-impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock> core::fmt::Debug
-    for EphemeralHandler<Async, Conn, E, Clk>
+impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock>
+    core::fmt::Debug for EphemeralHandler<Async, Conn, E, Clk>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("EphemeralHandler").finish_non_exhaustive()
@@ -366,7 +371,9 @@ pub enum EphemeralHandlerError<SendErr: core::error::Error> {
         E: EphemeralPolicy<Local>,
         Clk: Clock
 )]
-impl<Async: FutureForm, Conn, E, Clk> Handler<Async, Conn> for EphemeralHandler<Async, Conn, E, Clk> {
+impl<Async: FutureForm, Conn, E, Clk> Handler<Async, Conn>
+    for EphemeralHandler<Async, Conn, E, Clk>
+{
     type Message = EphemeralMessage;
     type HandlerError = EphemeralHandlerError<Conn::SendError>;
 

--- a/subduction_ephemeral/src/handler.rs
+++ b/subduction_ephemeral/src/handler.rs
@@ -47,12 +47,12 @@ use crate::{
 /// Construct via [`new()`](Self::new), which returns both the handler
 /// and a receiver for inbound [`EphemeralEvent`]s.
 #[allow(clippy::type_complexity)]
-pub struct EphemeralHandler<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock> {
+pub struct EphemeralHandler<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock> {
     /// Inbound subscriptions: which peers are subscribed to receive ephemeral messages from us.
     ephemeral_subscriptions: Arc<Mutex<Map<Topic, Set<PeerId>>>>,
     /// Outbound subscriptions: sedimentree IDs we want to receive ephemeral messages for.
     outgoing_subscriptions: Arc<Mutex<Set<Topic>>>,
-    connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>>,
+    connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
     policy: E,
     callback_tx: Sender<EphemeralEvent>,
     max_payload_size: usize,
@@ -61,8 +61,8 @@ pub struct EphemeralHandler<F: FutureForm, C: Clone + 'static, E: EphemeralPolic
     nonce_cache: Arc<Mutex<EphemeralNonceCache>>,
 }
 
-impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F> + Clone, Clk: Clock> Clone
-    for EphemeralHandler<F, C, E, Clk>
+impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async> + Clone, Clk: Clock> Clone
+    for EphemeralHandler<Async, Conn, E, Clk>
 {
     fn clone(&self) -> Self {
         Self {
@@ -79,16 +79,16 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F> + Clone, Clk: Cloc
     }
 }
 
-impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock> core::fmt::Debug
-    for EphemeralHandler<F, C, E, Clk>
+impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock> core::fmt::Debug
+    for EphemeralHandler<Async, Conn, E, Clk>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("EphemeralHandler").finish_non_exhaustive()
     }
 }
 
-impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
-    EphemeralHandler<F, C, E, Clk>
+impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock>
+    EphemeralHandler<Async, Conn, E, Clk>
 {
     /// Create a new ephemeral handler.
     ///
@@ -96,7 +96,7 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
     /// The `connections` map is shared with `Subduction` / `SyncHandler`.
     #[allow(clippy::type_complexity)]
     pub fn new(
-        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<C, F>>>>>,
+        connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         policy: E,
         config: EphemeralConfig,
         clock: Clk,
@@ -137,7 +137,7 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
     /// fire-and-forget semantics.
     pub async fn publish(&self, msg: EphemeralMessage)
     where
-        C: Connection<F, EphemeralMessage>,
+        Conn: Connection<Async, EphemeralMessage>,
     {
         let EphemeralMessage::Ephemeral(ref signed) = msg else {
             warn!("publish called with non-Ephemeral message, ignoring");
@@ -217,7 +217,7 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
 
         // Collect target connections while holding the lock, then drop it
         // before awaiting sends to avoid holding the mutex across .await.
-        let targets: Vec<Authenticated<C, F>> = {
+        let targets: Vec<Authenticated<Conn, Async>> = {
             let conns = self.connections.lock().await;
             authorized_peers
                 .iter()
@@ -248,7 +248,7 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
     /// also receive the subscription request.
     pub async fn subscribe(&self, topics: NonEmpty<Topic>)
     where
-        C: Connection<F, EphemeralMessage>,
+        Conn: Connection<Async, EphemeralMessage>,
     {
         {
             let mut outgoing = self.outgoing_subscriptions.lock().await;
@@ -267,7 +267,7 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
     /// from outgoing subscription tracking.
     pub async fn unsubscribe(&self, topics: NonEmpty<Topic>)
     where
-        C: Connection<F, EphemeralMessage>,
+        Conn: Connection<Async, EphemeralMessage>,
     {
         {
             let mut outgoing = self.outgoing_subscriptions.lock().await;
@@ -286,7 +286,7 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
     /// ephemeral messages for our subscribed topics.
     pub async fn subscribe_peer(&self, peer_id: PeerId)
     where
-        C: Connection<F, EphemeralMessage>,
+        Conn: Connection<Async, EphemeralMessage>,
     {
         let topics: NonEmpty<Topic> = {
             let outgoing = self.outgoing_subscriptions.lock().await;
@@ -299,7 +299,7 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
 
         let msg = EphemeralMessage::Subscribe { topics };
 
-        let targets: Vec<Authenticated<C, F>> = {
+        let targets: Vec<Authenticated<Conn, Async>> = {
             let conns = self.connections.lock().await;
             conns
                 .get(&peer_id)
@@ -321,9 +321,9 @@ impl<F: FutureForm, C: Clone + 'static, E: EphemeralPolicy<F>, Clk: Clock>
 
     async fn send_to_all_peers(&self, msg: &EphemeralMessage)
     where
-        C: Connection<F, EphemeralMessage>,
+        Conn: Connection<Async, EphemeralMessage>,
     {
-        let targets: Vec<Authenticated<C, F>> = {
+        let targets: Vec<Authenticated<Conn, Async>> = {
             let conns = self.connections.lock().await;
             conns
                 .values()
@@ -353,33 +353,33 @@ pub enum EphemeralHandlerError<SendErr: core::error::Error> {
 
 #[future_form::future_form(
     Sendable where
-        C: Connection<Sendable, EphemeralMessage>
+        Conn: Connection<Sendable, EphemeralMessage>
             + Clone + Send + Sync + 'static,
         E: EphemeralPolicy<Sendable> + Send + Sync,
         E::SubscribeDisallowed: Send + 'static,
         E::PublishDisallowed: Send + 'static,
-        C::SendError: Send + 'static,
+        Conn::SendError: Send + 'static,
         Clk: Clock + Send + Sync,
     Local where
-        C: Connection<Local, EphemeralMessage>
+        Conn: Connection<Local, EphemeralMessage>
             + Clone + 'static,
         E: EphemeralPolicy<Local>,
         Clk: Clock
 )]
-impl<K: FutureForm, C, E, Clk> Handler<K, C> for EphemeralHandler<K, C, E, Clk> {
+impl<Async: FutureForm, Conn, E, Clk> Handler<Async, Conn> for EphemeralHandler<Async, Conn, E, Clk> {
     type Message = EphemeralMessage;
-    type HandlerError = EphemeralHandlerError<C::SendError>;
+    type HandlerError = EphemeralHandlerError<Conn::SendError>;
 
     fn handle<'a>(
         &'a self,
-        conn: &'a Authenticated<C, K>,
+        conn: &'a Authenticated<Conn, Async>,
         message: EphemeralMessage,
-    ) -> K::Future<'a, Result<(), Self::HandlerError>> {
-        K::from_future(async move { self.dispatch(conn, message).await })
+    ) -> Async::Future<'a, Result<(), Self::HandlerError>> {
+        Async::from_future(async move { self.dispatch(conn, message).await })
     }
 
-    fn on_peer_disconnect(&self, peer: PeerId) -> K::Future<'_, ()> {
-        K::from_future(async move {
+    fn on_peer_disconnect(&self, peer: PeerId) -> Async::Future<'_, ()> {
+        Async::from_future(async move {
             let mut subs = self.ephemeral_subscriptions.lock().await;
             subs.retain(|_id, peers| {
                 peers.remove(&peer);
@@ -394,17 +394,17 @@ impl<K: FutureForm, C, E, Clk> Handler<K, C> for EphemeralHandler<K, C, E, Clk> 
 }
 
 impl<
-    F: FutureForm,
-    C: Connection<F, EphemeralMessage> + Clone + 'static,
-    E: EphemeralPolicy<F>,
+    Async: FutureForm,
+    Conn: Connection<Async, EphemeralMessage> + Clone + 'static,
+    E: EphemeralPolicy<Async>,
     Clk: Clock,
-> EphemeralHandler<F, C, E, Clk>
+> EphemeralHandler<Async, Conn, E, Clk>
 {
     async fn dispatch(
         &self,
-        conn: &Authenticated<C, F>,
+        conn: &Authenticated<Conn, Async>,
         message: EphemeralMessage,
-    ) -> Result<(), EphemeralHandlerError<C::SendError>> {
+    ) -> Result<(), EphemeralHandlerError<Conn::SendError>> {
         match message {
             EphemeralMessage::Ephemeral { .. } => {
                 self.recv_ephemeral(conn, message).await;
@@ -437,7 +437,7 @@ impl<
     ///
     /// [`design/ephemeral.md`]: https://github.com/inkandswitch/subduction/blob/main/design/ephemeral.md#recv-ephemeralhandlerrecv_ephemeral
     #[allow(clippy::too_many_lines)]
-    async fn recv_ephemeral(&self, conn: &Authenticated<C, F>, message: EphemeralMessage) {
+    async fn recv_ephemeral(&self, conn: &Authenticated<Conn, Async>, message: EphemeralMessage) {
         let EphemeralMessage::Ephemeral(ref signed) = message else {
             return;
         };
@@ -602,7 +602,7 @@ impl<
 
         // Collect target connections while holding the lock, then drop it
         // before awaiting sends to avoid holding the mutex across .await.
-        let targets: Vec<Authenticated<C, F>> = {
+        let targets: Vec<Authenticated<Conn, Async>> = {
             let conns = self.connections.lock().await;
             authorized_peers
                 .iter()
@@ -631,7 +631,7 @@ impl<
     ///
     /// Policy checks are batched first (no lock held), then all
     /// authorized topics are inserted under a single lock acquisition.
-    async fn recv_subscribe(&self, conn: &Authenticated<C, F>, topics: NonEmpty<Topic>) {
+    async fn recv_subscribe(&self, conn: &Authenticated<Conn, Async>, topics: NonEmpty<Topic>) {
         let peer = conn.peer_id();
         let mut authorized = Vec::new();
         let mut rejected = Vec::new();
@@ -672,7 +672,7 @@ impl<
     }
 
     /// Handle an unsubscribe request from a peer.
-    async fn recv_unsubscribe(&self, conn: &Authenticated<C, F>, topics: NonEmpty<Topic>) {
+    async fn recv_unsubscribe(&self, conn: &Authenticated<Conn, Async>, topics: NonEmpty<Topic>) {
         let peer = conn.peer_id();
         let mut subs = self.ephemeral_subscriptions.lock().await;
 

--- a/subduction_ephemeral/src/policy.rs
+++ b/subduction_ephemeral/src/policy.rs
@@ -43,7 +43,7 @@ use crate::topic::Topic;
 ///
 /// `authorize_subscribe` is checked at subscribe time (courtesy) and
 /// re-checked at forward time (security invariant — handles revocation).
-pub trait EphemeralPolicy<K: FutureForm + ?Sized> {
+pub trait EphemeralPolicy<Async: FutureForm + ?Sized> {
     /// Error returned when a subscribe is disallowed.
     type SubscribeDisallowed: core::error::Error;
 
@@ -55,14 +55,14 @@ pub trait EphemeralPolicy<K: FutureForm + ?Sized> {
         &self,
         peer: PeerId,
         id: Topic,
-    ) -> K::Future<'_, Result<(), Self::SubscribeDisallowed>>;
+    ) -> Async::Future<'_, Result<(), Self::SubscribeDisallowed>>;
 
     /// Check whether `peer` may publish ephemeral messages to `id`.
     fn authorize_publish(
         &self,
         peer: PeerId,
         id: Topic,
-    ) -> K::Future<'_, Result<(), Self::PublishDisallowed>>;
+    ) -> Async::Future<'_, Result<(), Self::PublishDisallowed>>;
 
     /// Batch-filter subscribers to only those currently authorized.
     ///
@@ -71,7 +71,7 @@ pub trait EphemeralPolicy<K: FutureForm + ?Sized> {
         &self,
         id: Topic,
         peers: Vec<PeerId>,
-    ) -> K::Future<'_, Vec<PeerId>>;
+    ) -> Async::Future<'_, Vec<PeerId>>;
 }
 
 /// An open policy that allows all ephemeral operations.
@@ -82,7 +82,7 @@ pub trait EphemeralPolicy<K: FutureForm + ?Sized> {
 pub struct OpenEphemeralPolicy;
 
 #[future_form(Sendable, Local)]
-impl<K: FutureForm> EphemeralPolicy<K> for OpenEphemeralPolicy {
+impl<Async: FutureForm> EphemeralPolicy<Async> for OpenEphemeralPolicy {
     type SubscribeDisallowed = Infallible;
     type PublishDisallowed = Infallible;
 
@@ -90,23 +90,23 @@ impl<K: FutureForm> EphemeralPolicy<K> for OpenEphemeralPolicy {
         &self,
         _peer: PeerId,
         _id: Topic,
-    ) -> K::Future<'_, Result<(), Self::SubscribeDisallowed>> {
-        K::from_future(async { Ok(()) })
+    ) -> Async::Future<'_, Result<(), Self::SubscribeDisallowed>> {
+        Async::from_future(async { Ok(()) })
     }
 
     fn authorize_publish(
         &self,
         _peer: PeerId,
         _id: Topic,
-    ) -> K::Future<'_, Result<(), Self::PublishDisallowed>> {
-        K::from_future(async { Ok(()) })
+    ) -> Async::Future<'_, Result<(), Self::PublishDisallowed>> {
+        Async::from_future(async { Ok(()) })
     }
 
     fn filter_authorized_subscribers(
         &self,
         _id: Topic,
         peers: Vec<PeerId>,
-    ) -> K::Future<'_, Vec<PeerId>> {
-        K::from_future(async { peers })
+    ) -> Async::Future<'_, Vec<PeerId>> {
+        Async::from_future(async { peers })
     }
 }

--- a/subduction_http_longpoll/src/client.rs
+++ b/subduction_http_longpoll/src/client.rs
@@ -186,7 +186,8 @@ impl<Async: FutureForm, Sign: Signer<Async>, H: HttpClient<Async> + 'static> Con
             let send_conn = conn;
 
             let send_task = Async::from_future(async move {
-                send_loop::<Async, H>(send_http, send_url, session_id, send_conn, send_cancel_rx).await;
+                send_loop::<Async, H>(send_http, send_url, session_id, send_conn, send_cancel_rx)
+                    .await;
             });
 
             Ok(ConnectResult {
@@ -379,7 +380,9 @@ struct ClientHttpHandshake<Async: FutureForm, H: HttpClient<Async>> {
 }
 
 #[future_form(Sendable where H: Send, Local)]
-impl<Async: FutureForm, H: HttpClient<Async>> handshake::Handshake<Async> for &mut ClientHttpHandshake<Async, H> {
+impl<Async: FutureForm, H: HttpClient<Async>> handshake::Handshake<Async>
+    for &mut ClientHttpHandshake<Async, H>
+{
     type Error = ClientError;
 
     fn send(&mut self, bytes: Vec<u8>) -> Async::Future<'_, Result<(), Self::Error>> {

--- a/subduction_http_longpoll/src/client.rs
+++ b/subduction_http_longpoll/src/client.rs
@@ -45,21 +45,21 @@ use crate::{
 
 /// Result of a successful connection, containing the authenticated connection
 /// and background task futures that the caller must spawn.
-pub struct ConnectResult<K: FutureForm> {
+pub struct ConnectResult<Async: FutureForm> {
     /// The authenticated connection, ready for registration with Subduction.
-    pub authenticated: subduction_core::authenticated::Authenticated<HttpLongPollTransport, K>,
+    pub authenticated: subduction_core::authenticated::Authenticated<HttpLongPollTransport, Async>,
 
     /// The session ID assigned by the server.
     pub session_id: SessionId,
 
     /// Background recv-polling task. Must be spawned to drive inbound messages.
-    pub poll_task: K::Future<'static, ()>,
+    pub poll_task: Async::Future<'static, ()>,
 
     /// Background send task. Must be spawned to drive outbound messages.
-    pub send_task: K::Future<'static, ()>,
+    pub send_task: Async::Future<'static, ()>,
 }
 
-impl<K: FutureForm> core::fmt::Debug for ConnectResult<K> {
+impl<Async: FutureForm> core::fmt::Debug for ConnectResult<Async> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ConnectResult")
             .field("session_id", &self.session_id)
@@ -107,7 +107,7 @@ impl<H> HttpLongPollClient<H> {
 ///
 /// Prefer the convenience methods [`HttpLongPollClient::connect`] and
 /// [`HttpLongPollClient::connect_discover`] over calling this trait directly.
-pub trait Connect<K: FutureForm, Sig: Signer<K>> {
+pub trait Connect<Async: FutureForm, Sign: Signer<Async>> {
     /// Connect with a specific [`Audience`] (known peer ID or service discovery).
     ///
     /// # Errors
@@ -116,29 +116,29 @@ pub trait Connect<K: FutureForm, Sig: Signer<K>> {
     #[allow(clippy::type_complexity)]
     fn connect_with_audience<'a>(
         &'a self,
-        signer: &'a Sig,
+        signer: &'a Sign,
         audience: Audience,
         now: TimestampSeconds,
-    ) -> K::Future<'a, Result<ConnectResult<K>, ClientError>>;
+    ) -> Async::Future<'a, Result<ConnectResult<Async>, ClientError>>;
 }
 
-#[future_form(Sendable where H: Send + Sync, Sig: Sync, H::Error: Send, Local)]
-impl<K: FutureForm, Sig: Signer<K>, H: HttpClient<K> + 'static> Connect<K, Sig>
+#[future_form(Sendable where H: Send + Sync, Sign: Sync, H::Error: Send, Local)]
+impl<Async: FutureForm, Sign: Signer<Async>, H: HttpClient<Async> + 'static> Connect<Async, Sign>
     for HttpLongPollClient<H>
 {
     fn connect_with_audience<'a>(
         &'a self,
-        signer: &'a Sig,
+        signer: &'a Sign,
         audience: Audience,
         now: TimestampSeconds,
-    ) -> K::Future<'a, Result<ConnectResult<K>, ClientError>> {
+    ) -> Async::Future<'a, Result<ConnectResult<Async>, ClientError>> {
         let http = self.http.clone();
         let base_url = self.base_url.clone();
 
-        K::from_future(async move {
+        Async::from_future(async move {
             let nonce = Nonce::random();
 
-            let mut client_handshake = ClientHttpHandshake::<K, H> {
+            let mut client_handshake = ClientHttpHandshake::<Async, H> {
                 http: http.clone(),
                 base_url: base_url.clone(),
                 session_id: None,
@@ -147,7 +147,7 @@ impl<K: FutureForm, Sig: Signer<K>, H: HttpClient<K> + 'static> Connect<K, Sig>
             };
 
             #[allow(clippy::expect_used)]
-            let (authenticated, session_id) = handshake::initiate::<K, _, _, _, _>(
+            let (authenticated, session_id) = handshake::initiate::<Async, _, _, _, _>(
                 &mut client_handshake,
                 |handshake, peer_id| {
                     let session_id = handshake
@@ -177,16 +177,16 @@ impl<K: FutureForm, Sig: Signer<K>, H: HttpClient<K> + 'static> Connect<K, Sig>
             let poll_http = http.clone();
             let poll_conn = conn.clone();
 
-            let poll_task = K::from_future(async move {
-                poll_loop::<K, H>(poll_http, poll_url, session_id, poll_conn, cancel_rx).await;
+            let poll_task = Async::from_future(async move {
+                poll_loop::<Async, H>(poll_http, poll_url, session_id, poll_conn, cancel_rx).await;
             });
 
             let send_url = format!("{base_url}/lp/send");
             let send_http = http;
             let send_conn = conn;
 
-            let send_task = K::from_future(async move {
-                send_loop::<K, H>(send_http, send_url, session_id, send_conn, send_cancel_rx).await;
+            let send_task = Async::from_future(async move {
+                send_loop::<Async, H>(send_http, send_url, session_id, send_conn, send_cancel_rx).await;
             });
 
             Ok(ConnectResult {
@@ -202,23 +202,23 @@ impl<K: FutureForm, Sig: Signer<K>, H: HttpClient<K> + 'static> Connect<K, Sig>
 impl<H> HttpLongPollClient<H> {
     /// Connect to the server with a known peer ID.
     ///
-    /// The [`FutureForm`] variant `K` is inferred from the HTTP client `H`:
+    /// The [`FutureForm`] variant `Async` is inferred from the HTTP client `H`:
     /// [`Sendable`](future_form::Sendable) for native clients,
     /// [`Local`](future_form::Local) for browser `fetch()`.
     ///
     /// # Errors
     ///
     /// Returns [`ClientError`] if the handshake or connection setup fails.
-    pub fn connect<'a, K: FutureForm, Sig: Signer<K>>(
+    pub fn connect<'a, Async: FutureForm, Sign: Signer<Async>>(
         &'a self,
-        signer: &'a Sig,
+        signer: &'a Sign,
         expected_peer_id: PeerId,
         now: TimestampSeconds,
-    ) -> K::Future<'a, Result<ConnectResult<K>, ClientError>>
+    ) -> Async::Future<'a, Result<ConnectResult<Async>, ClientError>>
     where
-        Self: Connect<K, Sig>,
+        Self: Connect<Async, Sign>,
     {
-        Connect::<K, Sig>::connect_with_audience(
+        Connect::<Async, Sign>::connect_with_audience(
             self,
             signer,
             Audience::known(expected_peer_id),
@@ -228,23 +228,23 @@ impl<H> HttpLongPollClient<H> {
 
     /// Connect to the server using service discovery.
     ///
-    /// The [`FutureForm`] variant `K` is inferred from the HTTP client `H`:
+    /// The [`FutureForm`] variant `Async` is inferred from the HTTP client `H`:
     /// [`Sendable`](future_form::Sendable) for native clients,
     /// [`Local`](future_form::Local) for browser `fetch()`.
     ///
     /// # Errors
     ///
     /// Returns [`ClientError`] if the handshake or connection setup fails.
-    pub fn connect_discover<'a, K: FutureForm, Sig: Signer<K>>(
+    pub fn connect_discover<'a, Async: FutureForm, Sign: Signer<Async>>(
         &'a self,
-        signer: &'a Sig,
+        signer: &'a Sign,
         service_name: &str,
         now: TimestampSeconds,
-    ) -> K::Future<'a, Result<ConnectResult<K>, ClientError>>
+    ) -> Async::Future<'a, Result<ConnectResult<Async>, ClientError>>
     where
-        Self: Connect<K, Sig>,
+        Self: Connect<Async, Sign>,
     {
-        Connect::<K, Sig>::connect_with_audience(
+        Connect::<Async, Sign>::connect_with_audience(
             self,
             signer,
             Audience::discover(service_name.as_bytes()),
@@ -259,7 +259,7 @@ impl<H> HttpLongPollClient<H> {
 
 /// Background task that continuously polls `POST /lp/recv` and pushes
 /// raw bytes into the connection's inbound channel.
-async fn poll_loop<K: FutureForm, H: HttpClient<K>>(
+async fn poll_loop<Async: FutureForm, H: HttpClient<Async>>(
     http: H,
     url: String,
     session_id: SessionId,
@@ -312,7 +312,7 @@ async fn poll_loop<K: FutureForm, H: HttpClient<K>>(
 
 /// Background task that drains the connection's outbound channel and sends
 /// each message via `POST /lp/send`.
-async fn send_loop<K: FutureForm, H: HttpClient<K>>(
+async fn send_loop<Async: FutureForm, H: HttpClient<Async>>(
     http: H,
     url: String,
     session_id: SessionId,
@@ -370,23 +370,23 @@ async fn send_loop<K: FutureForm, H: HttpClient<K>>(
 /// 2. `recv()` — returns the response bytes captured during `send()`
 ///
 /// This maps the streaming `Handshake` interface to a single HTTP round-trip.
-struct ClientHttpHandshake<K: FutureForm, H: HttpClient<K>> {
+struct ClientHttpHandshake<Async: FutureForm, H: HttpClient<Async>> {
     http: H,
     base_url: String,
     session_id: Option<SessionId>,
     response_bytes: Option<Vec<u8>>,
-    _k: core::marker::PhantomData<K>,
+    _k: core::marker::PhantomData<Async>,
 }
 
 #[future_form(Sendable where H: Send, Local)]
-impl<K: FutureForm, H: HttpClient<K>> handshake::Handshake<K> for &mut ClientHttpHandshake<K, H> {
+impl<Async: FutureForm, H: HttpClient<Async>> handshake::Handshake<Async> for &mut ClientHttpHandshake<Async, H> {
     type Error = ClientError;
 
-    fn send(&mut self, bytes: Vec<u8>) -> K::Future<'_, Result<(), Self::Error>> {
+    fn send(&mut self, bytes: Vec<u8>) -> Async::Future<'_, Result<(), Self::Error>> {
         let url = format!("{}/lp/handshake", self.base_url);
         let http = self.http.clone();
 
-        K::from_future(async move {
+        Async::from_future(async move {
             let resp = http
                 .post(&url, &[("content-type", "application/octet-stream")], bytes)
                 .await
@@ -419,9 +419,9 @@ impl<K: FutureForm, H: HttpClient<K>> handshake::Handshake<K> for &mut ClientHtt
         })
     }
 
-    fn recv(&mut self) -> K::Future<'_, Result<Vec<u8>, Self::Error>> {
+    fn recv(&mut self) -> Async::Future<'_, Result<Vec<u8>, Self::Error>> {
         let bytes = self.response_bytes.take();
-        K::from_future(async move {
+        Async::from_future(async move {
             bytes.ok_or_else(|| {
                 ClientError::HandshakeDecode(
                     "no response bytes available (send not called?)".into(),

--- a/subduction_http_longpoll/src/http_client.rs
+++ b/subduction_http_longpoll/src/http_client.rs
@@ -16,7 +16,7 @@ pub mod reqwest_client;
 /// Implementations should handle the mechanics of making HTTP requests
 /// (TLS, connection pooling, etc.) while this trait exposes only what
 /// the long-poll transport needs.
-pub trait HttpClient<K: FutureForm>: Clone {
+pub trait HttpClient<Async: FutureForm>: Clone {
     /// The error type for HTTP operations.
     type Error: core::error::Error + 'static;
 
@@ -26,7 +26,7 @@ pub trait HttpClient<K: FutureForm>: Clone {
         url: &str,
         headers: &[(&str, &str)],
         body: Vec<u8>,
-    ) -> K::Future<'_, Result<HttpResponse, Self::Error>>;
+    ) -> Async::Future<'_, Result<HttpResponse, Self::Error>>;
 }
 
 /// A minimal HTTP response.

--- a/subduction_http_longpoll/src/session.rs
+++ b/subduction_http_longpoll/src/session.rs
@@ -15,7 +15,7 @@ use subduction_core::{authenticated::Authenticated, peer::id::PeerId};
 use crate::transport::HttpLongPollTransport;
 
 // NOTE: SessionStore and SessionEntry are concrete on `Sendable` (not generic
-// over `K: FutureForm`) because `HttpLongPollTransport<O>` only implements
+// over `Async: FutureForm`) because `HttpLongPollTransport<O>` only implements
 // `Connection<Sendable>`. This mirrors the `subduction_websocket` pattern.
 
 /// An opaque session identifier, assigned after successful handshake.

--- a/subduction_http_longpoll/src/session.rs
+++ b/subduction_http_longpoll/src/session.rs
@@ -15,8 +15,13 @@ use subduction_core::{authenticated::Authenticated, peer::id::PeerId};
 use crate::transport::HttpLongPollTransport;
 
 // NOTE: SessionStore and SessionEntry are concrete on `Sendable` (not generic
-// over `Async: FutureForm`) because `HttpLongPollTransport<O>` only implements
-// `Connection<Sendable>`. This mirrors the `subduction_websocket` pattern.
+// over `Async: FutureForm`) because they are exclusively used by the
+// multi-threaded HTTP server, which requires `Send + Sync` state. The
+// underlying `HttpLongPollTransport` itself is FutureForm-generic and
+// implements `Transport<Async>` for both `Sendable` and `Local`; the
+// `Sendable` choice here lives on `SessionEntry::authenticated:
+// Option<Authenticated<HttpLongPollTransport, Sendable>>`. This mirrors the
+// `subduction_websocket` pattern.
 
 /// An opaque session identifier, assigned after successful handshake.
 ///

--- a/subduction_http_longpoll/src/transport.rs
+++ b/subduction_http_longpoll/src/transport.rs
@@ -1,4 +1,4 @@
-//! HTTP long-poll connection implementing [`Transport<K>`].
+//! HTTP long-poll connection implementing [`Transport<Async>`].
 //!
 //! Unlike the WebSocket transport, there are no background listener/sender
 //! tasks. Instead, the HTTP server's request handlers directly push to and
@@ -49,7 +49,7 @@ struct Inner {
     cancel_guard: Mutex<Option<async_channel::Sender<()>>>,
 }
 
-/// An HTTP long-poll connection that implements [`Transport<K>`].
+/// An HTTP long-poll connection that implements [`Transport<Async>`].
 ///
 /// Created during handshake and stored in the [`SessionStore`](crate::session::SessionStore).
 /// The server's HTTP handlers interact with this connection's channels to
@@ -135,21 +135,21 @@ impl HttpLongPollTransport {
 }
 
 #[future_form(Sendable, Local)]
-impl<K: FutureForm> Transport<K> for HttpLongPollTransport {
+impl<Async: FutureForm> Transport<Async> for HttpLongPollTransport {
     type SendError = SendError;
     type RecvError = RecvError;
     type DisconnectionError = DisconnectionError;
 
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>> {
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>> {
         tracing::info!(peer_id = %self.inner.peer_id, "HttpLongPoll::disconnect");
         let conn = self.clone();
-        K::from_future(async move {
+        Async::from_future(async move {
             conn.close();
             Ok(())
         })
     }
 
-    fn send_bytes(&self, bytes: &[u8]) -> K::Future<'_, Result<(), Self::SendError>> {
+    fn send_bytes(&self, bytes: &[u8]) -> Async::Future<'_, Result<(), Self::SendError>> {
         tracing::debug!(
             "http-lp: sending {} outbound bytes to peer {}",
             bytes.len(),
@@ -158,13 +158,13 @@ impl<K: FutureForm> Transport<K> for HttpLongPollTransport {
 
         let data = bytes.to_vec();
         let tx = self.inner.outbound_tx.clone();
-        K::from_future(async move {
+        Async::from_future(async move {
             tx.send(data).await.map_err(|_| SendError)?;
             Ok(())
         })
     }
 
-    fn recv_bytes(&self) -> K::Future<'_, Result<Vec<u8>, Self::RecvError>> {
+    fn recv_bytes(&self) -> Async::Future<'_, Result<Vec<u8>, Self::RecvError>> {
         let chan = self.inner.inbound_reader.clone();
         tracing::debug!(
             chan_id = self.inner.chan_id,
@@ -172,7 +172,7 @@ impl<K: FutureForm> Transport<K> for HttpLongPollTransport {
             self.inner.peer_id
         );
 
-        K::from_future(async move {
+        Async::from_future(async move {
             let bytes = chan.recv().await.map_err(|_| {
                 tracing::error!("inbound channel closed unexpectedly");
                 RecvError

--- a/subduction_keyhive/src/cache.rs
+++ b/subduction_keyhive/src/cache.rs
@@ -126,22 +126,44 @@ impl PeriodicEventCache {
     /// # Errors
     ///
     /// Returns [`ProtocolError`] if event serialization fails.
-    pub(crate) async fn refresh<Signer, T, P, C, L, R, Conn, Store, K>(
+    pub(crate) async fn refresh<
+        Signer,
+        CRef,
+        Plaintext,
+        CipherStore,
+        Listener,
+        Rng,
+        Conn,
+        Store,
+        Async,
+    >(
         &mut self,
-        protocol: &KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, K>,
+        protocol: &KeyhiveProtocol<
+            Signer,
+            CRef,
+            Plaintext,
+            CipherStore,
+            Listener,
+            Rng,
+            Conn,
+            Store,
+            Async,
+        >,
     ) -> Result<bool, ProtocolError<Conn::SendError>>
     where
-        Signer: AsyncSigner<K> + Clone,
-        T: ContentRef + serde::de::DeserializeOwned,
-        P: for<'de> serde::Deserialize<'de>,
-        C: CiphertextStore<K, T, P> + CiphertextStoreExt<K, T, P> + Clone,
-        L: MembershipListener<K, Signer, T>,
-        R: rand::CryptoRng + rand::RngCore,
-        Conn: KeyhiveConnection<K>,
+        Signer: AsyncSigner<Async> + Clone,
+        CRef: ContentRef + serde::de::DeserializeOwned,
+        Plaintext: for<'de> serde::Deserialize<'de>,
+        CipherStore: CiphertextStore<Async, CRef, Plaintext>
+            + CiphertextStoreExt<Async, CRef, Plaintext>
+            + Clone,
+        Listener: MembershipListener<Async, Signer, CRef>,
+        Rng: rand::CryptoRng + rand::RngCore,
+        Conn: KeyhiveConnection<Async>,
         Conn::SendError: 'static,
         Conn::DisconnectError: 'static,
-        Store: KeyhiveStorage<K>,
-        K: future_form::FutureForm,
+        Store: KeyhiveStorage<Async>,
+        Async: future_form::FutureForm,
     {
         let total = protocol.total_ops().await;
         if self.last_total_ops == Some(total) {

--- a/subduction_keyhive/src/connection.rs
+++ b/subduction_keyhive/src/connection.rs
@@ -9,7 +9,7 @@ use crate::{peer_id::KeyhivePeerId, signed_message::SignedMessage};
 /// This trait abstracts over the underlying transport mechanism, allowing
 /// the keyhive protocol to work with different connection backends such as
 /// WebSocket, in-memory channels, or other transports.
-pub trait KeyhiveConnection<K: FutureForm>: Clone {
+pub trait KeyhiveConnection<Async: FutureForm>: Clone {
     /// The error type returned when sending a message fails.
     type SendError: core::error::Error;
 
@@ -23,11 +23,11 @@ pub trait KeyhiveConnection<K: FutureForm>: Clone {
     fn peer_id(&self) -> KeyhivePeerId;
 
     /// Send a signed message to the peer.
-    fn send(&self, message: SignedMessage) -> K::Future<'_, Result<(), Self::SendError>>;
+    fn send(&self, message: SignedMessage) -> Async::Future<'_, Result<(), Self::SendError>>;
 
     /// Receive a signed message from the peer.
-    fn recv(&self) -> K::Future<'_, Result<SignedMessage, Self::RecvError>>;
+    fn recv(&self) -> Async::Future<'_, Result<SignedMessage, Self::RecvError>>;
 
     /// Disconnect from the peer gracefully.
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectError>>;
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectError>>;
 }

--- a/subduction_keyhive/src/lib.rs
+++ b/subduction_keyhive/src/lib.rs
@@ -35,7 +35,12 @@ pub mod storage_ops;
 #[cfg(feature = "serde")]
 mod syncpoints;
 
-#[cfg(any(test, feature = "test-utils"))]
+// `test_utils` imports from `crate::protocol`, which is `serde`-gated.
+// The `test-utils` feature already pulls in `serde` transitively, so the
+// `serde` predicate here only governs the plain `cargo test` path (no
+// explicit features), preventing `test_utils` from being compiled before
+// `protocol` exists.
+#[cfg(any(all(test, feature = "serde"), feature = "test-utils"))]
 #[allow(
     clippy::expect_used,
     clippy::indexing_slicing,

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -69,26 +69,26 @@ use crate::{
 };
 
 /// Shared keyhive instance behind a mutex.
-type SharedKeyhive<K, Signer, T, P, C, L, R> = Arc<Mutex<Keyhive<K, Signer, T, P, C, L, R>>>;
+type SharedKeyhive<Async, Signer, T, P, C, L, R> = Arc<Mutex<Keyhive<Async, Signer, T, P, C, L, R>>>;
 
 /// Keyhive sync protocol handler.
 ///
 /// Manages peer connections and implements the keyhive sync protocol for
 /// reconciling operations between peers. All keyhive access is serialized
 /// through an `Arc<Mutex<Keyhive>>`.
-pub struct KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, K>
+pub struct KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
 where
-    Signer: AsyncSigner<K> + Clone,
+    Signer: AsyncSigner<Async> + Clone,
     T: ContentRef,
     P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<K, T, P> + CiphertextStoreExt<K, T, P> + Clone,
-    L: MembershipListener<K, Signer, T>,
+    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
+    L: MembershipListener<Async, Signer, T>,
     R: rand::CryptoRng + rand::RngCore,
-    Conn: KeyhiveConnection<K>,
-    Store: KeyhiveStorage<K>,
-    K: future_form::FutureForm,
+    Conn: KeyhiveConnection<Async>,
+    Store: KeyhiveStorage<Async>,
+    Async: future_form::FutureForm,
 {
-    keyhive: SharedKeyhive<K, Signer, T, P, C, L, R>,
+    keyhive: SharedKeyhive<Async, Signer, T, P, C, L, R>,
     storage: Store,
     peer_id: KeyhivePeerId,
     peers: Mutex<Map<KeyhivePeerId, Conn>>,
@@ -96,21 +96,21 @@ where
     archive_config: Option<(usize, StorageHash)>,
     syncpoints: Mutex<SyncpointMap>,
     cache: Mutex<PeriodicEventCache>,
-    _marker: core::marker::PhantomData<K>,
+    _marker: core::marker::PhantomData<Async>,
 }
 
-impl<Signer, T, P, C, L, R, Conn, Store, K> core::fmt::Debug
-    for KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, K>
+impl<Signer, T, P, C, L, R, Conn, Store, Async> core::fmt::Debug
+    for KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
 where
-    Signer: AsyncSigner<K> + Clone,
+    Signer: AsyncSigner<Async> + Clone,
     T: ContentRef,
     P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<K, T, P> + CiphertextStoreExt<K, T, P> + Clone,
-    L: MembershipListener<K, Signer, T>,
+    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
+    L: MembershipListener<Async, Signer, T>,
     R: rand::CryptoRng + rand::RngCore,
-    Conn: KeyhiveConnection<K>,
-    Store: KeyhiveStorage<K>,
-    K: future_form::FutureForm,
+    Conn: KeyhiveConnection<Async>,
+    Store: KeyhiveStorage<Async>,
+    Async: future_form::FutureForm,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("KeyhiveProtocol")
@@ -119,23 +119,23 @@ where
     }
 }
 
-impl<Signer, T, P, C, L, R, Conn, Store, K> KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, K>
+impl<Signer, T, P, C, L, R, Conn, Store, Async> KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
 where
-    Signer: AsyncSigner<K> + Clone,
+    Signer: AsyncSigner<Async> + Clone,
     T: ContentRef + serde::de::DeserializeOwned,
     P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<K, T, P> + CiphertextStoreExt<K, T, P> + Clone,
-    L: MembershipListener<K, Signer, T>,
+    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
+    L: MembershipListener<Async, Signer, T>,
     R: rand::CryptoRng + rand::RngCore,
-    Conn: KeyhiveConnection<K>,
+    Conn: KeyhiveConnection<Async>,
     Conn::SendError: 'static,
     Conn::DisconnectError: 'static,
-    Store: KeyhiveStorage<K>,
-    K: future_form::FutureForm,
+    Store: KeyhiveStorage<Async>,
+    Async: future_form::FutureForm,
 {
     /// Create a new protocol handler.
     pub fn new(
-        keyhive: SharedKeyhive<K, Signer, T, P, C, L, R>,
+        keyhive: SharedKeyhive<Async, Signer, T, P, C, L, R>,
         storage: Store,
         peer_id: KeyhivePeerId,
         contact_card: ContactCard,
@@ -282,7 +282,7 @@ where
                 if !skip_serialization.contains(&h)
                     && let Entry::Vacant(e) = event_data.entry(h)
                 {
-                    let event: Event<K, Signer, T, L> = op.clone().into();
+                    let event: Event<Async, Signer, T, L> = op.clone().into();
                     let static_event = StaticEvent::from(event);
                     e.insert(serialize_event_pair(&static_event)?);
                 }
@@ -297,7 +297,7 @@ where
         for (source_id, key_ops) in &all_prekey.ops {
             let events = key_ops
                 .iter()
-                .map(|op| -> Event<K, Signer, T, L> { Event::from(op.as_ref().clone()) });
+                .map(|op| -> Event<Async, Signer, T, L> { Event::from(op.as_ref().clone()) });
             prekey_source_hashes.insert(
                 *source_id,
                 hash_and_insert_events(&mut event_data, events, skip_serialization)?,
@@ -308,7 +308,7 @@ where
         for (source_id, cgka_ops) in &all_cgka.ops {
             let events = cgka_ops
                 .iter()
-                .map(|op| -> Event<K, Signer, T, L> { Event::from(op.clone()) });
+                .map(|op| -> Event<Async, Signer, T, L> { Event::from(op.clone()) });
             cgka_source_hashes.insert(
                 *source_id,
                 hash_and_insert_events(&mut event_data, events, skip_serialization)?,
@@ -1239,17 +1239,17 @@ where
 }
 
 /// Get sync-relevant events for an agent: membership, prekey, and CGKA operations.
-async fn sync_events_for_agent<K, Signer, T, P, C, L, R>(
-    keyhive: &Keyhive<K, Signer, T, P, C, L, R>,
-    agent: &Agent<K, Signer, T, L>,
+async fn sync_events_for_agent<Async, Signer, T, P, C, L, R>(
+    keyhive: &Keyhive<Async, Signer, T, P, C, L, R>,
+    agent: &Agent<Async, Signer, T, L>,
 ) -> Map<Digest<StaticEvent<T>>, StaticEvent<T>>
 where
-    K: future_form::FutureForm,
-    Signer: AsyncSigner<K> + Clone,
+    Async: future_form::FutureForm,
+    Signer: AsyncSigner<Async> + Clone,
     T: ContentRef,
     P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<K, T, P> + CiphertextStoreExt<K, T, P> + Clone,
-    L: MembershipListener<K, Signer, T>,
+    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
+    L: MembershipListener<Async, Signer, T>,
     R: rand::CryptoRng + rand::RngCore,
 {
     keyhive
@@ -1262,16 +1262,16 @@ where
 /// Hash, serialize, and deduplicate events into `event_data`, returning hashes.
 ///
 /// Hashes present in `skip_serialization` are recorded but not serialized.
-fn hash_and_insert_events<K, Signer, T, L, E>(
+fn hash_and_insert_events<Async, Signer, T, L, E>(
     event_data: &mut BTreeMap<EventHash, (EventBytes, CborBytes)>,
-    events: impl Iterator<Item = Event<K, Signer, T, L>>,
+    events: impl Iterator<Item = Event<Async, Signer, T, L>>,
     skip_serialization: &BTreeSet<EventHash>,
 ) -> Result<Vec<EventHash>, ProtocolError<E>>
 where
-    K: future_form::FutureForm,
-    Signer: AsyncSigner<K> + Clone,
+    Async: future_form::FutureForm,
+    Signer: AsyncSigner<Async> + Clone,
     T: ContentRef,
-    L: MembershipListener<K, Signer, T>,
+    L: MembershipListener<Async, Signer, T>,
     E: core::error::Error + 'static,
 {
     let mut hashes = Vec::new();

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -119,7 +119,8 @@ where
     }
 }
 
-impl<Signer, T, P, C, L, R, Conn, Store, Async> KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
+impl<Signer, T, P, C, L, R, Conn, Store, Async>
+    KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
 where
     Signer: AsyncSigner<Async> + Clone,
     T: ContentRef + serde::de::DeserializeOwned,

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements the keyhive synchronization protocol, which enables
 //! peers to reconcile their keyhive operations (delegations, revocations,
-//! prekey operations, CGKA operations). T
+//! prekey operations, CGKA operations).
 //!
 //! ## Full sync exchange
 //!
@@ -69,26 +69,29 @@ use crate::{
 };
 
 /// Shared keyhive instance behind a mutex.
-type SharedKeyhive<Async, Signer, T, P, C, L, R> = Arc<Mutex<Keyhive<Async, Signer, T, P, C, L, R>>>;
+type SharedKeyhive<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng> =
+    Arc<Mutex<Keyhive<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng>>>;
 
 /// Keyhive sync protocol handler.
 ///
 /// Manages peer connections and implements the keyhive sync protocol for
 /// reconciling operations between peers. All keyhive access is serialized
 /// through an `Arc<Mutex<Keyhive>>`.
-pub struct KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
+pub struct KeyhiveProtocol<Signer, CRef, Plaintext, CipherStore, Listener, Rng, Conn, Store, Async>
 where
     Signer: AsyncSigner<Async> + Clone,
-    T: ContentRef,
-    P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
-    L: MembershipListener<Async, Signer, T>,
-    R: rand::CryptoRng + rand::RngCore,
+    CRef: ContentRef,
+    Plaintext: for<'de> serde::Deserialize<'de>,
+    CipherStore: CiphertextStore<Async, CRef, Plaintext>
+        + CiphertextStoreExt<Async, CRef, Plaintext>
+        + Clone,
+    Listener: MembershipListener<Async, Signer, CRef>,
+    Rng: rand::CryptoRng + rand::RngCore,
     Conn: KeyhiveConnection<Async>,
     Store: KeyhiveStorage<Async>,
     Async: future_form::FutureForm,
 {
-    keyhive: SharedKeyhive<Async, Signer, T, P, C, L, R>,
+    keyhive: SharedKeyhive<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng>,
     storage: Store,
     peer_id: KeyhivePeerId,
     peers: Mutex<Map<KeyhivePeerId, Conn>>,
@@ -99,15 +102,17 @@ where
     _marker: core::marker::PhantomData<Async>,
 }
 
-impl<Signer, T, P, C, L, R, Conn, Store, Async> core::fmt::Debug
-    for KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
+impl<Signer, CRef, Plaintext, CipherStore, Listener, Rng, Conn, Store, Async> core::fmt::Debug
+    for KeyhiveProtocol<Signer, CRef, Plaintext, CipherStore, Listener, Rng, Conn, Store, Async>
 where
     Signer: AsyncSigner<Async> + Clone,
-    T: ContentRef,
-    P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
-    L: MembershipListener<Async, Signer, T>,
-    R: rand::CryptoRng + rand::RngCore,
+    CRef: ContentRef,
+    Plaintext: for<'de> serde::Deserialize<'de>,
+    CipherStore: CiphertextStore<Async, CRef, Plaintext>
+        + CiphertextStoreExt<Async, CRef, Plaintext>
+        + Clone,
+    Listener: MembershipListener<Async, Signer, CRef>,
+    Rng: rand::CryptoRng + rand::RngCore,
     Conn: KeyhiveConnection<Async>,
     Store: KeyhiveStorage<Async>,
     Async: future_form::FutureForm,
@@ -119,15 +124,17 @@ where
     }
 }
 
-impl<Signer, T, P, C, L, R, Conn, Store, Async>
-    KeyhiveProtocol<Signer, T, P, C, L, R, Conn, Store, Async>
+impl<Signer, CRef, Plaintext, CipherStore, Listener, Rng, Conn, Store, Async>
+    KeyhiveProtocol<Signer, CRef, Plaintext, CipherStore, Listener, Rng, Conn, Store, Async>
 where
     Signer: AsyncSigner<Async> + Clone,
-    T: ContentRef + serde::de::DeserializeOwned,
-    P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
-    L: MembershipListener<Async, Signer, T>,
-    R: rand::CryptoRng + rand::RngCore,
+    CRef: ContentRef + serde::de::DeserializeOwned,
+    Plaintext: for<'de> serde::Deserialize<'de>,
+    CipherStore: CiphertextStore<Async, CRef, Plaintext>
+        + CiphertextStoreExt<Async, CRef, Plaintext>
+        + Clone,
+    Listener: MembershipListener<Async, Signer, CRef>,
+    Rng: rand::CryptoRng + rand::RngCore,
     Conn: KeyhiveConnection<Async>,
     Conn::SendError: 'static,
     Conn::DisconnectError: 'static,
@@ -136,7 +143,7 @@ where
 {
     /// Create a new protocol handler.
     pub fn new(
-        keyhive: SharedKeyhive<Async, Signer, T, P, C, L, R>,
+        keyhive: SharedKeyhive<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng>,
         storage: Store,
         peer_id: KeyhivePeerId,
         contact_card: ContactCard,
@@ -283,7 +290,7 @@ where
                 if !skip_serialization.contains(&h)
                     && let Entry::Vacant(e) = event_data.entry(h)
                 {
-                    let event: Event<Async, Signer, T, L> = op.clone().into();
+                    let event: Event<Async, Signer, CRef, Listener> = op.clone().into();
                     let static_event = StaticEvent::from(event);
                     e.insert(serialize_event_pair(&static_event)?);
                 }
@@ -298,7 +305,9 @@ where
         for (source_id, key_ops) in &all_prekey.ops {
             let events = key_ops
                 .iter()
-                .map(|op| -> Event<Async, Signer, T, L> { Event::from(op.as_ref().clone()) });
+                .map(|op| -> Event<Async, Signer, CRef, Listener> {
+                    Event::from(op.as_ref().clone())
+                });
             prekey_source_hashes.insert(
                 *source_id,
                 hash_and_insert_events(&mut event_data, events, skip_serialization)?,
@@ -309,7 +318,7 @@ where
         for (source_id, cgka_ops) in &all_cgka.ops {
             let events = cgka_ops
                 .iter()
-                .map(|op| -> Event<Async, Signer, T, L> { Event::from(op.clone()) });
+                .map(|op| -> Event<Async, Signer, CRef, Listener> { Event::from(op.clone()) });
             cgka_source_hashes.insert(
                 *source_id,
                 hash_and_insert_events(&mut event_data, events, skip_serialization)?,
@@ -942,7 +951,7 @@ where
                 (Some(ref our_agent), Some(ref their_agent)) => {
                     let our_events = sync_events_for_agent(&keyhive, our_agent).await;
                     let their_events = sync_events_for_agent(&keyhive, their_agent).await;
-                    let public_events: Map<Digest<StaticEvent<T>>, StaticEvent<T>> =
+                    let public_events: Map<Digest<StaticEvent<CRef>>, StaticEvent<CRef>> =
                         if let Some(ref public_agent) = keyhive.get_agent(Public.id()).await {
                             sync_events_for_agent(&keyhive, public_agent).await
                         } else {
@@ -1022,9 +1031,9 @@ where
         &self,
         event_bytes_list: &[EventBytes],
     ) -> Result<(), ProtocolError<Conn::SendError>> {
-        let mut events: Vec<StaticEvent<T>> = Vec::with_capacity(event_bytes_list.len());
+        let mut events: Vec<StaticEvent<CRef>> = Vec::with_capacity(event_bytes_list.len());
         for (idx, bytes) in event_bytes_list.iter().enumerate() {
-            match bincode_deserialize::<StaticEvent<T>>(bytes) {
+            match bincode_deserialize::<StaticEvent<CRef>>(bytes) {
                 Ok(ev) => events.push(ev),
                 Err(e) => {
                     let head_len = core::cmp::min(bytes.len(), 96);
@@ -1098,7 +1107,7 @@ where
             storage_ops::ingest_from_storage(&keyhive, &self.storage).await?;
         }
 
-        let events: Vec<StaticEvent<T>> = event_bytes_list
+        let events: Vec<StaticEvent<CRef>> = event_bytes_list
             .iter()
             .filter_map(|bytes| match bincode_deserialize(bytes) {
                 Ok(ev) => Some(ev),
@@ -1140,7 +1149,7 @@ where
                 .map_err(ProtocolError::ReceiveContactCard)?;
         }
 
-        let event: StaticEvent<T> = match contact_card.op() {
+        let event: StaticEvent<CRef> = match contact_card.op() {
             KeyOp::Add(add) => StaticEvent::PrekeysExpanded(Box::new(add.as_ref().clone())),
             KeyOp::Rotate(rot) => StaticEvent::PrekeyRotated(Box::new(rot.as_ref().clone())),
         };
@@ -1240,18 +1249,20 @@ where
 }
 
 /// Get sync-relevant events for an agent: membership, prekey, and CGKA operations.
-async fn sync_events_for_agent<Async, Signer, T, P, C, L, R>(
-    keyhive: &Keyhive<Async, Signer, T, P, C, L, R>,
-    agent: &Agent<Async, Signer, T, L>,
-) -> Map<Digest<StaticEvent<T>>, StaticEvent<T>>
+async fn sync_events_for_agent<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng>(
+    keyhive: &Keyhive<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng>,
+    agent: &Agent<Async, Signer, CRef, Listener>,
+) -> Map<Digest<StaticEvent<CRef>>, StaticEvent<CRef>>
 where
     Async: future_form::FutureForm,
     Signer: AsyncSigner<Async> + Clone,
-    T: ContentRef,
-    P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
-    L: MembershipListener<Async, Signer, T>,
-    R: rand::CryptoRng + rand::RngCore,
+    CRef: ContentRef,
+    Plaintext: for<'de> serde::Deserialize<'de>,
+    CipherStore: CiphertextStore<Async, CRef, Plaintext>
+        + CiphertextStoreExt<Async, CRef, Plaintext>
+        + Clone,
+    Listener: MembershipListener<Async, Signer, CRef>,
+    Rng: rand::CryptoRng + rand::RngCore,
 {
     keyhive
         .static_events_for_agent(agent)
@@ -1263,16 +1274,16 @@ where
 /// Hash, serialize, and deduplicate events into `event_data`, returning hashes.
 ///
 /// Hashes present in `skip_serialization` are recorded but not serialized.
-fn hash_and_insert_events<Async, Signer, T, L, E>(
+fn hash_and_insert_events<Async, Signer, CRef, Listener, E>(
     event_data: &mut BTreeMap<EventHash, (EventBytes, CborBytes)>,
-    events: impl Iterator<Item = Event<Async, Signer, T, L>>,
+    events: impl Iterator<Item = Event<Async, Signer, CRef, Listener>>,
     skip_serialization: &BTreeSet<EventHash>,
 ) -> Result<Vec<EventHash>, ProtocolError<E>>
 where
     Async: future_form::FutureForm,
     Signer: AsyncSigner<Async> + Clone,
-    T: ContentRef,
-    L: MembershipListener<Async, Signer, T>,
+    CRef: ContentRef,
+    Listener: MembershipListener<Async, Signer, CRef>,
     E: core::error::Error + 'static,
 {
     let mut hashes = Vec::new();
@@ -1291,8 +1302,8 @@ where
 }
 
 /// Serialize a map of digested events into a hash-keyed byte map.
-fn collect_serialized_events<T: ContentRef, E: core::error::Error + 'static>(
-    events: Map<Digest<StaticEvent<T>>, StaticEvent<T>>,
+fn collect_serialized_events<CRef: ContentRef, E: core::error::Error + 'static>(
+    events: Map<Digest<StaticEvent<CRef>>, StaticEvent<CRef>>,
 ) -> Result<BTreeMap<EventHash, (EventBytes, CborBytes)>, ProtocolError<E>> {
     let mut out = BTreeMap::new();
     for (digest, event) in events {
@@ -1304,8 +1315,8 @@ fn collect_serialized_events<T: ContentRef, E: core::error::Error + 'static>(
 }
 
 /// Serialize a `StaticEvent` to bincode bytes and a CBOR byte-string wrapper.
-fn serialize_event_pair<T: ContentRef, E: core::error::Error + 'static>(
-    event: &StaticEvent<T>,
+fn serialize_event_pair<CRef: ContentRef, E: core::error::Error + 'static>(
+    event: &StaticEvent<CRef>,
 ) -> Result<(EventBytes, CborBytes), ProtocolError<E>> {
     let bytes =
         bincode_serialize(event).map_err(|e| ProtocolError::Serialization(e.to_string()))?;

--- a/subduction_keyhive/src/signed_message.rs
+++ b/subduction_keyhive/src/signed_message.rs
@@ -160,7 +160,11 @@ impl SignedMessage {
     }
 
     /// Get a mutable reference to the signed bytes (for testing tamper scenarios).
-    #[cfg(test)]
+    ///
+    /// Only used from `protocol`'s tamper-detection tests; `protocol` itself
+    /// is `serde`-gated, so this method matches that gate to stay alive only
+    /// when there's actually a caller.
+    #[cfg(all(test, feature = "serde"))]
     pub(crate) const fn signed_bytes_mut(&mut self) -> &mut Vec<u8> {
         &mut self.signed
     }

--- a/subduction_keyhive/src/storage.rs
+++ b/subduction_keyhive/src/storage.rs
@@ -76,7 +76,7 @@ impl StorageHash {
 /// Archives contain the full keyhive state, while events are individual
 /// operations.
 #[allow(clippy::type_complexity)]
-pub trait KeyhiveStorage<K: FutureForm> {
+pub trait KeyhiveStorage<Async: FutureForm> {
     /// The error type for storage operations.
     type Error: core::error::Error;
 
@@ -88,16 +88,16 @@ pub trait KeyhiveStorage<K: FutureForm> {
         &self,
         hash: StorageHash,
         data: Vec<u8>,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Load all archives from storage.
     ///
     /// Returns a vector of (hash, data) pairs for all stored archives.
     #[allow(clippy::type_complexity)]
-    fn load_archives(&self) -> K::Future<'_, Result<Vec<(StorageHash, Vec<u8>)>, Self::Error>>;
+    fn load_archives(&self) -> Async::Future<'_, Result<Vec<(StorageHash, Vec<u8>)>, Self::Error>>;
 
     /// Delete an archive from storage.
-    fn delete_archive(&self, hash: StorageHash) -> K::Future<'_, Result<(), Self::Error>>;
+    fn delete_archive(&self, hash: StorageHash) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Save an event to storage.
     ///
@@ -107,16 +107,16 @@ pub trait KeyhiveStorage<K: FutureForm> {
         &self,
         hash: StorageHash,
         data: Vec<u8>,
-    ) -> K::Future<'_, Result<(), Self::Error>>;
+    ) -> Async::Future<'_, Result<(), Self::Error>>;
 
     /// Load all events from storage.
     ///
     /// Returns a vector of (hash, data) pairs for all stored events.
     #[allow(clippy::type_complexity)]
-    fn load_events(&self) -> K::Future<'_, Result<Vec<(StorageHash, Vec<u8>)>, Self::Error>>;
+    fn load_events(&self) -> Async::Future<'_, Result<Vec<(StorageHash, Vec<u8>)>, Self::Error>>;
 
     /// Delete an event from storage.
-    fn delete_event(&self, hash: StorageHash) -> K::Future<'_, Result<(), Self::Error>>;
+    fn delete_event(&self, hash: StorageHash) -> Async::Future<'_, Result<(), Self::Error>>;
 }
 
 /// An in-memory storage backend for testing.

--- a/subduction_keyhive/src/storage_ops.rs
+++ b/subduction_keyhive/src/storage_ops.rs
@@ -63,15 +63,15 @@ pub fn hash_event_bytes(bytes: &[u8]) -> StorageHash {
 /// # Errors
 ///
 /// Returns [`StorageError`] if CBOR serialization or the storage write fails.
-pub async fn save_keyhive_archive<T, S, K>(
+pub async fn save_keyhive_archive<T, S, Async>(
     storage: &S,
     storage_id: StorageHash,
     archive: &Archive<T>,
 ) -> Result<(), StorageError>
 where
     T: ContentRef,
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     let bytes = cbor_serialize(archive)?;
 
@@ -96,14 +96,14 @@ where
 ///
 /// Returns [`StorageError`] if bincode serialization or the storage write
 /// fails.
-pub async fn save_event<T, S, K>(
+pub async fn save_event<T, S, Async>(
     storage: &S,
     event: &StaticEvent<T>,
 ) -> Result<StorageHash, StorageError>
 where
     T: ContentRef,
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     let bytes = bincode_serialize(event)?;
     save_event_bytes(storage, bytes).await
@@ -116,13 +116,13 @@ where
 /// # Errors
 ///
 /// Returns [`StorageError`] if the storage write fails.
-pub async fn save_event_bytes<S, K>(
+pub async fn save_event_bytes<S, Async>(
     storage: &S,
     bytes: Vec<u8>,
 ) -> Result<StorageHash, StorageError>
 where
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     let hash = hash_event_bytes(&bytes);
 
@@ -145,13 +145,13 @@ where
 /// # Errors
 ///
 /// Returns [`StorageError`] if the storage read or CBOR deserialization fails.
-pub async fn load_archives<T, S, K>(
+pub async fn load_archives<T, S, Async>(
     storage: &S,
 ) -> Result<Vec<(StorageHash, Archive<T>)>, StorageError>
 where
     T: ContentRef + serde::de::DeserializeOwned,
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     let raw_archives = storage
         .load_archives()
@@ -173,13 +173,13 @@ where
 /// # Errors
 ///
 /// Returns [`StorageError`] if the storage read or CBOR deserialization fails.
-pub async fn load_events<T, S, K>(
+pub async fn load_events<T, S, Async>(
     storage: &S,
 ) -> Result<Vec<(StorageHash, StaticEvent<T>)>, StorageError>
 where
     T: ContentRef + serde::de::DeserializeOwned,
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     let raw_events = storage
         .load_events()
@@ -203,12 +203,12 @@ where
 /// # Errors
 ///
 /// Returns [`StorageError`] if the storage read fails.
-pub async fn load_event_bytes<S, K>(
+pub async fn load_event_bytes<S, Async>(
     storage: &S,
 ) -> Result<Vec<(StorageHash, Vec<u8>)>, StorageError>
 where
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     storage
         .load_events()
@@ -225,19 +225,19 @@ where
 /// # Errors
 ///
 /// Returns [`StorageError`] if loading, deserialization, or archive ingestion fails.
-pub async fn ingest_from_storage<K, Signer, T, P, C, L, R, S>(
-    keyhive: &Keyhive<K, Signer, T, P, C, L, R>,
+pub async fn ingest_from_storage<Async, Signer, T, P, C, L, R, S>(
+    keyhive: &Keyhive<Async, Signer, T, P, C, L, R>,
     storage: &S,
 ) -> Result<Vec<Arc<StaticEvent<T>>>, StorageError>
 where
-    Signer: AsyncSigner<K> + Clone,
+    Signer: AsyncSigner<Async> + Clone,
     T: ContentRef + serde::de::DeserializeOwned,
     P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<K, T, P> + CiphertextStoreExt<K, T, P> + Clone,
-    L: MembershipListener<K, Signer, T>,
+    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
+    L: MembershipListener<Async, Signer, T>,
     R: rand::CryptoRng + rand::RngCore,
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     // Load archives
     let archives: Vec<(StorageHash, Archive<T>)> = load_archives(storage).await?;
@@ -282,20 +282,20 @@ where
 ///
 /// Returns [`StorageError`] if any storage operation, serialization, or
 /// deserialization fails.
-pub async fn compact<K, Signer, T, P, C, L, R, S>(
-    keyhive: &Keyhive<K, Signer, T, P, C, L, R>,
+pub async fn compact<Async, Signer, T, P, C, L, R, S>(
+    keyhive: &Keyhive<Async, Signer, T, P, C, L, R>,
     storage: &S,
     storage_id: StorageHash,
 ) -> Result<(), StorageError>
 where
-    Signer: AsyncSigner<K> + Clone,
+    Signer: AsyncSigner<Async> + Clone,
     T: ContentRef + serde::de::DeserializeOwned,
     P: for<'de> serde::Deserialize<'de>,
-    C: CiphertextStore<K, T, P> + CiphertextStoreExt<K, T, P> + Clone,
-    L: MembershipListener<K, Signer, T>,
+    C: CiphertextStore<Async, T, P> + CiphertextStoreExt<Async, T, P> + Clone,
+    L: MembershipListener<Async, Signer, T>,
     R: rand::CryptoRng + rand::RngCore,
-    S: KeyhiveStorage<K>,
-    K: FutureForm,
+    S: KeyhiveStorage<Async>,
+    Async: FutureForm,
 {
     // Load raw data (we need hashes for cleanup)
     let raw_archives = storage

--- a/subduction_websocket/src/handshake.rs
+++ b/subduction_websocket/src/handshake.rs
@@ -101,18 +101,18 @@ impl<T> DerefMut for WebSocketHandshake<T> {
     Sendable where T: AsyncRead + AsyncWrite + Unpin + Send,
     Local where T: AsyncRead + AsyncWrite + Unpin
 )]
-impl<K: FutureForm, T> Handshake<K> for WebSocketHandshake<T> {
+impl<Async: FutureForm, T> Handshake<Async> for WebSocketHandshake<T> {
     type Error = WebSocketHandshakeError;
 
-    fn send(&mut self, bytes: Vec<u8>) -> K::Future<'_, Result<(), Self::Error>> {
-        K::from_future(async move {
+    fn send(&mut self, bytes: Vec<u8>) -> Async::Future<'_, Result<(), Self::Error>> {
+        Async::from_future(async move {
             SinkExt::send(&mut self.0, tungstenite::Message::Binary(bytes.into())).await?;
             Ok(())
         })
     }
 
-    fn recv(&mut self) -> K::Future<'_, Result<Vec<u8>, Self::Error>> {
-        K::from_future(async move {
+    fn recv(&mut self) -> Async::Future<'_, Result<Vec<u8>, Self::Error>> {
+        Async::from_future(async move {
             loop {
                 let msg = self
                     .0

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -159,23 +159,23 @@ pub enum KeepAliveOutcome {
 /// Parameterized by [`FutureForm`]: `KeepAliveTask<Sendable>` is
 /// `Send`-spawnable on multi-threaded runtimes; `KeepAliveTask<Local>`
 /// is for single-threaded runtimes (Wasm).
-pub struct KeepAliveTask<K: FutureForm>(K::Future<'static, KeepAliveOutcome>);
+pub struct KeepAliveTask<Async: FutureForm>(Async::Future<'static, KeepAliveOutcome>);
 
-impl<K: FutureForm> core::fmt::Debug for KeepAliveTask<K> {
+impl<Async: FutureForm> core::fmt::Debug for KeepAliveTask<Async> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("KeepAliveTask").finish_non_exhaustive()
     }
 }
 
-impl<K: FutureForm> KeepAliveTask<K> {
-    pub(crate) const fn new(fut: K::Future<'static, KeepAliveOutcome>) -> Self {
+impl<Async: FutureForm> KeepAliveTask<Async> {
+    pub(crate) const fn new(fut: Async::Future<'static, KeepAliveOutcome>) -> Self {
         Self(fut)
     }
 }
 
-impl<K: FutureForm> IntoFuture for KeepAliveTask<K> {
+impl<Async: FutureForm> IntoFuture for KeepAliveTask<Async> {
     type Output = KeepAliveOutcome;
-    type IntoFuture = K::Future<'static, KeepAliveOutcome>;
+    type IntoFuture = Async::Future<'static, KeepAliveOutcome>;
 
     fn into_future(self) -> Self::IntoFuture {
         self.0
@@ -186,9 +186,9 @@ impl<K: FutureForm> IntoFuture for KeepAliveTask<K> {
 ///
 /// Parameterized over:
 /// - `T`: the underlying async I/O stream (e.g., `TcpStream`, `ConnectStream`)
-/// - `K`: the async future form (`Local` or `Sendable`)
+/// - `Async`: the async future form (`Local` or `Sendable`)
 #[derive(Debug)]
-pub struct WebSocket<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> {
+pub struct WebSocket<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> {
     chan_id: u64,
     peer_id: PeerId,
 
@@ -208,7 +208,7 @@ pub struct WebSocket<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> {
     /// keepalive task. Unused (but cheap) when keepalive is disabled.
     pong_received: Arc<AtomicBool>,
 
-    _phantom: PhantomData<K>,
+    _phantom: PhantomData<Async>,
 }
 
 #[future_form(
@@ -217,30 +217,30 @@ pub struct WebSocket<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> {
     Local where
         T: AsyncRead + AsyncWrite + Unpin + Send
 )]
-impl<T, K: FutureForm> Transport<K> for WebSocket<T, K> {
+impl<T, Async: FutureForm> Transport<Async> for WebSocket<T, Async> {
     type SendError = SendError;
     type RecvError = RecvError;
     type DisconnectionError = DisconnectionError;
 
-    fn disconnect(&self) -> K::Future<'_, Result<(), Self::DisconnectionError>> {
+    fn disconnect(&self) -> Async::Future<'_, Result<(), Self::DisconnectionError>> {
         tracing::info!(peer_id = %self.peer_id, "WebSocket::disconnect");
-        K::from_future(async { Ok(()) })
+        Async::from_future(async { Ok(()) })
     }
 
-    fn send_bytes(&self, bytes: &[u8]) -> K::Future<'_, Result<(), Self::SendError>> {
+    fn send_bytes(&self, bytes: &[u8]) -> Async::Future<'_, Result<(), Self::SendError>> {
         let msg = tungstenite::Message::Binary(bytes.to_vec().into());
         let tx = self.outbound_tx.clone();
-        K::from_future(async move {
+        Async::from_future(async move {
             tx.send(msg).await.map_err(|_| SendError)?;
             Ok(())
         })
     }
 
-    fn recv_bytes(&self) -> K::Future<'_, Result<Vec<u8>, Self::RecvError>> {
+    fn recv_bytes(&self) -> Async::Future<'_, Result<Vec<u8>, Self::RecvError>> {
         let chan = self.inbound_reader.clone();
         tracing::debug!(chan_id = self.chan_id, "waiting on recv {:?}", self.peer_id);
 
-        K::from_future(async move {
+        Async::from_future(async move {
             let bytes = chan.recv().await.map_err(|_| {
                 tracing::error!("inbound channel closed unexpectedly");
                 RecvError
@@ -252,7 +252,7 @@ impl<T, K: FutureForm> Transport<K> for WebSocket<T, K> {
     }
 }
 
-impl<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> WebSocket<T, K> {
+impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
     /// Create a new WebSocket transport without keepalive.
     ///
     /// Returns the transport and a sender task to spawn. The sender
@@ -264,7 +264,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> WebSocket<T, K> {
     pub fn new(
         ws: WebSocketStream<T>,
         peer_id: PeerId,
-    ) -> (Self, impl Future<Output = Result<(), RunError>> + use<T, K>) {
+    ) -> (Self, impl Future<Output = Result<(), RunError>> + use<T, Async>) {
         tracing::info!("new WebSocket connection for peer {peer_id:?} (keepalive: false)");
         Self::new_inner(ws, peer_id)
     }
@@ -273,7 +273,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> WebSocket<T, K> {
     fn new_inner(
         ws: WebSocketStream<T>,
         peer_id: PeerId,
-    ) -> (Self, impl Future<Output = Result<(), RunError>> + use<T, K>) {
+    ) -> (Self, impl Future<Output = Result<(), RunError>> + use<T, Async>) {
         let (ws_writer, ws_reader) = ws.split();
         let (inbound_writer, inbound_reader) = async_channel::bounded(128);
         let (outbound_tx, outbound_rx) = async_channel::bounded(OUTBOUND_CHANNEL_CAPACITY);
@@ -474,7 +474,7 @@ const fn is_expected_disconnect(e: &tungstenite::Error) -> bool {
 ///
 /// Cycle: `sleep(ping)` → clear flag → send Ping → `sleep(pong)` →
 /// check flag. Threshold consecutive misses trigger disconnect.
-async fn keepalive_loop<S, K>(
+async fn keepalive_loop<S, Async>(
     config: KeepAlive,
     peer_id: PeerId,
     outbound_tx: async_channel::Sender<tungstenite::Message>,
@@ -483,8 +483,8 @@ async fn keepalive_loop<S, K>(
     sleeper: S,
 ) -> KeepAliveOutcome
 where
-    S: Sleeper<K>,
-    K: FutureForm + ?Sized,
+    S: Sleeper<Async>,
+    Async: FutureForm + ?Sized,
 {
     use tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
 
@@ -548,7 +548,7 @@ where
     }
 }
 
-impl<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> Clone for WebSocket<T, K> {
+impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> Clone for WebSocket<T, Async> {
     fn clone(&self) -> Self {
         Self {
             chan_id: self.chan_id,
@@ -564,7 +564,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> Clone for WebSocket<T, K>
     }
 }
 
-impl<T: AsyncRead + AsyncWrite + Unpin, K: FutureForm> PartialEq for WebSocket<T, K> {
+impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> PartialEq for WebSocket<T, Async> {
     fn eq(&self, other: &Self) -> bool {
         self.peer_id == other.peer_id
             && Arc::ptr_eq(&self.ws_reader, &other.ws_reader)

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -264,7 +264,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
     pub fn new(
         ws: WebSocketStream<T>,
         peer_id: PeerId,
-    ) -> (Self, impl Future<Output = Result<(), RunError>> + use<T, Async>) {
+    ) -> (
+        Self,
+        impl Future<Output = Result<(), RunError>> + use<T, Async>,
+    ) {
         tracing::info!("new WebSocket connection for peer {peer_id:?} (keepalive: false)");
         Self::new_inner(ws, peer_id)
     }
@@ -273,7 +276,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
     fn new_inner(
         ws: WebSocketStream<T>,
         peer_id: PeerId,
-    ) -> (Self, impl Future<Output = Result<(), RunError>> + use<T, Async>) {
+    ) -> (
+        Self,
+        impl Future<Output = Result<(), RunError>> + use<T, Async>,
+    ) {
         let (ws_writer, ws_reader) = ws.split();
         let (inbound_writer, inbound_reader) = async_channel::bounded(128);
         let (outbound_tx, outbound_rx) = async_channel::bounded(OUTBOUND_CHANNEL_CAPACITY);


### PR DESCRIPTION
A quick fix from last week's crit session: give generic params more descriptive names when there's a lot of them! Very easy to do with a combination of find-and-replace and robotic assistance