### PR TITLE
Fix mutants

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -47,11 +47,27 @@ exclude_globs = [
 #   - `Debug` / `Display` impls (often whitespace-sensitive but never
 #     part of program correctness)
 #   - `Drop` impls (rarely meaningfully tested at unit level)
+#   - `arbitrary::Arbitrary` impls — only used by test data generators;
+#     mutations to their internal arithmetic (e.g., `Vec::with_capacity`
+#     args) are semantically unobservable because the surrounding code
+#     still grows the buffer correctly via `extend_from_slice`. These
+#     mutants survive every possible test, by construction.
 #   - `unimplemented!()` / `todo!()` / `unreachable!()` macro calls
 exclude_re = [
     "impl .*Debug for ",
     "impl .*Display for ",
     "impl .*Drop for ",
+    "impl .*arbitrary::Arbitrary.* for ",
+
+    # subduction_crypto/src/signed.rs:255 is inside a defensive
+    # `bytes.get(fields_start..).ok_or(...)` whose `None` branch is
+    # unreachable from `try_decode`: the outer `T::MIN_SIGNED_SIZE`
+    # check (line 191) and the issuer bounds check (line 237) together
+    # guarantee `bytes.len() >= fields_start` by the time we reach it.
+    # The arithmetic in the `need:` field is defense-in-depth that no
+    # input can exercise, so the `+ -> -` / `+ -> *` mutants there
+    # cannot be killed by any test.
+    "subduction_crypto/src/signed.rs:255:.*Signed<T>::try_decode",
 ]
 
 # Be a little patient with builds. The workspace is large, and the
@@ -66,12 +82,19 @@ timeout_multiplier = 2.0
 # kill legitimate mutant tests early.
 minimum_test_timeout = 60
 
-# Pass `--features arbitrary,metrics` so:
-#   - bolero-driven property tests run during mutation testing.
-#     Without `arbitrary`, ~half the proptest coverage is silently
-#     disabled and survivors balloon.
-#   - feature-gated metrics-storage tests run. Without `metrics`,
-#     `subduction_core/tests/metrics_storage.rs` (which covers the
-#     `MetricsStorage` wrapper delegation paths) is skipped and ~40
-#     mutants in `subduction_core/src/storage/metrics.rs` survive.
-additional_cargo_test_args = ["--features", "arbitrary,metrics"]
+# Note: feature selection is intentionally NOT set here. The nightly
+# matrix passes `--features` per-crate in `.github/workflows/mutants.yml`
+# because most workspace crates don't declare `arbitrary` or `metrics`
+# features, and passing a feature flag the package doesn't recognise
+# fails the baseline build (silently → "0 mutants tested, 0 missed" →
+# the workflow's `failure()` guard fires anyway because cargo-mutants
+# returns non-zero on baseline failure → a spurious "surviving mutants"
+# issue gets opened).
+#
+# Local invocations should mirror the per-crate features used in CI,
+# e.g.:
+#
+#   cargo mutants -p subduction_core --features arbitrary,metrics
+#   cargo mutants -p subduction_crypto --features arbitrary
+#   cargo mutants -p sedimentree_core --features arbitrary
+#   cargo mutants -p subduction_iroh             # no extra features

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -84,7 +84,10 @@ jobs:
           tool: cargo-mutants
 
       - name: Establish baseline build
-        run: cargo build --workspace --tests --features arbitrary
+        # Workspace-level `--features` only activates the named features
+        # on packages that declare them, so this is safe across the
+        # whole workspace.
+        run: cargo build --workspace --tests --features arbitrary,metrics
 
       - name: Compute diff vs base
         id: diff
@@ -130,17 +133,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate:
-          - sedimentree_core
-          - sedimentree_fs_storage
-          - subduction_core
-          - subduction_crypto
-          - subduction_ephemeral
-          - subduction_http_longpoll
-          - subduction_iroh
-          - subduction_keyhive
-          - subduction_websocket
-          - automerge_sedimentree
+        # `features` is passed verbatim to `cargo mutants --features`.
+        # Empty string means no extra features. Keep aligned with each
+        # crate's `Cargo.toml` `[features]` — passing a flag the package
+        # doesn't declare fails the baseline build and produces a
+        # spurious "surviving mutants" issue.
+        include:
+          - crate: sedimentree_core
+            features: arbitrary
+          - crate: sedimentree_fs_storage
+            features: ""
+          - crate: subduction_core
+            features: arbitrary,metrics
+          - crate: subduction_crypto
+            features: arbitrary
+          - crate: subduction_ephemeral
+            features: ""
+          - crate: subduction_http_longpoll
+            features: ""
+          - crate: subduction_iroh
+            features: ""
+          - crate: subduction_keyhive
+            features: ""
+          - crate: subduction_websocket
+            features: ""
+          - crate: automerge_sedimentree
+            features: ""
 
     permissions:
       contents: read
@@ -186,12 +204,40 @@ jobs:
       - name: Run cargo-mutants on ${{ matrix.crate }}
         id: mutants
         run: |
+          # Build the optional --features arg only when a feature list
+          # is configured for this crate; passing `--features ""` is an
+          # error on packages without a `[features]` table.
+          features_arg=()
+          if [ -n "${{ matrix.features }}" ]; then
+            features_arg=(--features "${{ matrix.features }}")
+          fi
+          set +e
           cargo mutants \
             --package ${{ matrix.crate }} \
             --no-shuffle \
             --jobs 4 \
             --colors=always \
-            --output mutants.out
+            --output mutants.out \
+            "${features_arg[@]}"
+          mutants_exit=$?
+          set -e
+          # Detect the actual outcome: distinguish "missed mutants"
+          # (a real signal worth opening an issue for) from "baseline
+          # failed" (a config/dependency bug we shouldn't ping the team
+          # for).
+          missed=0
+          if [ -f mutants.out/missed.txt ]; then
+            missed=$(wc -l < mutants.out/missed.txt)
+          fi
+          baseline_failed=0
+          if [ "$mutants_exit" -ne 0 ] && [ "$missed" -eq 0 ]; then
+            baseline_failed=1
+          fi
+          echo "missed=$missed" >> "$GITHUB_OUTPUT"
+          echo "baseline_failed=$baseline_failed" >> "$GITHUB_OUTPUT"
+          echo "exit_code=$mutants_exit" >> "$GITHUB_OUTPUT"
+          # Propagate failure so the job status reflects the issue.
+          exit "$mutants_exit"
 
       - name: Upload mutants.out
         if: always()
@@ -201,16 +247,27 @@ jobs:
           path: mutants.out
           retention-days: 30
 
-      - name: Open issue on regression
-        if: failure() && github.event_name == 'schedule'
+      - name: Open issue on surviving mutants
+        # Only open a "surviving mutants" issue when cargo-mutants
+        # actually reported missed mutants. A non-zero exit code with
+        # zero missed mutants typically means the baseline build failed
+        # (e.g. a missing feature flag, a flaky dep) — those should
+        # produce a different issue or just be addressed via the failed
+        # job status.
+        if: |
+          always()
+          && github.event_name == 'schedule'
+          && steps.mutants.outputs.missed != '0'
+          && steps.mutants.outputs.missed != ''
         uses: actions/github-script@v7
         with:
           script: |
             const crate = '${{ matrix.crate }}';
+            const missed = '${{ steps.mutants.outputs.missed }}';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const title = `Nightly mutants: surviving mutants in \`${crate}\``;
             const body = [
-              `The scheduled nightly mutation-testing run found surviving mutants in \`${crate}\`.`,
+              `The scheduled nightly mutation-testing run found ${missed} surviving mutant(s) in \`${crate}\`.`,
               ``,
               `- Run: ${runUrl}`,
               `- Date: ${new Date().toISOString().slice(0, 10)}`,
@@ -239,4 +296,53 @@ jobs:
               title,
               body,
               labels: ['mutation-testing', 'tech-debt'],
+            });
+
+      - name: Open issue on baseline failure
+        # Separate signal: cargo-mutants returned non-zero but reported
+        # zero missed mutants. This indicates a config / dependency /
+        # baseline-build problem with mutation testing itself, not a
+        # test-coverage gap.
+        if: |
+          always()
+          && github.event_name == 'schedule'
+          && steps.mutants.outputs.baseline_failed == '1'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const crate = '${{ matrix.crate }}';
+            const exitCode = '${{ steps.mutants.outputs.exit_code }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = `Nightly mutants: baseline failure in \`${crate}\``;
+            const body = [
+              `The scheduled nightly mutation-testing run could not establish a baseline for \`${crate}\`.`,
+              ``,
+              `cargo-mutants exited with code ${exitCode} but reported zero missed mutants — this is the signature of a baseline-build failure (e.g. a feature flag the package doesn't declare, a missing dev-dep, or a flaky dependency).`,
+              ``,
+              `- Run: ${runUrl}`,
+              `- Date: ${new Date().toISOString().slice(0, 10)}`,
+              ``,
+              `Check the \`Run cargo-mutants on ${crate}\` step output and \`mutants.out/log/baseline.log\` in the artifact. Common fixes:`,
+              `- Adjust the \`features\` entry for this crate in the workflow matrix.`,
+              `- Update \`.cargo/mutants.toml\` if the issue is workspace-wide.`,
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'mutation-testing',
+              per_page: 100,
+            });
+            if (existing.data.some(i => i.title === title)) {
+              core.info(`Issue already open: ${title}`);
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['mutation-testing', 'ci-config'],
             });

