### PR TITLE
Clean up `as_batch_sync`

### DIFF
--- a/subduction_cli/src/handler.rs
+++ b/subduction_cli/src/handler.rs
@@ -92,27 +92,6 @@ impl Handler<Sendable, CliConn> for CliHandler {
     type Message = CliWireMessage;
     type HandlerError = CliListenError;
 
-    fn as_batch_sync_response(
-        msg: &CliWireMessage,
-    ) -> Option<&subduction_core::connection::message::BatchSyncResponse> {
-        match msg {
-            CliWireMessage::Sync(sync_msg) => match sync_msg.as_ref() {
-                subduction_core::connection::message::SyncMessage::BatchSyncResponse(resp) => {
-                    Some(resp)
-                }
-                subduction_core::connection::message::SyncMessage::BatchSyncRequest(_)
-                | subduction_core::connection::message::SyncMessage::BlobsRequest { .. }
-                | subduction_core::connection::message::SyncMessage::BlobsResponse { .. }
-                | subduction_core::connection::message::SyncMessage::DataRequestRejected(_)
-                | subduction_core::connection::message::SyncMessage::Fragment { .. }
-                | subduction_core::connection::message::SyncMessage::LooseCommit { .. }
-                | subduction_core::connection::message::SyncMessage::RemoveSubscriptions(_)
-                | subduction_core::connection::message::SyncMessage::HeadsUpdate { .. } => None,
-            },
-            CliWireMessage::Ephemeral(_) | CliWireMessage::Keyhive(_) => None,
-        }
-    }
-
     fn handle<'a>(
         &'a self,
         conn: &'a Authenticated<CliConn, Sendable>,
@@ -185,8 +164,8 @@ mod tests {
     use subduction_core::{
         connection::message::{
             BatchSyncResponse, RemoveSubscriptions, RequestId, SyncMessage, SyncResult,
+            TryAsBatchSyncResponse,
         },
-        handler::Handler,
         peer::id::PeerId,
         remote_heads::RemoteHeads,
         timestamp::TimestampSeconds,
@@ -198,7 +177,6 @@ mod tests {
     };
     use subduction_keyhive::KeyhiveMessage;
 
-    use super::{CliConn, CliHandler};
     use crate::wire::CliWireMessage;
 
     fn test_peer_id() -> PeerId {
@@ -213,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn as_batch_sync_response_extracts_from_sync() {
+    fn try_as_batch_sync_response_extracts_from_sync() {
         let resp = BatchSyncResponse {
             req_id: test_request_id(),
             id: SedimentreeId::new([0xAA; 32]),
@@ -222,24 +200,22 @@ mod tests {
         };
         let msg = CliWireMessage::Sync(Box::new(SyncMessage::BatchSyncResponse(resp.clone())));
 
-        let extracted = <CliHandler as Handler<Sendable, CliConn>>::as_batch_sync_response(&msg);
-        assert_eq!(extracted, Some(&resp));
+        assert_eq!(msg.try_as_batch_sync_response(), Some(&resp));
     }
 
     #[test]
-    fn as_batch_sync_response_none_for_other_sync() {
+    fn try_as_batch_sync_response_none_for_other_sync() {
         let msg = CliWireMessage::Sync(Box::new(SyncMessage::RemoveSubscriptions(
             RemoveSubscriptions {
                 ids: vec![SedimentreeId::new([0xBB; 32])],
             },
         )));
 
-        let extracted = <CliHandler as Handler<Sendable, CliConn>>::as_batch_sync_response(&msg);
-        assert_eq!(extracted, None);
+        assert_eq!(msg.try_as_batch_sync_response(), None);
     }
 
     #[tokio::test]
-    async fn as_batch_sync_response_none_for_ephemeral() {
+    async fn try_as_batch_sync_response_none_for_ephemeral() {
         let signer = MemorySigner::generate();
         let ep = EphemeralPayload {
             id: Topic::new([0xCC; 32]),
@@ -252,15 +228,13 @@ mod tests {
             verified.into_signed(),
         )));
 
-        let extracted = <CliHandler as Handler<Sendable, CliConn>>::as_batch_sync_response(&msg);
-        assert_eq!(extracted, None);
+        assert_eq!(msg.try_as_batch_sync_response(), None);
     }
 
     #[test]
-    fn as_batch_sync_response_none_for_keyhive() {
+    fn try_as_batch_sync_response_none_for_keyhive() {
         let msg = CliWireMessage::Keyhive(KeyhiveMessage::new(vec![0xDE, 0xAD]));
 
-        let extracted = <CliHandler as Handler<Sendable, CliConn>>::as_batch_sync_response(&msg);
-        assert_eq!(extracted, None);
+        assert_eq!(msg.try_as_batch_sync_response(), None);
     }
 }

--- a/subduction_cli/src/wire.rs
+++ b/subduction_cli/src/wire.rs
@@ -12,7 +12,9 @@ use sedimentree_core::codec::{
     encode::Encode,
     error::{DecodeError, InvalidSchema},
 };
-use subduction_core::connection::message::{MESSAGE_SCHEMA, SyncMessage};
+use subduction_core::connection::message::{
+    BatchSyncResponse, MESSAGE_SCHEMA, SyncMessage, TryAsBatchSyncResponse,
+};
 use subduction_ephemeral::message::{EPHEMERAL_SCHEMA, EphemeralMessage};
 use subduction_keyhive::{KEYHIVE_SCHEMA, KeyhiveMessage};
 
@@ -47,6 +49,20 @@ impl From<EphemeralMessage> for CliWireMessage {
 impl From<KeyhiveMessage> for CliWireMessage {
     fn from(msg: KeyhiveMessage) -> Self {
         Self::Keyhive(msg)
+    }
+}
+
+/// Borrow a [`BatchSyncResponse`] from the wire envelope. Returns
+/// `None` for ephemeral or keyhive messages so the [`Subduction`]
+/// listen loop dispatches them through their respective handlers.
+///
+/// [`Subduction`]: subduction_core::subduction::Subduction
+impl TryAsBatchSyncResponse for CliWireMessage {
+    fn try_as_batch_sync_response(&self) -> Option<&BatchSyncResponse> {
+        match self {
+            CliWireMessage::Sync(sync) => sync.try_as_batch_sync_response(),
+            CliWireMessage::Ephemeral(_) | CliWireMessage::Keyhive(_) => None,
+        }
     }
 }
 

--- a/subduction_core/src/connection/message.rs
+++ b/subduction_core/src/connection/message.rs
@@ -37,7 +37,7 @@ use sedimentree_core::{
 };
 use subduction_crypto::signed::Signed;
 
-use crate::peer::id::PeerId;
+use crate::{peer::id::PeerId, remote_heads::RemoteHeads};
 
 /// The API contact messages to be sent over a [`Connection`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -236,6 +236,38 @@ impl From<BatchSyncResponse> for SyncMessage {
     }
 }
 
+/// Fallible borrow of a [`BatchSyncResponse`] from a wire message.
+///
+/// Implementors return `Some(&resp)` when the message _is_ a
+/// `BatchSyncResponse`, or `None` otherwise. The
+/// [`Subduction`](crate::subduction::Subduction) listen loop uses this
+/// to route responses to pending roundtrip callers before dispatching
+/// to the handler.
+///
+/// The `Try` prefix mirrors stdlib `TryFrom`/`TryInto` fallibility; the
+/// `As` suffix mirrors `AsRef`-style borrow semantics. Returning
+/// `Option` (rather than `Result<_, ()>`) keeps the call site terse.
+pub trait TryAsBatchSyncResponse {
+    /// Borrow a [`BatchSyncResponse`] from `self` if `self` contains one.
+    fn try_as_batch_sync_response(&self) -> Option<&BatchSyncResponse>;
+}
+
+impl TryAsBatchSyncResponse for SyncMessage {
+    fn try_as_batch_sync_response(&self) -> Option<&BatchSyncResponse> {
+        match self {
+            SyncMessage::BatchSyncResponse(resp) => Some(resp),
+            SyncMessage::BatchSyncRequest(_)
+            | SyncMessage::BlobsRequest { .. }
+            | SyncMessage::BlobsResponse { .. }
+            | SyncMessage::DataRequestRejected(_)
+            | SyncMessage::Fragment { .. }
+            | SyncMessage::LooseCommit { .. }
+            | SyncMessage::RemoveSubscriptions(_)
+            | SyncMessage::HeadsUpdate { .. } => None,
+        }
+    }
+}
+
 /// A request to remove subscriptions from specific sedimentrees.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(not(feature = "std"), derive(Hash))]
@@ -269,8 +301,6 @@ impl From<DataRequestRejected> for SyncMessage {
         SyncMessage::DataRequestRejected(rejection)
     }
 }
-
-use crate::remote_heads::RemoteHeads;
 
 /// A unique identifier for a particular request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/subduction_core/src/connection/message.rs
+++ b/subduction_core/src/connection/message.rs
@@ -1344,6 +1344,139 @@ mod tests {
         }
     }
 
+    mod try_as_batch_sync_response_impl {
+        use super::*;
+        use future_form::Sendable;
+        use subduction_crypto::{signed::Signed, signer::memory::MemorySigner};
+
+        fn sample_response() -> BatchSyncResponse {
+            BatchSyncResponse {
+                req_id: RequestId {
+                    requestor: PeerId::new([7u8; 32]),
+                    nonce: 99,
+                },
+                id: SedimentreeId::new([1u8; 32]),
+                result: SyncResult::NotFound,
+                responder_heads: RemoteHeads::default(),
+            }
+        }
+
+        #[test]
+        fn batch_sync_response_returns_some_with_same_response() {
+            let resp = sample_response();
+            let msg = SyncMessage::BatchSyncResponse(resp.clone());
+            assert_eq!(msg.try_as_batch_sync_response(), Some(&resp));
+        }
+
+        #[test]
+        fn batch_sync_request_returns_none() {
+            let msg = SyncMessage::BatchSyncRequest(BatchSyncRequest {
+                id: SedimentreeId::new([2u8; 32]),
+                req_id: RequestId {
+                    requestor: PeerId::new([8u8; 32]),
+                    nonce: 1,
+                },
+                fingerprint_summary: FingerprintSummary::new(
+                    FingerprintSeed::new(0, 0),
+                    BTreeSet::new(),
+                    BTreeSet::new(),
+                ),
+                subscribe: false,
+            });
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+
+        #[test]
+        fn blobs_request_returns_none() {
+            let msg = SyncMessage::BlobsRequest {
+                id: SedimentreeId::new([3u8; 32]),
+                digests: vec![Digest::force_from_bytes([4u8; 32])],
+            };
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+
+        #[test]
+        fn blobs_response_returns_none() {
+            let msg = SyncMessage::BlobsResponse {
+                id: SedimentreeId::new([5u8; 32]),
+                blobs: vec![Blob::new(Vec::from([1u8; 16]))],
+            };
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+
+        #[test]
+        fn data_request_rejected_returns_none() {
+            let msg = SyncMessage::DataRequestRejected(DataRequestRejected {
+                id: SedimentreeId::new([6u8; 32]),
+            });
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+
+        #[tokio::test]
+        async fn loose_commit_returns_none() {
+            let signer = MemorySigner::from_bytes(&[42u8; 32]);
+            let id = SedimentreeId::new([7u8; 32]);
+            let blob = Blob::new(Vec::new());
+            let commit = LooseCommit::new(
+                id,
+                CommitId::new([0x42; 32]),
+                BTreeSet::new(),
+                sedimentree_core::blob::BlobMeta::new(&blob),
+            );
+            let signed_commit = Signed::seal::<Sendable, _>(&signer, commit)
+                .await
+                .into_signed();
+            let msg = SyncMessage::LooseCommit {
+                id,
+                commit: signed_commit,
+                blob: Blob::new(Vec::from([3u8; 16])),
+                sender_heads: RemoteHeads::default(),
+            };
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+
+        #[tokio::test]
+        async fn fragment_returns_none() {
+            let signer = MemorySigner::from_bytes(&[42u8; 32]);
+            let id = SedimentreeId::new([8u8; 32]);
+            let blob = Blob::new(Vec::new());
+            let fragment = Fragment::new(
+                id,
+                CommitId::new([2u8; 32]),
+                BTreeSet::new(),
+                &[],
+                sedimentree_core::blob::BlobMeta::new(&blob),
+            );
+            let signed_fragment = Signed::seal::<Sendable, _>(&signer, fragment)
+                .await
+                .into_signed();
+            let msg = SyncMessage::Fragment {
+                id,
+                fragment: signed_fragment,
+                blob: Blob::new(Vec::from([3u8; 16])),
+                sender_heads: RemoteHeads::default(),
+            };
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+
+        #[test]
+        fn remove_subscriptions_returns_none() {
+            let msg = SyncMessage::RemoveSubscriptions(RemoveSubscriptions {
+                ids: vec![SedimentreeId::new([9u8; 32])],
+            });
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+
+        #[test]
+        fn heads_update_returns_none() {
+            let msg = SyncMessage::HeadsUpdate {
+                id: SedimentreeId::new([10u8; 32]),
+                heads: RemoteHeads::default(),
+            };
+            assert_eq!(msg.try_as_batch_sync_response(), None);
+        }
+    }
+
     #[cfg(all(test, feature = "std", feature = "bolero"))]
     mod proptests {
         use super::*;
@@ -1365,6 +1498,24 @@ mod tests {
                 .for_each(|resp| {
                     let msg: SyncMessage = resp.clone().into();
                     assert_eq!(msg.request_id(), Some(resp.req_id));
+                });
+        }
+
+        /// `try_as_batch_sync_response().is_some()` iff the variant is
+        /// `BatchSyncResponse`, and on `Some(r)` returns the exact contained
+        /// response. Guards the routing predicate at `subduction.rs:319`
+        /// against future variants that quietly miss the match.
+        #[test]
+        fn prop_try_as_batch_sync_response_iff_variant() {
+            bolero::check!()
+                .with_arbitrary::<SyncMessage>()
+                .for_each(|msg| {
+                    let result = msg.try_as_batch_sync_response();
+                    if let SyncMessage::BatchSyncResponse(expected) = msg {
+                        assert_eq!(result, Some(expected));
+                    } else {
+                        assert_eq!(result, None);
+                    }
                 });
         }
 

--- a/subduction_core/src/handler.rs
+++ b/subduction_core/src/handler.rs
@@ -54,7 +54,7 @@ use future_form::FutureForm;
 use sedimentree_core::codec::{decode::Decode, encode::Encode};
 
 use crate::{
-    authenticated::Authenticated, connection::message::BatchSyncResponse, peer::id::PeerId,
+    authenticated::Authenticated, connection::message::TryAsBatchSyncResponse, peer::id::PeerId,
 };
 
 /// A handler for messages received from authenticated peers.
@@ -84,7 +84,20 @@ pub trait Handler<Async: FutureForm, Conn: Clone> {
     /// [`SyncMessage`](crate::connection::message::SyncMessage).
     /// Composed handlers typically use a wire envelope type (e.g.,
     /// `WireMessage`) and dispatch to sub-handlers via pattern matching.
-    type Message: Encode + Decode + Clone + Send + core::fmt::Debug + 'static;
+    ///
+    /// The
+    /// [`TryAsBatchSyncResponse`](crate::connection::message::TryAsBatchSyncResponse)
+    /// supertrait lets the
+    /// [`Subduction`](crate::subduction::Subduction) listen loop route
+    /// `BatchSyncResponse`s to pending roundtrip callers without a
+    /// bespoke trait method.
+    type Message: Encode
+        + Decode
+        + Clone
+        + Send
+        + core::fmt::Debug
+        + 'static
+        + TryAsBatchSyncResponse;
 
     /// Error type returned by the handler.
     type HandlerError: core::error::Error;
@@ -101,26 +114,6 @@ pub trait Handler<Async: FutureForm, Conn: Clone> {
         conn: &'a Authenticated<Conn, Async>,
         message: Self::Message,
     ) -> Async::Future<'a, Result<(), Self::HandlerError>>;
-
-    /// Extract a [`BatchSyncResponse`] from a message, if present.
-    ///
-    /// Used by the `Subduction` listen loop to route responses to pending
-    /// roundtrip callers before dispatching to the handler.
-    ///
-    /// The default returns `None` (no response extraction). Override this
-    /// for message types that can contain `BatchSyncResponse` —
-    /// e.g. `SyncMessage`, `WireMessage`.
-    fn as_batch_sync_response(_msg: &Self::Message) -> Option<&BatchSyncResponse> {
-        None
-    }
-
-    /// Check whether a message is a [`BatchSyncResponse`].
-    ///
-    /// Used by the connection manager to route responses through a dedicated
-    /// unbounded channel, bypassing the bounded request queue.
-    fn is_batch_sync_response_msg(msg: &Self::Message) -> bool {
-        Self::as_batch_sync_response(msg).is_some()
-    }
 
     /// Called when a peer's last connection drops.
     ///

--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -257,20 +257,6 @@ impl<Async: FutureForm, Store, Conn, Auth, Metric, R, const SHARDS: usize> Handl
     type Message = SyncMessage;
     type HandlerError = ListenError<Async, Store, Conn, SyncMessage>;
 
-    fn as_batch_sync_response(msg: &Self::Message) -> Option<&BatchSyncResponse> {
-        match msg {
-            SyncMessage::BatchSyncResponse(resp) => Some(resp),
-            SyncMessage::BatchSyncRequest(_)
-            | SyncMessage::BlobsRequest { .. }
-            | SyncMessage::BlobsResponse { .. }
-            | SyncMessage::DataRequestRejected(_)
-            | SyncMessage::Fragment { .. }
-            | SyncMessage::LooseCommit { .. }
-            | SyncMessage::RemoveSubscriptions(_)
-            | SyncMessage::HeadsUpdate { .. } => None,
-        }
-    }
-
     fn handle<'a>(
         &'a self,
         conn: &'a Authenticated<Conn, Async>,

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -73,7 +73,7 @@ use crate::{
         manager::{Command, ConnectionManager, RunManager, Spawn},
         message::{
             BatchSyncRequest, BatchSyncResponse, DataRequestRejected, RequestedData, SyncDiff,
-            SyncMessage, SyncResult,
+            SyncMessage, SyncResult, TryAsBatchSyncResponse,
         },
         stats::{SendCount, SyncStats},
     },
@@ -316,7 +316,7 @@ where
             manager_receiver,
             queue_sender,
             response_sender,
-            Hdl::is_batch_sync_response_msg,
+            |msg: &Hdl::Message| msg.try_as_batch_sync_response().is_some(),
             closed_sender,
         );
 
@@ -572,7 +572,7 @@ where
                 resp_result = self.response_queue.recv().fuse() => {
                     if let Ok((conn, msg)) = resp_result {
                         let peer_id = conn.peer_id();
-                        if let Some(resp) = Hdl::as_batch_sync_response(&msg) {
+                        if let Some(resp) = msg.try_as_batch_sync_response() {
                             let muxes_for_peer = {
                                 let multiplexers = self.multiplexers.lock().await;
                                 multiplexers.get(&peer_id).cloned()
@@ -625,7 +625,7 @@ where
                         // Safety net: if a BatchSyncResponse ended up in the
                         // request queue (should go through response_queue),
                         // route it to the multiplexer rather than the handler.
-                        if let Some(resp) = Hdl::as_batch_sync_response(&msg) {
+                        if let Some(resp) = msg.try_as_batch_sync_response() {
                             tracing::debug!(
                                 "BatchSyncResponse from peer {peer_id} arrived via msg_queue \
                                  (expected response_queue) — routing to multiplexer"

--- a/subduction_ephemeral/src/composed.rs
+++ b/subduction_ephemeral/src/composed.rs
@@ -6,7 +6,7 @@
 use alloc::boxed::Box;
 use core::fmt::Debug;
 
-use future_form::{FutureForm, Sendable};
+use future_form::{FutureForm, Local, Sendable, future_form};
 use sedimentree_core::{
     codec::{decode::Decode, encode::Encode},
     id::SedimentreeId,
@@ -164,13 +164,22 @@ where
     }
 }
 
-impl<C, SyncH, EphH, W> Handler<Sendable, C> for ComposedHandler<SyncH, EphH, W>
+#[future_form(
+    Sendable where
+        C: Clone + Send + Sync + 'static,
+        SyncH: Handler<Sendable, C, Message = SyncMessage> + Send + Sync,
+        SyncH::HandlerError: Send + 'static,
+        EphH: Handler<Sendable, C, Message = EphemeralMessage> + Send + Sync,
+        EphH::HandlerError: Send + 'static,
+    Local where
+        C: Clone + 'static,
+        SyncH: Handler<Local, C, Message = SyncMessage>,
+        EphH: Handler<Local, C, Message = EphemeralMessage>,
+)]
+impl<Async: FutureForm, C, SyncH, EphH, W> Handler<Async, C> for ComposedHandler<SyncH, EphH, W>
 where
-    C: Clone + Send + Sync + 'static,
-    SyncH: Handler<Sendable, C, Message = SyncMessage> + Send + Sync,
-    SyncH::HandlerError: Send + 'static,
-    EphH: Handler<Sendable, C, Message = EphemeralMessage> + Send + Sync,
-    EphH::HandlerError: Send + 'static,
+    SyncH: Handler<Async, C, Message = SyncMessage>,
+    EphH: Handler<Async, C, Message = EphemeralMessage>,
     W: WireEnvelope,
 {
     type Message = W;
@@ -182,10 +191,10 @@ where
 
     fn handle<'a>(
         &'a self,
-        conn: &'a Authenticated<C, Sendable>,
+        conn: &'a Authenticated<C, Async>,
         message: W,
-    ) -> futures::future::BoxFuture<'a, Result<(), Self::HandlerError>> {
-        Box::pin(async move {
+    ) -> Async::Future<'a, Result<(), Self::HandlerError>> {
+        Async::from_future(async move {
             match message.dispatch() {
                 Dispatched::Sync(msg) => self
                     .sync
@@ -201,52 +210,8 @@ where
         })
     }
 
-    fn on_peer_disconnect(&self, peer: PeerId) -> futures::future::BoxFuture<'_, ()> {
-        Box::pin(async move {
-            self.sync.on_peer_disconnect(peer).await;
-            self.ephemeral.on_peer_disconnect(peer).await;
-        })
-    }
-}
-
-// Local impl — same logic, different boxing
-impl<C, SyncH, EphH, W> Handler<future_form::Local, C> for ComposedHandler<SyncH, EphH, W>
-where
-    C: Clone + 'static,
-    SyncH: Handler<future_form::Local, C, Message = SyncMessage>,
-    EphH: Handler<future_form::Local, C, Message = EphemeralMessage>,
-    W: WireEnvelope,
-{
-    type Message = W;
-    type HandlerError = ComposedHandlerError<SyncH::HandlerError, EphH::HandlerError>;
-
-    fn as_batch_sync_response(msg: &W) -> Option<&BatchSyncResponse> {
-        msg.as_batch_sync_response()
-    }
-
-    fn handle<'a>(
-        &'a self,
-        conn: &'a Authenticated<C, future_form::Local>,
-        message: W,
-    ) -> futures::future::LocalBoxFuture<'a, Result<(), Self::HandlerError>> {
-        Box::pin(async move {
-            match message.dispatch() {
-                Dispatched::Sync(msg) => self
-                    .sync
-                    .handle(conn, *msg)
-                    .await
-                    .map_err(ComposedHandlerError::Sync),
-                Dispatched::Ephemeral(msg) => self
-                    .ephemeral
-                    .handle(conn, msg)
-                    .await
-                    .map_err(ComposedHandlerError::Ephemeral),
-            }
-        })
-    }
-
-    fn on_peer_disconnect(&self, peer: PeerId) -> futures::future::LocalBoxFuture<'_, ()> {
-        Box::pin(async move {
+    fn on_peer_disconnect(&self, peer: PeerId) -> Async::Future<'_, ()> {
+        Async::from_future(async move {
             self.sync.on_peer_disconnect(peer).await;
             self.ephemeral.on_peer_disconnect(peer).await;
         })

--- a/subduction_ephemeral/src/composed.rs
+++ b/subduction_ephemeral/src/composed.rs
@@ -13,10 +13,7 @@ use sedimentree_core::{
 };
 use subduction_core::{
     authenticated::Authenticated,
-    connection::{
-        Connection,
-        message::{BatchSyncResponse, SyncMessage},
-    },
+    connection::{Connection, message::SyncMessage},
     handler::Handler,
     peer::id::PeerId,
     remote_heads::{RemoteHeads, RemoteHeadsNotifier},
@@ -40,11 +37,14 @@ pub enum Dispatched {
 /// Trait for wire envelope types that can be dispatched to sub-handlers.
 ///
 /// Implement this on your wire message enum (e.g., `CliWireMessage`,
-/// `WireMessage`) to enable [`ComposedHandler`] dispatch.
+/// `WireMessage`) to enable [`ComposedHandler`] dispatch. The
+/// [`TryAsBatchSyncResponse`](subduction_core::connection::message::TryAsBatchSyncResponse)
+/// supertrait is required by [`Handler::Message`].
 pub trait WireEnvelope:
     sedimentree_core::codec::encode::Encode
     + sedimentree_core::codec::decode::Decode
     + From<SyncMessage>
+    + subduction_core::connection::message::TryAsBatchSyncResponse
     + Clone
     + Send
     + Debug
@@ -52,9 +52,6 @@ pub trait WireEnvelope:
 {
     /// Dispatch this message into its sub-handler variant.
     fn dispatch(self) -> Dispatched;
-
-    /// Extract a [`BatchSyncResponse`] reference for roundtrip routing.
-    fn as_batch_sync_response(&self) -> Option<&BatchSyncResponse>;
 }
 
 /// Composed handler that dispatches to sync and ephemeral sub-handlers.
@@ -184,10 +181,6 @@ where
 {
     type Message = W;
     type HandlerError = ComposedHandlerError<SyncH::HandlerError, EphH::HandlerError>;
-
-    fn as_batch_sync_response(msg: &W) -> Option<&BatchSyncResponse> {
-        msg.as_batch_sync_response()
-    }
 
     fn handle<'a>(
         &'a self,

--- a/subduction_ephemeral/src/message.rs
+++ b/subduction_ephemeral/src/message.rs
@@ -49,7 +49,10 @@ use sedimentree_core::codec::{
     error::{DecodeError, InvalidEnumTag, InvalidSchema, SizeMismatch},
     schema::{self, Schema},
 };
-use subduction_core::timestamp::TimestampSeconds;
+use subduction_core::{
+    connection::message::{BatchSyncResponse, TryAsBatchSyncResponse},
+    timestamp::TimestampSeconds,
+};
 use subduction_crypto::signed::Signed;
 
 use crate::{
@@ -202,6 +205,17 @@ pub enum EphemeralMessage {
         /// The topics that were rejected.
         topics: NonEmpty<Topic>,
     },
+}
+
+/// Ephemeral messages are never `BatchSyncResponse`s; this always
+/// returns `None` so the [`Subduction`] listen loop dispatches the
+/// message through its ephemeral handler.
+///
+/// [`Subduction`]: subduction_core::subduction::Subduction
+impl TryAsBatchSyncResponse for EphemeralMessage {
+    fn try_as_batch_sync_response(&self) -> Option<&BatchSyncResponse> {
+        None
+    }
 }
 
 impl Encode for EphemeralMessage {

--- a/subduction_ephemeral/tests/composed_handler.rs
+++ b/subduction_ephemeral/tests/composed_handler.rs
@@ -1,7 +1,8 @@
 //! Unit tests for [`ComposedHandler`].
 //!
-//! Uses lightweight mock handlers to verify dispatch, `as_batch_sync_response`
-//! extraction, and `on_peer_disconnect` fan-out.
+//! Uses lightweight mock handlers to verify dispatch,
+//! `try_as_batch_sync_response` extraction, and `on_peer_disconnect`
+//! fan-out.
 
 #![allow(clippy::expect_used, clippy::panic, clippy::indexing_slicing)]
 
@@ -18,7 +19,7 @@ use sedimentree_core::{
 use subduction_core::{
     authenticated::Authenticated,
     connection::{
-        message::{BatchSyncResponse, RequestId, SyncMessage, SyncResult},
+        message::{BatchSyncResponse, RequestId, SyncMessage, SyncResult, TryAsBatchSyncResponse},
         test_utils::ChannelMockConnection,
     },
     handler::Handler,
@@ -103,28 +104,20 @@ impl Decode for TestWireMessage {
     }
 }
 
+impl subduction_core::connection::message::TryAsBatchSyncResponse for TestWireMessage {
+    fn try_as_batch_sync_response(&self) -> Option<&BatchSyncResponse> {
+        match self {
+            Self::Sync(msg) => msg.try_as_batch_sync_response(),
+            Self::Ephemeral(_) => None,
+        }
+    }
+}
+
 impl WireEnvelope for TestWireMessage {
     fn dispatch(self) -> Dispatched {
         match self {
             Self::Sync(msg) => Dispatched::Sync(msg),
             Self::Ephemeral(msg) => Dispatched::Ephemeral(msg),
-        }
-    }
-
-    fn as_batch_sync_response(&self) -> Option<&BatchSyncResponse> {
-        match self {
-            Self::Sync(msg) => match msg.as_ref() {
-                SyncMessage::BatchSyncResponse(resp) => Some(resp),
-                SyncMessage::BatchSyncRequest(_)
-                | SyncMessage::BlobsRequest { .. }
-                | SyncMessage::BlobsResponse { .. }
-                | SyncMessage::DataRequestRejected(_)
-                | SyncMessage::Fragment { .. }
-                | SyncMessage::LooseCommit { .. }
-                | SyncMessage::RemoveSubscriptions(_)
-                | SyncMessage::HeadsUpdate { .. } => None,
-            },
-            Self::Ephemeral(_) => None,
         }
     }
 }
@@ -156,20 +149,6 @@ impl Handler<Sendable, TestConn> for TrackingSyncHandler {
                 .expect("tracking channel open");
             Ok(())
         })
-    }
-
-    fn as_batch_sync_response(msg: &SyncMessage) -> Option<&BatchSyncResponse> {
-        match msg {
-            SyncMessage::BatchSyncResponse(resp) => Some(resp),
-            SyncMessage::BatchSyncRequest(_)
-            | SyncMessage::BlobsRequest { .. }
-            | SyncMessage::BlobsResponse { .. }
-            | SyncMessage::DataRequestRejected(_)
-            | SyncMessage::Fragment { .. }
-            | SyncMessage::LooseCommit { .. }
-            | SyncMessage::RemoveSubscriptions(_)
-            | SyncMessage::HeadsUpdate { .. } => None,
-        }
     }
 
     fn on_peer_disconnect(&self, peer: PeerId) -> futures::future::BoxFuture<'_, ()> {
@@ -315,7 +294,7 @@ async fn dispatch_ephemeral_message_to_ephemeral_handler() -> TestResult {
 }
 
 #[test]
-fn as_batch_sync_response_extracts_from_sync() {
+fn try_as_batch_sync_response_extracts_from_sync() {
     let req_id = test_request_id();
     let resp = BatchSyncResponse {
         req_id,
@@ -325,44 +304,26 @@ fn as_batch_sync_response_extracts_from_sync() {
     };
 
     let wire = TestWireMessage::Sync(Box::new(SyncMessage::BatchSyncResponse(resp.clone())));
-    let extracted =
-        <ComposedHandler<TrackingSyncHandler, TrackingEphemeralHandler, TestWireMessage> as Handler<
-            Sendable,
-            TestConn,
-        >>::as_batch_sync_response(&wire);
-
-    assert_eq!(extracted, Some(&resp));
+    assert_eq!(wire.try_as_batch_sync_response(), Some(&resp));
 }
 
 #[test]
-fn as_batch_sync_response_returns_none_for_other_sync() {
+fn try_as_batch_sync_response_returns_none_for_other_sync() {
     let wire = TestWireMessage::Sync(Box::new(SyncMessage::BlobsRequest {
         id: SedimentreeId::new([0xCC; 32]),
         digests: vec![],
     }));
 
-    let extracted =
-        <ComposedHandler<TrackingSyncHandler, TrackingEphemeralHandler, TestWireMessage> as Handler<
-            Sendable,
-            TestConn,
-        >>::as_batch_sync_response(&wire);
-
-    assert_eq!(extracted, None);
+    assert_eq!(wire.try_as_batch_sync_response(), None);
 }
 
 #[test]
-fn as_batch_sync_response_returns_none_for_ephemeral() {
+fn try_as_batch_sync_response_returns_none_for_ephemeral() {
     let wire = TestWireMessage::Ephemeral(EphemeralMessage::Subscribe {
         topics: NonEmpty::new(Topic::new([0xDD; 32])),
     });
 
-    let extracted =
-        <ComposedHandler<TrackingSyncHandler, TrackingEphemeralHandler, TestWireMessage> as Handler<
-            Sendable,
-            TestConn,
-        >>::as_batch_sync_response(&wire);
-
-    assert_eq!(extracted, None);
+    assert_eq!(wire.try_as_batch_sync_response(), None);
 }
 
 #[tokio::test]

--- a/subduction_keyhive/Cargo.toml
+++ b/subduction_keyhive/Cargo.toml
@@ -22,7 +22,7 @@ ciborium = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 future_form = { workspace = true }
-subduction_core = { workspace = true, optional = true }
+subduction_core = { workspace = true }
 subduction_crypto = { workspace = true, optional = true }
 keyhive_core = { workspace = true }
 keyhive_crypto = { workspace = true }
@@ -39,7 +39,7 @@ tracing = { workspace = true }
 [features]
 default = []
 bolero = ["dep:bolero"]
-handler = ["dep:async-channel", "dep:subduction_core", "dep:subduction_crypto", "std"]
+handler = ["dep:async-channel", "dep:subduction_crypto", "std"]
 runtime = ["handler", "serde", "dep:tokio", "dep:tokio-util"]
 serde = ["dep:serde", "dep:serde_bytes", "dep:serde_json", "std"]
 std = ["thiserror/std"]

--- a/subduction_keyhive/src/handler.rs
+++ b/subduction_keyhive/src/handler.rs
@@ -19,7 +19,6 @@ use core::marker::PhantomData;
 use rand::rngs::OsRng;
 
 use crate::{KeyhiveMessage, SignedMessage, signed_message::CborError};
-
 // ── Command enum ────────────────────────────────────────────────────────
 
 /// Commands sent from the handle to the actor.

--- a/subduction_keyhive/src/wire.rs
+++ b/subduction_keyhive/src/wire.rs
@@ -23,6 +23,7 @@ use sedimentree_core::codec::{
     encode::Encode,
     error::{DecodeError, InvalidSchema, SizeMismatch},
 };
+use subduction_core::connection::message::{BatchSyncResponse, TryAsBatchSyncResponse};
 
 #[cfg(all(feature = "serde", feature = "std"))]
 use crate::signed_message::SignedMessage;
@@ -82,6 +83,14 @@ impl KeyhiveMessage {
     #[must_use]
     pub fn into_payload(self) -> Vec<u8> {
         self.payload
+    }
+}
+
+/// Keyhive messages are never `BatchSyncResponse`s; this always
+/// returns `None`.
+impl TryAsBatchSyncResponse for KeyhiveMessage {
+    fn try_as_batch_sync_response(&self) -> Option<&BatchSyncResponse> {
+        None
     }
 }
 

--- a/subduction_wasm/src/handler.rs
+++ b/subduction_wasm/src/handler.rs
@@ -10,7 +10,7 @@ use js_sys::Uint8Array;
 use sedimentree_core::id::SedimentreeId;
 use subduction_core::{
     authenticated::Authenticated,
-    connection::message::{BatchSyncResponse, SyncMessage},
+    connection::message::SyncMessage,
     handler::{Handler, sync::SyncHandler},
     peer::id::PeerId,
     remote_heads::{RemoteHeads, RemoteHeadsNotifier},
@@ -192,19 +192,6 @@ impl RemoteHeadsNotifier for WasmComposedHandler {
 impl Handler<Local, WasmConn> for WasmComposedHandler {
     type Message = WireMessage;
     type HandlerError = WasmListenError;
-
-    fn as_batch_sync_response(msg: &WireMessage) -> Option<&BatchSyncResponse> {
-        match msg {
-            WireMessage::Sync(sync_msg) => {
-                if let SyncMessage::BatchSyncResponse(resp) = sync_msg.as_ref() {
-                    Some(resp)
-                } else {
-                    None
-                }
-            }
-            WireMessage::Ephemeral(_) | WireMessage::Keyhive(_) => None,
-        }
-    }
 
     fn handle<'a>(
         &'a self,

--- a/subduction_wasm/src/wire.rs
+++ b/subduction_wasm/src/wire.rs
@@ -12,7 +12,9 @@ use sedimentree_core::codec::{
     encode::Encode,
     error::{DecodeError, InvalidSchema},
 };
-use subduction_core::connection::message::{MESSAGE_SCHEMA, SyncMessage};
+use subduction_core::connection::message::{
+    BatchSyncResponse, MESSAGE_SCHEMA, SyncMessage, TryAsBatchSyncResponse,
+};
 use subduction_ephemeral::message::{EPHEMERAL_SCHEMA, EphemeralMessage};
 use subduction_keyhive::{KEYHIVE_SCHEMA, KeyhiveMessage};
 
@@ -49,6 +51,20 @@ impl From<EphemeralMessage> for WireMessage {
 impl From<KeyhiveMessage> for WireMessage {
     fn from(msg: KeyhiveMessage) -> Self {
         Self::Keyhive(msg)
+    }
+}
+
+/// Borrow a [`BatchSyncResponse`] from the wire envelope. Returns
+/// `None` for ephemeral or keyhive messages so the [`Subduction`]
+/// listen loop dispatches them through their respective handlers.
+///
+/// [`Subduction`]: subduction_core::subduction::Subduction
+impl TryAsBatchSyncResponse for WireMessage {
+    fn try_as_batch_sync_response(&self) -> Option<&BatchSyncResponse> {
+        match self {
+            WireMessage::Sync(sync) => sync.try_as_batch_sync_response(),
+            WireMessage::Ephemeral(_) | WireMessage::Keyhive(_) => None,
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [ ] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [ ] `cargo build --workspace --all-features` succeeds
- [ ] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo +nightly fmt --all -- --check` is clean
- [ ] Public API changes have doc comments
- [ ] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [ ] Required version updates for this release-blocking change have been applied