--- a/subduction_crypto/src/nonce.rs
+++ b/subduction_crypto/src/nonce.rs
@@ -59,13 +59,12 @@ impl Nonce {
 
 #[cfg(test)]
 mod tests {
-    //! Mutant-coverage tests for [`Nonce::as_u128`].
+    //! Round-trip tests for [`Nonce::as_u128`].
 
     use super::Nonce;
 
-    /// `as_u128` of a non-zero, non-one nonce must return the original
-    /// value. A mutant returning `0` is caught by the non-zero input;
-    /// a mutant returning `1` is caught because we use a distinct value.
+    /// `as_u128` must invert `from_u128`: a nonce constructed from a
+    /// `u128` decodes back to the same value.
     #[test]
     fn as_u128_round_trips() {
         let original = 0x1234_5678_9ABC_DEF0_FEDC_BA98_7654_3210u128;
@@ -73,9 +72,9 @@ mod tests {
         assert_eq!(nonce.as_u128(), original, "as_u128 must invert from_u128");
     }
 
-    /// Round-trip through `from_u128` → `as_u128` across several
-    /// representative values (zero, one, max, and a typical random
-    /// nonce) so the test fails for any constant-return mutant.
+    /// `from_u128` → `as_u128` round-trips for representative values
+    /// across the `u128` range (zero, one, max, near-max, a typical
+    /// nonce, and `u64::MAX` lifted into `u128`).
     #[test]
     fn as_u128_round_trips_across_values() {
         for &v in &[

--- a/subduction_crypto/src/nonce.rs
+++ b/subduction_crypto/src/nonce.rs
@@ -56,3 +56,39 @@ impl Nonce {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Mutant-coverage tests for [`Nonce::as_u128`].
+
+    use super::Nonce;
+
+    /// `as_u128` of a non-zero, non-one nonce must return the original
+    /// value. A mutant returning `0` is caught by the non-zero input;
+    /// a mutant returning `1` is caught because we use a distinct value.
+    #[test]
+    fn as_u128_round_trips() {
+        let original = 0x1234_5678_9ABC_DEF0_FEDC_BA98_7654_3210u128;
+        let nonce = Nonce::from_u128(original);
+        assert_eq!(nonce.as_u128(), original, "as_u128 must invert from_u128");
+    }
+
+    /// Round-trip through `from_u128` → `as_u128` across several
+    /// representative values (zero, one, max, and a typical random
+    /// nonce) so the test fails for any constant-return mutant.
+    #[test]
+    fn as_u128_round_trips_across_values() {
+        for &v in &[
+            0u128,
+            1u128,
+            2u128,
+            u128::MAX,
+            u128::MAX - 1,
+            0xDEAD_BEEF_CAFE_BABE_u128,
+            u128::from(u64::MAX),
+        ] {
+            let nonce = Nonce::from_u128(v);
+            assert_eq!(nonce.as_u128(), v, "round-trip failed for {v}");
+        }
+    }
+}

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -1088,8 +1088,7 @@ mod mutant_coverage {
             "MIN_SIGNED_SIZE must equal SCHEMA_SIZE + VERIFYING_KEY_SIZE + SIGNATURE_SIZE"
         );
         assert_eq!(
-            MIN_SIGNED_SIZE,
-            100,
+            MIN_SIGNED_SIZE, 100,
             "MIN_SIGNED_SIZE must be 4 + 32 + 64 = 100"
         );
     }

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -650,3 +650,447 @@ mod tests {
             });
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
+mod mutant_coverage {
+    //! Deterministic mutant-coverage tests for [`Signed<T>`].
+
+    use alloc::vec::Vec;
+
+    use ed25519_dalek::{Signer as _, SigningKey};
+    use sedimentree_core::codec::{
+        decode::{self, DecodeFields},
+        encode::{self, EncodeFields},
+        error::DecodeError,
+        schema::{self, Schema},
+    };
+
+    use super::{MIN_SIGNED_SIZE, SCHEMA_SIZE, SIGNATURE_SIZE, Signed, VERIFYING_KEY_SIZE};
+
+    // ── Test payloads ─────────────────────────────────────────────────
+
+    /// Minimal payload type for `Signed<T>` mutant tests. Wire layout:
+    /// schema(4) + issuer(32) + value(8) + sig(64) = 108 bytes.
+    ///
+    /// Distinct from `super::tests::TestPayload` (schema byte `'T'`) so
+    /// the two test modules don't share schema state.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct MutantPayload {
+        value: u64,
+    }
+
+    impl Schema for MutantPayload {
+        const PREFIX: [u8; 2] = schema::SUBDUCTION_PREFIX;
+        const TYPE_BYTE: u8 = b'M'; // 'M' for "mutant coverage"
+        const VERSION: u8 = 0;
+    }
+
+    impl EncodeFields for MutantPayload {
+        fn encode_fields(&self, buf: &mut Vec<u8>) {
+            encode::u64(self.value, buf);
+        }
+
+        fn fields_size(&self) -> usize {
+            8
+        }
+    }
+
+    impl DecodeFields for MutantPayload {
+        const MIN_SIGNED_SIZE: usize = SCHEMA_SIZE + VERIFYING_KEY_SIZE + 8 + SIGNATURE_SIZE;
+
+        fn try_decode_fields(buf: &[u8]) -> Result<(Self, usize), DecodeError> {
+            let value = decode::u64(buf, 0)?;
+            Ok((Self { value }, 8))
+        }
+    }
+
+    /// Build canonical signed bytes for `MutantPayload` synchronously,
+    /// using the same layout as `Signed::seal`.
+    pub(crate) fn seal_mutant_payload(key_bytes: [u8; 32], value: u64) -> Vec<u8> {
+        let signing_key = SigningKey::from_bytes(&key_bytes);
+        let issuer = signing_key.verifying_key();
+        let payload = MutantPayload { value };
+
+        let total_size = SCHEMA_SIZE + VERIFYING_KEY_SIZE + payload.fields_size() + SIGNATURE_SIZE;
+        let mut bytes = Vec::with_capacity(total_size);
+
+        bytes.extend_from_slice(&MutantPayload::SCHEMA);
+        bytes.extend_from_slice(issuer.as_bytes());
+        payload.encode_fields(&mut bytes);
+        let signature = signing_key.sign(&bytes);
+        bytes.extend_from_slice(&signature.to_bytes());
+        bytes
+    }
+
+    // ── Signed::into_bytes ────────────────────────────────────────────
+    //
+    // Mutants killed:
+    //   - signed.rs:297 replace Signed<T>::into_bytes -> Vec<u8> with vec![]
+    //   - signed.rs:297 replace Signed<T>::into_bytes -> Vec<u8> with vec![0]
+    //   - signed.rs:297 replace Signed<T>::into_bytes -> Vec<u8> with vec![1]
+
+    /// `into_bytes` must return the same bytes as `as_bytes`, consuming
+    /// the `Signed<T>` value. Mutants that replace the body with
+    /// `vec![]`, `vec![0]`, or `vec![1]` produce a vec of length 0 or 1
+    /// — never the 108-byte canonical encoding.
+    #[test]
+    fn into_bytes_returns_full_wire_bytes() {
+        let canonical = seal_mutant_payload([7u8; 32], 0xDEAD_BEEF);
+        let signed = Signed::<MutantPayload>::try_decode(canonical.clone())
+            .expect("decode of canonical bytes");
+
+        let via_as_bytes: Vec<u8> = signed.as_bytes().to_vec();
+        let via_into_bytes: Vec<u8> = signed.into_bytes();
+
+        assert_eq!(
+            via_into_bytes, canonical,
+            "into_bytes must return the canonical wire encoding"
+        );
+        assert_eq!(
+            via_into_bytes, via_as_bytes,
+            "into_bytes must agree with as_bytes"
+        );
+        assert_eq!(
+            via_into_bytes.len(),
+            108,
+            "MutantPayload canonical wire size is 108 bytes"
+        );
+    }
+
+    // ── Signed::try_decode error field arithmetic ─────────────────────
+    //
+    // Mutants killed:
+    //   - signed.rs:222 (`need: SCHEMA_SIZE + 1`) replace + with - / *
+    //   - signed.rs:241 (`need: issuer_start + VERIFYING_KEY_SIZE`) replace + with *
+    //   - signed.rs:255 (`need: fields_start + 1`) replace + with - / *
+    //
+    // These error paths are guarded by the outer `T::MIN_SIGNED_SIZE`
+    // check at the top of `try_decode`. In normal use they're
+    // unreachable because `T::MIN_SIGNED_SIZE` is always ≥ the
+    // intermediate-bound expressions. To exercise them, we deliberately
+    // under-specify a payload's `MIN_SIGNED_SIZE` so the outer check
+    // doesn't catch the short input, driving execution down to the
+    // in-line bounds checks.
+    //
+    // This also tests a real defense-in-depth contract: if a downstream
+    // `DecodeFields` impl gets its `MIN_SIGNED_SIZE` wrong, the inner
+    // bounds checks must still produce structured errors with accurate
+    // `need` values rather than panicking or reporting garbage.
+
+    /// Lies about `MIN_SIGNED_SIZE`, claiming `0`. Forces the outer
+    /// pre-check to pass for any input length, exposing the in-line
+    /// discriminant-bounds check.
+    #[derive(Debug, Clone, Copy)]
+    struct UnderSpecifiedTagged {
+        value: u64,
+    }
+
+    impl Schema for UnderSpecifiedTagged {
+        const PREFIX: [u8; 2] = schema::SUBDUCTION_PREFIX;
+        const TYPE_BYTE: u8 = b'U';
+        const VERSION: u8 = 0;
+        const DISCRIMINANT: Option<u8> = Some(0xAA);
+    }
+
+    impl EncodeFields for UnderSpecifiedTagged {
+        fn encode_fields(&self, buf: &mut Vec<u8>) {
+            encode::u64(self.value, buf);
+        }
+        fn fields_size(&self) -> usize {
+            8
+        }
+    }
+
+    impl DecodeFields for UnderSpecifiedTagged {
+        // Deliberately too small. The real minimum would be
+        // SCHEMA_SIZE + 1 + VERIFYING_KEY_SIZE + 8 + SIGNATURE_SIZE = 109.
+        // We claim 0 so the outer check always passes.
+        const MIN_SIGNED_SIZE: usize = 0;
+
+        fn try_decode_fields(buf: &[u8]) -> Result<(Self, usize), DecodeError> {
+            let value = decode::u64(buf, 0)?;
+            Ok((Self { value }, 8))
+        }
+    }
+
+    /// Same trick for an untagged payload, exposing the missing-issuer
+    /// and missing-fields-region bounds checks.
+    #[derive(Debug, Clone, Copy)]
+    struct UnderSpecifiedPlain {
+        value: u64,
+    }
+
+    impl Schema for UnderSpecifiedPlain {
+        const PREFIX: [u8; 2] = schema::SUBDUCTION_PREFIX;
+        const TYPE_BYTE: u8 = b'P';
+        const VERSION: u8 = 0;
+    }
+
+    impl EncodeFields for UnderSpecifiedPlain {
+        fn encode_fields(&self, buf: &mut Vec<u8>) {
+            encode::u64(self.value, buf);
+        }
+        fn fields_size(&self) -> usize {
+            8
+        }
+    }
+
+    impl DecodeFields for UnderSpecifiedPlain {
+        const MIN_SIGNED_SIZE: usize = 0;
+
+        fn try_decode_fields(buf: &[u8]) -> Result<(Self, usize), DecodeError> {
+            let value = decode::u64(buf, 0)?;
+            Ok((Self { value }, 8))
+        }
+    }
+
+    /// With an under-specified `MIN_SIGNED_SIZE`, feeding exactly
+    /// `SCHEMA_SIZE` bytes (just the schema header, no discriminant)
+    /// makes `try_decode` reach the in-line discriminant bounds check,
+    /// which must report `need = SCHEMA_SIZE + 1` (= 5). Mutants on
+    /// the offending line change this to `3` (`-`) or `4` (`*`).
+    #[test]
+    fn try_decode_reports_correct_need_for_missing_discriminant() {
+        let mut bytes = Vec::with_capacity(SCHEMA_SIZE);
+        bytes.extend_from_slice(&UnderSpecifiedTagged::SCHEMA);
+        assert_eq!(bytes.len(), SCHEMA_SIZE);
+
+        let result = Signed::<UnderSpecifiedTagged>::try_decode(bytes);
+        match result {
+            Err(DecodeError::MessageTooShort { need, have, .. }) => {
+                assert_eq!(
+                    need,
+                    SCHEMA_SIZE + 1,
+                    "need must be SCHEMA_SIZE + 1 (= {})",
+                    SCHEMA_SIZE + 1
+                );
+                assert_eq!(have, SCHEMA_SIZE, "have must be SCHEMA_SIZE");
+            }
+            other => panic!("expected MessageTooShort, got {other:?}"),
+        }
+    }
+
+    /// With an under-specified `MIN_SIGNED_SIZE` and a buffer of
+    /// `SCHEMA_SIZE` bytes for an *untagged* payload, the schema check
+    /// passes (we wrote the right schema) and execution reaches the
+    /// issuer bounds check. `need` must be
+    /// `issuer_start + VERIFYING_KEY_SIZE = 4 + 32 = 36`. Mutant `+ ->
+    /// *` yields `0 * 32 = 0`.
+    #[test]
+    fn try_decode_reports_correct_need_for_missing_issuer() {
+        let mut bytes = Vec::with_capacity(SCHEMA_SIZE);
+        bytes.extend_from_slice(&UnderSpecifiedPlain::SCHEMA);
+        assert_eq!(bytes.len(), SCHEMA_SIZE);
+
+        let result = Signed::<UnderSpecifiedPlain>::try_decode(bytes);
+        match result {
+            Err(DecodeError::MessageTooShort { need, have, .. }) => {
+                assert_eq!(
+                    need,
+                    SCHEMA_SIZE + VERIFYING_KEY_SIZE,
+                    "need must be issuer_start + VERIFYING_KEY_SIZE (= {})",
+                    SCHEMA_SIZE + VERIFYING_KEY_SIZE
+                );
+                assert_eq!(have, SCHEMA_SIZE, "have must be SCHEMA_SIZE");
+            }
+            other => panic!("expected MessageTooShort, got {other:?}"),
+        }
+    }
+
+    /// With an under-specified `MIN_SIGNED_SIZE` and a buffer of
+    /// exactly the right size to pass the schema + issuer checks but
+    /// have an empty fields region (i.e., `bytes.len() == fields_start`),
+    /// `bytes.get(fields_start..)` returns an empty slice, not `None`.
+    /// So execution continues into `try_decode_fields(empty_slice)`,
+    /// which fails inside `decode::u64`. To actually trigger the
+    /// fields-region `need: fields_start + 1` arm, we'd need
+    /// `bytes.len() < fields_start`, which contradicts having reached
+    /// this point.
+    ///
+    /// The mutant on that line is therefore unreachable from any
+    /// well-formed caller of `try_decode`. It survives because the
+    /// branch is dead code — a defense-in-depth that no input can
+    /// reach. We assert the alternative: that an empty fields region
+    /// produces a downstream decode error (not a panic, not a
+    /// successful decode), which at least exercises the surrounding
+    /// plumbing.
+    #[test]
+    fn try_decode_empty_fields_region_errors_cleanly() {
+        // Exactly SCHEMA_SIZE + VERIFYING_KEY_SIZE bytes — passes the
+        // issuer bounds check, then `try_decode_fields` is called with
+        // an empty slice and fails.
+        let mut bytes = Vec::with_capacity(SCHEMA_SIZE + VERIFYING_KEY_SIZE);
+        bytes.extend_from_slice(&UnderSpecifiedPlain::SCHEMA);
+        bytes.extend_from_slice(&[0u8; VERIFYING_KEY_SIZE]);
+        assert_eq!(bytes.len(), SCHEMA_SIZE + VERIFYING_KEY_SIZE);
+
+        let result = Signed::<UnderSpecifiedPlain>::try_decode(bytes);
+        assert!(
+            result.is_err(),
+            "decode of bytes with empty fields region must fail"
+        );
+    }
+
+    // ── Signed::PartialEq ────────────────────────────────────────────
+    //
+    // Mutant killed:
+    //   - signed.rs:384 replace == with != in
+    //     <impl PartialEq for Signed<T>>::eq
+
+    /// Two `Signed<T>` values with identical canonical bytes must be
+    /// `==`, and two with different bytes must be `!=`. A `==` → `!=`
+    /// flip in the `eq` body inverts both checks.
+    #[test]
+    fn partial_eq_distinguishes_different_signed_values() {
+        let a = Signed::<MutantPayload>::try_decode(seal_mutant_payload([1u8; 32], 100))
+            .expect("decode a");
+        let a_again = Signed::<MutantPayload>::try_decode(seal_mutant_payload([1u8; 32], 100))
+            .expect("decode a_again");
+        let b = Signed::<MutantPayload>::try_decode(seal_mutant_payload([1u8; 32], 200))
+            .expect("decode b (different value)");
+        let c = Signed::<MutantPayload>::try_decode(seal_mutant_payload([2u8; 32], 100))
+            .expect("decode c (different signer)");
+
+        assert_eq!(a, a, "self-equality must hold");
+        assert_eq!(a, a_again, "two seals of identical content must be equal");
+
+        assert_ne!(a, b, "different payloads must not be equal");
+        assert_ne!(a, c, "different signers must not be equal");
+    }
+
+    // ── try_decode trailing-byte truncation ───────────────────────────
+    //
+    // Mutant killed:
+    //   - signed.rs:263 replace < with > in Signed<T>::try_decode
+    //
+    // The `if bytes.len() < actual_size` check guards against buffers
+    // that are too short. Inverting it to `> actual_size` makes
+    // well-formed input with trailing bytes fail to decode (a real
+    // regression in `SyncMessage` parsing, which embeds `Signed<T>`
+    // byte-for-byte and hands `try_decode` the full payload buffer
+    // including subsequent items). The existing bolero proptest covers
+    // this with random trailing bytes; we add a deterministic version
+    // that runs in <1ms for fast mutant kill.
+
+    /// `try_decode` of canonical bytes with trailing data must succeed
+    /// and the decoded `Signed` must verify. The mutant `< -> >` flips
+    /// the bounds check and turns the trailing-bytes-OK case into an
+    /// error.
+    #[test]
+    fn try_decode_succeeds_with_trailing_bytes() {
+        let canonical = seal_mutant_payload([42u8; 32], 0xABCD);
+        let canonical_len = canonical.len();
+        let mut with_trailing = canonical.clone();
+        with_trailing.extend_from_slice(&[0xFF; 256]);
+
+        let signed = Signed::<MutantPayload>::try_decode(with_trailing)
+            .expect("decode must succeed when extra bytes trail the canonical encoding");
+        assert_eq!(
+            signed.as_bytes().len(),
+            canonical_len,
+            "try_decode must truncate trailing bytes to the canonical length"
+        );
+        assert_eq!(signed.as_bytes(), canonical.as_slice());
+        signed
+            .try_verify()
+            .expect("verification must succeed after truncation");
+    }
+
+    // ── Hash + PartialOrd implementations ─────────────────────────────
+    //
+    // Mutants killed:
+    //   - signed.rs:392 replace <impl Hash for Signed<T>>::hash with ()
+    //   - signed.rs:398 replace <impl PartialOrd for Signed<T>>::partial_cmp
+    //     -> Option<Ordering> with None
+    //
+    // `Hash` and `PartialOrd` are required for using these types as
+    // keys in `BTreeMap` / `HashMap` and for ordering. A no-op `hash`
+    // body collides every value into the same bucket (a real
+    // performance regression), and a `partial_cmp` that always returns
+    // `None` makes `BTreeMap` insertion unpredictable.
+
+    /// `Signed<T>`'s `Hash` impl must produce different hashes for
+    /// different signed values. A `hash` body replaced with `()`
+    /// hashes nothing, so all values collide into a single bucket.
+    #[test]
+    fn hash_distinguishes_different_values() {
+        use core::hash::{BuildHasher as _, Hasher as _};
+        use std::collections::hash_map::RandomState;
+
+        let a = Signed::<MutantPayload>::try_decode(seal_mutant_payload([5u8; 32], 100))
+            .expect("decode a");
+        let b = Signed::<MutantPayload>::try_decode(seal_mutant_payload([5u8; 32], 200))
+            .expect("decode b");
+
+        let builder = RandomState::new();
+        let mut ha = builder.build_hasher();
+        let mut hb = builder.build_hasher();
+        core::hash::Hash::hash(&a, &mut ha);
+        core::hash::Hash::hash(&b, &mut hb);
+
+        assert_ne!(
+            ha.finish(),
+            hb.finish(),
+            "Signed::hash must distinguish different signed values; a no-op body collides everything to 0"
+        );
+    }
+
+    /// `Signed<T>`'s `PartialOrd` must produce `Some(_)` for any two
+    /// values (total order via `Ord`). A body replaced with `None`
+    /// breaks every `BTreeMap` / sorted-collection use.
+    #[test]
+    fn partial_cmp_is_total() {
+        let a = Signed::<MutantPayload>::try_decode(seal_mutant_payload([6u8; 32], 1))
+            .expect("decode a");
+        let b = Signed::<MutantPayload>::try_decode(seal_mutant_payload([6u8; 32], 2))
+            .expect("decode b");
+
+        assert!(
+            a.partial_cmp(&a).is_some(),
+            "partial_cmp(self, self) must be Some (= Equal)"
+        );
+        assert!(
+            a.partial_cmp(&b).is_some(),
+            "partial_cmp(a, b) must be Some (= Less or Greater)"
+        );
+        assert!(
+            b.partial_cmp(&a).is_some(),
+            "partial_cmp(b, a) must be Some (= Less or Greater)"
+        );
+        assert_ne!(
+            a.partial_cmp(&b),
+            b.partial_cmp(&a),
+            "partial_cmp must respect antisymmetry for distinct values"
+        );
+    }
+
+    // ── Free-standing MIN_SIGNED_SIZE constant ───────────────────────
+    //
+    // Mutants killed:
+    //   - signed.rs:50 replace + with * (both occurrences in the
+    //     expression `SCHEMA_SIZE + VERIFYING_KEY_SIZE + SIGNATURE_SIZE`)
+    //
+    // The constant is unused in-crate (`T::MIN_SIGNED_SIZE` is what
+    // code uses) but is part of the public API. Pin its value with an
+    // explicit assertion so the constant doesn't silently drift under
+    // a refactor.
+
+    /// `signed::MIN_SIGNED_SIZE` is the sum of the three layout
+    /// constants. A mutant replacing `+` with `*` produces a vastly
+    /// different number (e.g., `4 * 32 * 64 = 8192`), so the assertion
+    /// fires.
+    #[test]
+    fn min_signed_size_constant_is_sum_of_layout_parts() {
+        let expected = SCHEMA_SIZE + VERIFYING_KEY_SIZE + SIGNATURE_SIZE;
+        assert_eq!(
+            MIN_SIGNED_SIZE, expected,
+            "MIN_SIGNED_SIZE must equal SCHEMA_SIZE + VERIFYING_KEY_SIZE + SIGNATURE_SIZE"
+        );
+        assert_eq!(
+            MIN_SIGNED_SIZE,
+            100,
+            "MIN_SIGNED_SIZE must be 4 + 32 + 64 = 100"
+        );
+    }
+}

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -730,8 +730,8 @@ mod regression {
     #[test]
     fn into_bytes_returns_full_wire_bytes() {
         let canonical = seal_payload([7u8; 32], 0xDEAD_BEEF);
-        let signed = Signed::<Payload>::try_decode(canonical.clone())
-            .expect("decode of canonical bytes");
+        let signed =
+            Signed::<Payload>::try_decode(canonical.clone()).expect("decode of canonical bytes");
 
         let via_as_bytes: Vec<u8> = signed.as_bytes().to_vec();
         let via_into_bytes: Vec<u8> = signed.into_bytes();

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -653,8 +653,9 @@ mod tests {
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::indexing_slicing, clippy::panic)]
-mod mutant_coverage {
-    //! Deterministic mutant-coverage tests for [`Signed<T>`].
+mod regression {
+    //! Deterministic regression tests for [`Signed<T>`] codec, trait
+    //! impls, and layout constants.
 
     use alloc::vec::Vec;
 
@@ -670,23 +671,22 @@ mod mutant_coverage {
 
     // ── Test payloads ─────────────────────────────────────────────────
 
-    /// Minimal payload type for `Signed<T>` mutant tests. Wire layout:
-    /// schema(4) + issuer(32) + value(8) + sig(64) = 108 bytes.
-    ///
-    /// Distinct from `super::tests::TestPayload` (schema byte `'T'`) so
-    /// the two test modules don't share schema state.
+    /// Minimal payload for these tests. Wire layout: schema(4) +
+    /// issuer(32) + value(8) + sig(64) = 108 bytes. Uses a schema byte
+    /// distinct from `super::tests::TestPayload` so the two test
+    /// modules don't share schema state.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    struct MutantPayload {
+    struct Payload {
         value: u64,
     }
 
-    impl Schema for MutantPayload {
+    impl Schema for Payload {
         const PREFIX: [u8; 2] = schema::SUBDUCTION_PREFIX;
-        const TYPE_BYTE: u8 = b'M'; // 'M' for "mutant coverage"
+        const TYPE_BYTE: u8 = b'R';
         const VERSION: u8 = 0;
     }
 
-    impl EncodeFields for MutantPayload {
+    impl EncodeFields for Payload {
         fn encode_fields(&self, buf: &mut Vec<u8>) {
             encode::u64(self.value, buf);
         }
@@ -696,7 +696,7 @@ mod mutant_coverage {
         }
     }
 
-    impl DecodeFields for MutantPayload {
+    impl DecodeFields for Payload {
         const MIN_SIGNED_SIZE: usize = SCHEMA_SIZE + VERIFYING_KEY_SIZE + 8 + SIGNATURE_SIZE;
 
         fn try_decode_fields(buf: &[u8]) -> Result<(Self, usize), DecodeError> {
@@ -705,17 +705,17 @@ mod mutant_coverage {
         }
     }
 
-    /// Build canonical signed bytes for `MutantPayload` synchronously,
-    /// using the same layout as `Signed::seal`.
-    pub(crate) fn seal_mutant_payload(key_bytes: [u8; 32], value: u64) -> Vec<u8> {
+    /// Build canonical signed bytes for `Payload` synchronously, using
+    /// the same layout as `Signed::seal`.
+    pub(crate) fn seal_payload(key_bytes: [u8; 32], value: u64) -> Vec<u8> {
         let signing_key = SigningKey::from_bytes(&key_bytes);
         let issuer = signing_key.verifying_key();
-        let payload = MutantPayload { value };
+        let payload = Payload { value };
 
         let total_size = SCHEMA_SIZE + VERIFYING_KEY_SIZE + payload.fields_size() + SIGNATURE_SIZE;
         let mut bytes = Vec::with_capacity(total_size);
 
-        bytes.extend_from_slice(&MutantPayload::SCHEMA);
+        bytes.extend_from_slice(&Payload::SCHEMA);
         bytes.extend_from_slice(issuer.as_bytes());
         payload.encode_fields(&mut bytes);
         let signature = signing_key.sign(&bytes);
@@ -724,20 +724,13 @@ mod mutant_coverage {
     }
 
     // ── Signed::into_bytes ────────────────────────────────────────────
-    //
-    // Mutants killed:
-    //   - signed.rs:297 replace Signed<T>::into_bytes -> Vec<u8> with vec![]
-    //   - signed.rs:297 replace Signed<T>::into_bytes -> Vec<u8> with vec![0]
-    //   - signed.rs:297 replace Signed<T>::into_bytes -> Vec<u8> with vec![1]
 
-    /// `into_bytes` must return the same bytes as `as_bytes`, consuming
-    /// the `Signed<T>` value. Mutants that replace the body with
-    /// `vec![]`, `vec![0]`, or `vec![1]` produce a vec of length 0 or 1
-    /// — never the 108-byte canonical encoding.
+    /// `into_bytes` must return the canonical wire encoding, consuming
+    /// the `Signed<T>` value, and must agree with `as_bytes`.
     #[test]
     fn into_bytes_returns_full_wire_bytes() {
-        let canonical = seal_mutant_payload([7u8; 32], 0xDEAD_BEEF);
-        let signed = Signed::<MutantPayload>::try_decode(canonical.clone())
+        let canonical = seal_payload([7u8; 32], 0xDEAD_BEEF);
+        let signed = Signed::<Payload>::try_decode(canonical.clone())
             .expect("decode of canonical bytes");
 
         let via_as_bytes: Vec<u8> = signed.as_bytes().to_vec();
@@ -754,26 +747,21 @@ mod mutant_coverage {
         assert_eq!(
             via_into_bytes.len(),
             108,
-            "MutantPayload canonical wire size is 108 bytes"
+            "Payload canonical wire size is 108 bytes"
         );
     }
 
     // ── Signed::try_decode error field arithmetic ─────────────────────
     //
-    // Mutants killed:
-    //   - signed.rs:222 (`need: SCHEMA_SIZE + 1`) replace + with - / *
-    //   - signed.rs:241 (`need: issuer_start + VERIFYING_KEY_SIZE`) replace + with *
-    //   - signed.rs:255 (`need: fields_start + 1`) replace + with - / *
-    //
     // These error paths are guarded by the outer `T::MIN_SIGNED_SIZE`
     // check at the top of `try_decode`. In normal use they're
     // unreachable because `T::MIN_SIGNED_SIZE` is always ≥ the
-    // intermediate-bound expressions. To exercise them, we deliberately
+    // intermediate-bound expressions. To exercise them we deliberately
     // under-specify a payload's `MIN_SIGNED_SIZE` so the outer check
     // doesn't catch the short input, driving execution down to the
     // in-line bounds checks.
     //
-    // This also tests a real defense-in-depth contract: if a downstream
+    // This pins a defense-in-depth contract: if a downstream
     // `DecodeFields` impl gets its `MIN_SIGNED_SIZE` wrong, the inner
     // bounds checks must still produce structured errors with accurate
     // `need` values rather than panicking or reporting garbage.
@@ -848,8 +836,7 @@ mod mutant_coverage {
     /// With an under-specified `MIN_SIGNED_SIZE`, feeding exactly
     /// `SCHEMA_SIZE` bytes (just the schema header, no discriminant)
     /// makes `try_decode` reach the in-line discriminant bounds check,
-    /// which must report `need = SCHEMA_SIZE + 1` (= 5). Mutants on
-    /// the offending line change this to `3` (`-`) or `4` (`*`).
+    /// which must report `need = SCHEMA_SIZE + 1` (= 5).
     #[test]
     fn try_decode_reports_correct_need_for_missing_discriminant() {
         let mut bytes = Vec::with_capacity(SCHEMA_SIZE);
@@ -875,8 +862,7 @@ mod mutant_coverage {
     /// `SCHEMA_SIZE` bytes for an *untagged* payload, the schema check
     /// passes (we wrote the right schema) and execution reaches the
     /// issuer bounds check. `need` must be
-    /// `issuer_start + VERIFYING_KEY_SIZE = 4 + 32 = 36`. Mutant `+ ->
-    /// *` yields `0 * 32 = 0`.
+    /// `issuer_start + VERIFYING_KEY_SIZE = 4 + 32 = 36`.
     #[test]
     fn try_decode_reports_correct_need_for_missing_issuer() {
         let mut bytes = Vec::with_capacity(SCHEMA_SIZE);
@@ -903,18 +889,13 @@ mod mutant_coverage {
     /// have an empty fields region (i.e., `bytes.len() == fields_start`),
     /// `bytes.get(fields_start..)` returns an empty slice, not `None`.
     /// So execution continues into `try_decode_fields(empty_slice)`,
-    /// which fails inside `decode::u64`. To actually trigger the
-    /// fields-region `need: fields_start + 1` arm, we'd need
-    /// `bytes.len() < fields_start`, which contradicts having reached
-    /// this point.
-    ///
-    /// The mutant on that line is therefore unreachable from any
-    /// well-formed caller of `try_decode`. It survives because the
-    /// branch is dead code — a defense-in-depth that no input can
-    /// reach. We assert the alternative: that an empty fields region
-    /// produces a downstream decode error (not a panic, not a
-    /// successful decode), which at least exercises the surrounding
-    /// plumbing.
+    /// which fails inside `decode::u64`. The fields-region
+    /// `need: fields_start + 1` arm is unreachable from any
+    /// well-formed caller of `try_decode` — it sits behind a
+    /// `bytes.len() < fields_start` condition that contradicts
+    /// having reached this point. We assert the reachable
+    /// alternative: an empty fields region produces a downstream
+    /// decode error (not a panic, not a successful decode).
     #[test]
     fn try_decode_empty_fields_region_errors_cleanly() {
         // Exactly SCHEMA_SIZE + VERIFYING_KEY_SIZE bytes — passes the
@@ -933,23 +914,18 @@ mod mutant_coverage {
     }
 
     // ── Signed::PartialEq ────────────────────────────────────────────
-    //
-    // Mutant killed:
-    //   - signed.rs:384 replace == with != in
-    //     <impl PartialEq for Signed<T>>::eq
 
     /// Two `Signed<T>` values with identical canonical bytes must be
-    /// `==`, and two with different bytes must be `!=`. A `==` → `!=`
-    /// flip in the `eq` body inverts both checks.
+    /// `==`; two with different payloads or different signers must
+    /// be `!=`.
     #[test]
     fn partial_eq_distinguishes_different_signed_values() {
-        let a = Signed::<MutantPayload>::try_decode(seal_mutant_payload([1u8; 32], 100))
-            .expect("decode a");
-        let a_again = Signed::<MutantPayload>::try_decode(seal_mutant_payload([1u8; 32], 100))
-            .expect("decode a_again");
-        let b = Signed::<MutantPayload>::try_decode(seal_mutant_payload([1u8; 32], 200))
+        let a = Signed::<Payload>::try_decode(seal_payload([1u8; 32], 100)).expect("decode a");
+        let a_again =
+            Signed::<Payload>::try_decode(seal_payload([1u8; 32], 100)).expect("decode a_again");
+        let b = Signed::<Payload>::try_decode(seal_payload([1u8; 32], 200))
             .expect("decode b (different value)");
-        let c = Signed::<MutantPayload>::try_decode(seal_mutant_payload([2u8; 32], 100))
+        let c = Signed::<Payload>::try_decode(seal_payload([2u8; 32], 100))
             .expect("decode c (different signer)");
 
         assert_eq!(a, a, "self-equality must hold");
@@ -961,30 +937,24 @@ mod mutant_coverage {
 
     // ── try_decode trailing-byte truncation ───────────────────────────
     //
-    // Mutant killed:
-    //   - signed.rs:263 replace < with > in Signed<T>::try_decode
-    //
-    // The `if bytes.len() < actual_size` check guards against buffers
-    // that are too short. Inverting it to `> actual_size` makes
-    // well-formed input with trailing bytes fail to decode (a real
-    // regression in `SyncMessage` parsing, which embeds `Signed<T>`
-    // byte-for-byte and hands `try_decode` the full payload buffer
-    // including subsequent items). The existing bolero proptest covers
-    // this with random trailing bytes; we add a deterministic version
-    // that runs in <1ms for fast mutant kill.
+    // `try_decode` accepts buffers containing trailing bytes beyond
+    // the canonical encoding (e.g. when `Signed<T>` is embedded inside
+    // a larger message like `SyncMessage`, which hands `try_decode`
+    // the full payload buffer including subsequent items). The
+    // existing bolero proptest covers this with random trailing bytes;
+    // this is a deterministic complement that runs in <1ms.
 
-    /// `try_decode` of canonical bytes with trailing data must succeed
-    /// and the decoded `Signed` must verify. The mutant `< -> >` flips
-    /// the bounds check and turns the trailing-bytes-OK case into an
-    /// error.
+    /// `try_decode` of canonical bytes followed by arbitrary trailing
+    /// data must succeed, truncate to the canonical length, and
+    /// verify cleanly.
     #[test]
     fn try_decode_succeeds_with_trailing_bytes() {
-        let canonical = seal_mutant_payload([42u8; 32], 0xABCD);
+        let canonical = seal_payload([42u8; 32], 0xABCD);
         let canonical_len = canonical.len();
         let mut with_trailing = canonical.clone();
         with_trailing.extend_from_slice(&[0xFF; 256]);
 
-        let signed = Signed::<MutantPayload>::try_decode(with_trailing)
+        let signed = Signed::<Payload>::try_decode(with_trailing)
             .expect("decode must succeed when extra bytes trail the canonical encoding");
         assert_eq!(
             signed.as_bytes().len(),
@@ -999,29 +969,19 @@ mod mutant_coverage {
 
     // ── Hash + PartialOrd implementations ─────────────────────────────
     //
-    // Mutants killed:
-    //   - signed.rs:392 replace <impl Hash for Signed<T>>::hash with ()
-    //   - signed.rs:398 replace <impl PartialOrd for Signed<T>>::partial_cmp
-    //     -> Option<Ordering> with None
-    //
-    // `Hash` and `PartialOrd` are required for using these types as
-    // keys in `BTreeMap` / `HashMap` and for ordering. A no-op `hash`
-    // body collides every value into the same bucket (a real
-    // performance regression), and a `partial_cmp` that always returns
-    // `None` makes `BTreeMap` insertion unpredictable.
+    // `Hash` and `PartialOrd` are required for using `Signed<T>` as
+    // keys in `BTreeMap` / `HashMap` and for ordering. Pin both
+    // contracts deterministically.
 
     /// `Signed<T>`'s `Hash` impl must produce different hashes for
-    /// different signed values. A `hash` body replaced with `()`
-    /// hashes nothing, so all values collide into a single bucket.
+    /// different signed values.
     #[test]
     fn hash_distinguishes_different_values() {
         use core::hash::{BuildHasher as _, Hasher as _};
         use std::collections::hash_map::RandomState;
 
-        let a = Signed::<MutantPayload>::try_decode(seal_mutant_payload([5u8; 32], 100))
-            .expect("decode a");
-        let b = Signed::<MutantPayload>::try_decode(seal_mutant_payload([5u8; 32], 200))
-            .expect("decode b");
+        let a = Signed::<Payload>::try_decode(seal_payload([5u8; 32], 100)).expect("decode a");
+        let b = Signed::<Payload>::try_decode(seal_payload([5u8; 32], 200)).expect("decode b");
 
         let builder = RandomState::new();
         let mut ha = builder.build_hasher();
@@ -1032,19 +992,16 @@ mod mutant_coverage {
         assert_ne!(
             ha.finish(),
             hb.finish(),
-            "Signed::hash must distinguish different signed values; a no-op body collides everything to 0"
+            "Signed::hash must distinguish different signed values"
         );
     }
 
     /// `Signed<T>`'s `PartialOrd` must produce `Some(_)` for any two
-    /// values (total order via `Ord`). A body replaced with `None`
-    /// breaks every `BTreeMap` / sorted-collection use.
+    /// values, since `Ord` defines a total order.
     #[test]
     fn partial_cmp_is_total() {
-        let a = Signed::<MutantPayload>::try_decode(seal_mutant_payload([6u8; 32], 1))
-            .expect("decode a");
-        let b = Signed::<MutantPayload>::try_decode(seal_mutant_payload([6u8; 32], 2))
-            .expect("decode b");
+        let a = Signed::<Payload>::try_decode(seal_payload([6u8; 32], 1)).expect("decode a");
+        let b = Signed::<Payload>::try_decode(seal_payload([6u8; 32], 2)).expect("decode b");
 
         assert!(
             a.partial_cmp(&a).is_some(),
@@ -1067,19 +1024,13 @@ mod mutant_coverage {
 
     // ── Free-standing MIN_SIGNED_SIZE constant ───────────────────────
     //
-    // Mutants killed:
-    //   - signed.rs:50 replace + with * (both occurrences in the
-    //     expression `SCHEMA_SIZE + VERIFYING_KEY_SIZE + SIGNATURE_SIZE`)
-    //
     // The constant is unused in-crate (`T::MIN_SIGNED_SIZE` is what
     // code uses) but is part of the public API. Pin its value with an
-    // explicit assertion so the constant doesn't silently drift under
-    // a refactor.
+    // explicit assertion so it doesn't silently drift under a
+    // refactor.
 
     /// `signed::MIN_SIGNED_SIZE` is the sum of the three layout
-    /// constants. A mutant replacing `+` with `*` produces a vastly
-    /// different number (e.g., `4 * 32 * 64 = 8192`), so the assertion
-    /// fires.
+    /// constants.
     #[test]
     fn min_signed_size_constant_is_sum_of_layout_parts() {
         let expected = SCHEMA_SIZE + VERIFYING_KEY_SIZE + SIGNATURE_SIZE;

--- a/subduction_crypto/src/verified_signature.rs
+++ b/subduction_crypto/src/verified_signature.rs
@@ -184,3 +184,133 @@ impl<T: Schema + EncodeFields + DecodeFields + Ord> Ord for VerifiedSignature<T>
         }
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod mutant_coverage {
+    //! Deterministic mutant-coverage tests for [`VerifiedSignature<T>`].
+
+    use alloc::vec::Vec;
+
+    use ed25519_dalek::{Signer as _, SigningKey};
+    use sedimentree_core::codec::{
+        decode::{self, DecodeFields},
+        encode::{self, EncodeFields},
+        error::DecodeError,
+        schema::{self, Schema},
+    };
+
+    use super::VerifiedSignature;
+    use crate::signed::{SCHEMA_SIZE, SIGNATURE_SIZE, Signed, VERIFYING_KEY_SIZE};
+
+    /// Mirror of `signed::mutant_coverage::MutantPayload` with a
+    /// distinct schema byte (`'V'`) so each module's test fixtures stay
+    /// self-contained.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct MutantPayload {
+        value: u64,
+    }
+
+    impl Schema for MutantPayload {
+        const PREFIX: [u8; 2] = schema::SUBDUCTION_PREFIX;
+        const TYPE_BYTE: u8 = b'V'; // 'V' for verified-signature mutant coverage
+        const VERSION: u8 = 0;
+    }
+
+    impl EncodeFields for MutantPayload {
+        fn encode_fields(&self, buf: &mut Vec<u8>) {
+            encode::u64(self.value, buf);
+        }
+
+        fn fields_size(&self) -> usize {
+            8
+        }
+    }
+
+    impl DecodeFields for MutantPayload {
+        const MIN_SIGNED_SIZE: usize = SCHEMA_SIZE + VERIFYING_KEY_SIZE + 8 + SIGNATURE_SIZE;
+
+        fn try_decode_fields(buf: &[u8]) -> Result<(Self, usize), DecodeError> {
+            let value = decode::u64(buf, 0)?;
+            Ok((Self { value }, 8))
+        }
+    }
+
+    fn seal_mutant_payload(key_bytes: [u8; 32], value: u64) -> Vec<u8> {
+        let signing_key = SigningKey::from_bytes(&key_bytes);
+        let issuer = signing_key.verifying_key();
+        let payload = MutantPayload { value };
+
+        let total_size = SCHEMA_SIZE + VERIFYING_KEY_SIZE + payload.fields_size() + SIGNATURE_SIZE;
+        let mut bytes = Vec::with_capacity(total_size);
+
+        bytes.extend_from_slice(&MutantPayload::SCHEMA);
+        bytes.extend_from_slice(issuer.as_bytes());
+        payload.encode_fields(&mut bytes);
+        let signature = signing_key.sign(&bytes);
+        bytes.extend_from_slice(&signature.to_bytes());
+        bytes
+    }
+
+    fn verified(key_bytes: [u8; 32], value: u64) -> VerifiedSignature<MutantPayload> {
+        Signed::<MutantPayload>::try_decode(seal_mutant_payload(key_bytes, value))
+            .expect("decode")
+            .try_verify()
+            .expect("verify")
+    }
+
+    /// `VerifiedSignature<T>::eq` delegates to the underlying
+    /// `Signed<T>`. A `==` → `!=` flip in its body produces the same
+    /// kind of inversion we catch on `Signed`'s own `PartialEq`.
+    #[test]
+    fn partial_eq_distinguishes_different_values() {
+        let a = verified([3u8; 32], 555);
+        let a_again = verified([3u8; 32], 555);
+        let b = verified([3u8; 32], 999);
+
+        assert_eq!(a, a, "self-equality must hold for VerifiedSignature");
+        assert_eq!(
+            a, a_again,
+            "two verified seals of identical content must be equal"
+        );
+        assert_ne!(a, b, "different payloads must verify-equal-distinctly");
+    }
+
+    /// `VerifiedSignature<T>::hash` delegates to the inner `Signed<T>`.
+    /// A no-op body collides every value to a single hash.
+    #[test]
+    fn hash_distinguishes_different_values() {
+        use core::hash::{BuildHasher as _, Hasher as _};
+        use std::collections::hash_map::RandomState;
+
+        let a = verified([7u8; 32], 100);
+        let b = verified([7u8; 32], 200);
+
+        let builder = RandomState::new();
+        let mut ha = builder.build_hasher();
+        let mut hb = builder.build_hasher();
+        core::hash::Hash::hash(&a, &mut ha);
+        core::hash::Hash::hash(&b, &mut hb);
+
+        assert_ne!(
+            ha.finish(),
+            hb.finish(),
+            "VerifiedSignature::hash must distinguish different signed values"
+        );
+    }
+
+    /// `VerifiedSignature<T>::partial_cmp` must produce `Some(_)` for
+    /// any two values (total order under `Ord`). A body returning
+    /// `None` makes `BTreeMap<VerifiedSignature<T>, _>` insertions
+    /// undefined.
+    #[test]
+    fn partial_cmp_is_total() {
+        let a = verified([8u8; 32], 1);
+        let b = verified([8u8; 32], 2);
+
+        assert!(a.partial_cmp(&a).is_some());
+        assert!(a.partial_cmp(&b).is_some());
+        assert!(b.partial_cmp(&a).is_some());
+        assert_ne!(a.partial_cmp(&b), b.partial_cmp(&a));
+    }
+}

--- a/subduction_crypto/src/verified_signature.rs
+++ b/subduction_crypto/src/verified_signature.rs
@@ -187,8 +187,9 @@ impl<T: Schema + EncodeFields + DecodeFields + Ord> Ord for VerifiedSignature<T>
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]
-mod mutant_coverage {
-    //! Deterministic mutant-coverage tests for [`VerifiedSignature<T>`].
+mod tests {
+    //! Deterministic regression tests for [`VerifiedSignature<T>`]
+    //! trait impls.
 
     use alloc::vec::Vec;
 
@@ -203,21 +204,21 @@ mod mutant_coverage {
     use super::VerifiedSignature;
     use crate::signed::{SCHEMA_SIZE, SIGNATURE_SIZE, Signed, VERIFYING_KEY_SIZE};
 
-    /// Mirror of `signed::mutant_coverage::MutantPayload` with a
-    /// distinct schema byte (`'V'`) so each module's test fixtures stay
-    /// self-contained.
+    /// Minimal payload for these tests. Uses a schema byte distinct
+    /// from `signed::regression::Payload` so each module's test
+    /// fixtures stay self-contained.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    struct MutantPayload {
+    struct Payload {
         value: u64,
     }
 
-    impl Schema for MutantPayload {
+    impl Schema for Payload {
         const PREFIX: [u8; 2] = schema::SUBDUCTION_PREFIX;
-        const TYPE_BYTE: u8 = b'V'; // 'V' for verified-signature mutant coverage
+        const TYPE_BYTE: u8 = b'V';
         const VERSION: u8 = 0;
     }
 
-    impl EncodeFields for MutantPayload {
+    impl EncodeFields for Payload {
         fn encode_fields(&self, buf: &mut Vec<u8>) {
             encode::u64(self.value, buf);
         }
@@ -227,7 +228,7 @@ mod mutant_coverage {
         }
     }
 
-    impl DecodeFields for MutantPayload {
+    impl DecodeFields for Payload {
         const MIN_SIGNED_SIZE: usize = SCHEMA_SIZE + VERIFYING_KEY_SIZE + 8 + SIGNATURE_SIZE;
 
         fn try_decode_fields(buf: &[u8]) -> Result<(Self, usize), DecodeError> {
@@ -236,15 +237,15 @@ mod mutant_coverage {
         }
     }
 
-    fn seal_mutant_payload(key_bytes: [u8; 32], value: u64) -> Vec<u8> {
+    fn seal_payload(key_bytes: [u8; 32], value: u64) -> Vec<u8> {
         let signing_key = SigningKey::from_bytes(&key_bytes);
         let issuer = signing_key.verifying_key();
-        let payload = MutantPayload { value };
+        let payload = Payload { value };
 
         let total_size = SCHEMA_SIZE + VERIFYING_KEY_SIZE + payload.fields_size() + SIGNATURE_SIZE;
         let mut bytes = Vec::with_capacity(total_size);
 
-        bytes.extend_from_slice(&MutantPayload::SCHEMA);
+        bytes.extend_from_slice(&Payload::SCHEMA);
         bytes.extend_from_slice(issuer.as_bytes());
         payload.encode_fields(&mut bytes);
         let signature = signing_key.sign(&bytes);
@@ -252,16 +253,15 @@ mod mutant_coverage {
         bytes
     }
 
-    fn verified(key_bytes: [u8; 32], value: u64) -> VerifiedSignature<MutantPayload> {
-        Signed::<MutantPayload>::try_decode(seal_mutant_payload(key_bytes, value))
+    fn verified(key_bytes: [u8; 32], value: u64) -> VerifiedSignature<Payload> {
+        Signed::<Payload>::try_decode(seal_payload(key_bytes, value))
             .expect("decode")
             .try_verify()
             .expect("verify")
     }
 
     /// `VerifiedSignature<T>::eq` delegates to the underlying
-    /// `Signed<T>`. A `==` → `!=` flip in its body produces the same
-    /// kind of inversion we catch on `Signed`'s own `PartialEq`.
+    /// `Signed<T>` and must distinguish different signed values.
     #[test]
     fn partial_eq_distinguishes_different_values() {
         let a = verified([3u8; 32], 555);
@@ -276,8 +276,8 @@ mod mutant_coverage {
         assert_ne!(a, b, "different payloads must verify-equal-distinctly");
     }
 
-    /// `VerifiedSignature<T>::hash` delegates to the inner `Signed<T>`.
-    /// A no-op body collides every value to a single hash.
+    /// `VerifiedSignature<T>::hash` delegates to the inner `Signed<T>`
+    /// and must distinguish different signed values.
     #[test]
     fn hash_distinguishes_different_values() {
         use core::hash::{BuildHasher as _, Hasher as _};
@@ -300,9 +300,7 @@ mod mutant_coverage {
     }
 
     /// `VerifiedSignature<T>::partial_cmp` must produce `Some(_)` for
-    /// any two values (total order under `Ord`). A body returning
-    /// `None` makes `BTreeMap<VerifiedSignature<T>, _>` insertions
-    /// undefined.
+    /// any two values, since `Ord` defines a total order.
     #[test]
     fn partial_cmp_is_total() {
         let a = verified([8u8; 32], 1);


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-Fix failing mutants

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [ ] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [ ] `cargo build --workspace --all-features` succeeds
- [ ] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo +nightly fmt --all -- --check` is clean
- [ ] Public API changes have doc comments
- [ ] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [ ] Required version updates for this release-blocking change have been applied
