### PR TITLE
Propagate subscription requests upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,19 +283,18 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "automerge"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aab56635599ee2e9df28d9ce180c155b8dbcdd96e4c3f62895fc6a44137d328"
+version = "0.9.0"
+source = "git+https://github.com/automerge/automerge?branch=fragments#57c39ea43d6d7cf1c88447718872119d4cd16341"
 dependencies = [
  "cfg-if 1.0.4",
  "flate2",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hex",
  "hexane",
  "itertools 0.14.0",
  "js-sys",
  "leb128",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustc-hash 2.1.2",
  "serde",
  "sha2 0.11.0-rc.5",
@@ -317,10 +316,8 @@ dependencies = [
  "criterion",
  "pprof",
  "rand 0.8.6",
- "rayon",
  "sedimentree_core",
  "testresult",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -383,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -393,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -2195,8 +2192,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4ecba0bb4e14df997df7cab6d1b584c6432d8865cf2adfced814706d715a7b"
+source = "git+https://github.com/automerge/automerge?branch=fragments#57c39ea43d6d7cf1c88447718872119d4cd16341"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -3121,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -3700,9 +3696,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
@@ -3731,9 +3727,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3819,18 +3815,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -5829,7 +5825,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5838,7 +5834,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5908,9 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -6838,9 +6834,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ arbitrary = "1.4"
 async-channel = { version = "2.5", default-features = false }
 async-lock = { version = "3.4", default-features = false }
 async-tungstenite = "0.31.0"
-automerge = "0.8.0"
+automerge = { git = "https://github.com/automerge/automerge", branch = "fragments" }
 axum = "0.8"
 base58 = "0.2.0"
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
@@ -79,6 +79,7 @@ futures-util = { version = "0.3.31", default-features = false, features = ["allo
 getrandom = "0.2" # matches ed25519-dalek transitive dep
 hex = "0.4"
 http-body-util = "0.1"
+#iroh = "1.0.0-rc.0"
 iroh = "0.98.2"
 hyper = { version = "1.6", default-features = false }
 hyper-util = { version = "0.1", default-features = false }

--- a/automerge_sedimentree/Cargo.toml
+++ b/automerge_sedimentree/Cargo.toml
@@ -15,12 +15,10 @@ rust-version.workspace = true
 
 [dependencies]
 automerge = { workspace = true }
-rayon = { workspace = true, optional = true }
 sedimentree_core = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
-automerge_sedimentree = { path = ".", features = ["std"] }
+automerge_sedimentree = { path = ".", features = ["std", "test-utils"] }
 criterion = { workspace = true }
 criterion_pprof = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
@@ -29,11 +27,23 @@ testresult = { workspace = true }
 [[bench]]
 name = "egwalker"
 harness = false
+required-features = ["test-utils"]
+
+[[test]]
+name = "real_world_ingestion"
+required-features = ["test-utils"]
+
+[[test]]
+name = "fragment_members_disjoint"
+required-features = ["test-utils"]
 
 [features]
 default = []
-rayon = ["dep:rayon", "sedimentree_core/rayon", "std"]
 std = ["sedimentree_core/std"]
+# Expose IndexedSedimentreeAutomerge as a reference CommitStore impl for
+# tests and benches that cross-validate fragmentation strategies. Not part
+# of the published API.
+test-utils = ["std"]
 
 [lints]
 workspace = true

--- a/automerge_sedimentree/src/ingest.rs
+++ b/automerge_sedimentree/src/ingest.rs
@@ -1,107 +1,41 @@
 //! Automerge document ingestion into Sedimentree.
 //!
-//! This module provides the complete pipeline for converting an Automerge
-//! document into a [`Sedimentree`] — the core operation for migrating data
-//! from automerge's native format into the sedimentree sync format.
-//!
-//! # Pipeline
-//!
-//! ```text
-//! Automerge doc
-//!   │
-//!   ├─ get_changes_meta()    ← cheap: DAG structure only
-//!   │     │
-//!   │     └─ build_fragment_store()  ← O(n) BFS
-//!   │           │
-//!   │           ├─ fragment members   (depth > 0 commits)
-//!   │           └─ uncovered digests  (depth-0 loose commits)
-//!   │
-//!   └─ get_changes()         ← expensive: reconstructs raw bytes
-//!         │
-//!         └─ group by membership → fragment blobs + loose blobs
-//!
-//!   → Sedimentree { fragments, loose_commits }
-//! ```
-//!
-//! # Example
-//!
-//! ```rust,ignore
-//! use automerge::Automerge;
-//! use automerge_sedimentree::ingest::ingest_automerge;
-//! use sedimentree_core::id::SedimentreeId;
-//!
-//! let bytes = std::fs::read("document.am").unwrap();
-//! let doc = Automerge::load(&bytes).unwrap();
-//! let sed_id = SedimentreeId::new([0u8; 32]); // your document ID
-//! let result = ingest_automerge(&doc, sed_id).unwrap();
-//!
-//! println!("fragments: {}", result.fragment_count);
-//! println!("loose commits: {}", result.loose_count);
-//! ```
+//! Thin adapter over [`Automerge::fragments()`] and
+//! [`Automerge::bundle_fragments()`]. Automerge computes the fragmentation
+//! internally — we just map each level-1+ `automerge::Fragment` into a
+//! sedimentree [`Fragment`], and each level-0 fragment into a [`LooseCommit`].
 
 use alloc::{collections::BTreeSet, vec::Vec};
 
-use automerge::{Automerge, ChangeHash};
+use automerge::Automerge;
 use sedimentree_core::{
     blob::{Blob, BlobMeta},
     collections::{Map, Set},
-    commit::{
-        CommitStore, CountLeadingZeroBytes, FragmentError, FragmentState, MissingCommitError,
-    },
+    fragment::Fragment,
     id::SedimentreeId,
     loose_commit::{LooseCommit, id::CommitId},
     sedimentree::Sedimentree,
 };
 
-use crate::indexed::{IndexedSedimentreeAutomerge, OwnedParents};
-
-/// Errors that can occur during automerge document ingestion.
-#[derive(Debug, Clone, Copy, thiserror::Error)]
-pub enum IngestError {
-    /// A commit required during fragment construction was missing from the store.
-    #[error(transparent)]
-    MissingCommit(#[from] MissingCommitError),
-
-    /// A depth-0 commit was passed as a fragment head.
-    #[error("depth-0 commit cannot be a fragment head: {0}")]
-    DepthZeroHead(CommitId),
-}
-
-/// Extract the concrete error from a [`FragmentError`] produced by
-/// [`IndexedSedimentreeAutomerge`], whose `LookupError` is
-/// [`Infallible`](core::convert::Infallible).
-#[allow(clippy::needless_pass_by_value)] // Consumes the error by destructuring
-const fn extract_fragment_error(
-    err: FragmentError<'static, IndexedSedimentreeAutomerge>,
-) -> IngestError {
-    match err {
-        FragmentError::MissingCommit(m) => IngestError::MissingCommit(m),
-        FragmentError::DepthZeroHead(d) => IngestError::DepthZeroHead(d),
-        FragmentError::LookupError(infallible) => match infallible {},
-    }
-}
-
 /// Result of ingesting an Automerge document.
 ///
-/// Contains the [`Sedimentree`], the corresponding [`Blob`]s, and metadata.
-/// Pass `sedimentree` and `blobs` to [`Subduction::add_sedimentree`] to
-/// store and sync the data.
+/// Pass `sedimentree` and `blobs` to `Subduction::add_sedimentree` to store
+/// and sync the data. Blob order is fragments first, loose commits after.
 #[derive(Debug, Clone)]
 pub struct IngestResult {
-    /// The constructed sedimentree (fragments + loose commits with `BlobMeta`).
+    /// The constructed sedimentree.
     pub sedimentree: Sedimentree,
 
-    /// All blobs referenced by the sedimentree's fragments and loose commits.
-    /// Matched to the sedimentree entries by blob digest.
+    /// All blobs referenced by the sedimentree.
     pub blobs: Vec<Blob>,
 
     /// Total number of changes in the source document.
     pub change_count: usize,
 
-    /// Number of changes covered by fragments.
+    /// Number of distinct changes covered by fragments.
     pub covered_count: usize,
 
-    /// Number of loose commits (depth-0, not in any fragment).
+    /// Number of loose commits.
     pub loose_count: usize,
 
     /// Number of fragments produced.
@@ -109,268 +43,79 @@ pub struct IngestResult {
 }
 
 /// Ingest an Automerge document into a [`Sedimentree`].
-///
-/// This is the main entry point for converting an automerge document into
-/// the sedimentree format. It performs a two-phase decomposition:
-///
-/// 1. **Metadata phase** (cheap): builds the commit index from
-///    `get_changes_meta` and runs `build_fragment_store` to determine
-///    fragment boundaries and membership.
-///
-/// 2. **Byte extraction phase** (expensive): calls `get_changes` once to
-///    reconstruct raw change bytes, then groups them into fragment blobs
-///    and loose commit blobs.
-///
-/// The `sedimentree_id` identifies the document in the sedimentree storage
-/// layer.
-///
-/// # Errors
-///
-/// Returns [`IngestError::MissingCommit`] if a commit required during
-/// fragment construction is absent from the document.
-pub fn ingest_automerge(
-    doc: &Automerge,
-    sedimentree_id: SedimentreeId,
-) -> Result<IngestResult, IngestError> {
-    // Phase 1: metadata index + fragment decomposition.
-    let metadata = doc.get_changes_meta(&[]);
-    let change_count = metadata.len();
+#[must_use]
+pub fn ingest_automerge(doc: &Automerge, sedimentree_id: SedimentreeId) -> IngestResult {
+    let cached = doc.fragments(1..);
+    let loose = doc.fragments(0..=0);
 
-    let store = IndexedSedimentreeAutomerge::from_metadata(&metadata);
-    let heads: Vec<CommitId> = doc.get_heads().iter().map(|h| CommitId::new(h.0)).collect();
+    let cached_bytes = doc.bundle_fragments(cached.iter().cloned());
+    let loose_bytes = doc.bundle_fragments(loose.iter().cloned());
 
-    let mut known: Map<CommitId, FragmentState<OwnedParents>> = Map::new();
-    let fresh = store
-        .build_fragment_store(&heads, &mut known, &CountLeadingZeroBytes)
-        .map_err(extract_fragment_error)?;
-    let states: Vec<_> = fresh.into_iter().cloned().collect();
-
-    let covered: Set<CommitId> = known
-        .values()
-        .flat_map(|s| s.members().iter().copied())
-        .collect();
-    let covered_count = covered.len();
-
-    // Phase 2: produce blobs.
-    //
-    // One `get_changes(&[])` call to get all changes with raw bytes in
-    // topological (causal) order. Then for each fragment we filter to
-    // member changes only and concatenate their `raw_bytes()`.
-    //
-    // For loose commits: just the individual change's raw_bytes() (already
-    // small, no recompression needed).
-    let changes = doc.get_changes(&[]);
-    let index = ChangeIndex::new(&changes);
-
-    let (fragments, fragment_blobs) = compress_fragments(&states, &index, sedimentree_id);
-
-    let (loose_commits, loose_blobs) =
-        collect_loose_commits(&changes, &covered, &states, sedimentree_id);
-
-    let fragment_count = fragments.len();
-    let loose_count = loose_commits.len();
-    let mut blobs = fragment_blobs;
-    blobs.extend(loose_blobs);
-    let sedimentree = Sedimentree::new(fragments, loose_commits);
-
-    Ok(IngestResult {
-        sedimentree,
-        blobs,
-        change_count,
-        covered_count,
-        loose_count,
-        fragment_count,
-    })
-}
-
-/// Parallel variant of [`ingest_automerge`].
-///
-/// Uses [rayon] to compress fragment blobs concurrently. Each fragment's
-/// `load_incremental` + `save_after` runs on a separate thread. For a
-/// document with N fragments, this gives up to N-way parallelism.
-///
-/// The `get_changes` call (the main bottleneck) is still sequential —
-/// it's internal to automerge and single-threaded.
-///
-/// # Errors
-///
-/// Returns [`IngestError`] if fragment construction or blob compression fails.
-#[cfg(feature = "rayon")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rayon")))]
-pub fn ingest_automerge_par(
-    doc: &Automerge,
-    sedimentree_id: SedimentreeId,
-) -> Result<IngestResult, IngestError> {
-    let metadata = doc.get_changes_meta(&[]);
-    let change_count = metadata.len();
-
-    let store = IndexedSedimentreeAutomerge::from_metadata(&metadata);
-    let heads: Vec<CommitId> = doc.get_heads().iter().map(|h| CommitId::new(h.0)).collect();
-
-    let mut known: Map<CommitId, FragmentState<OwnedParents>> = Map::new();
-    let fresh = store
-        .build_fragment_store(&heads, &mut known, &CountLeadingZeroBytes)
-        .map_err(extract_fragment_error)?;
-    let states: Vec<_> = fresh.into_iter().cloned().collect();
-
-    let covered: Set<CommitId> = known
-        .values()
-        .flat_map(|s| s.members().iter().copied())
-        .collect();
-    let covered_count = covered.len();
-
-    let changes = doc.get_changes(&[]);
-    let index = ChangeIndex::new(&changes);
-
-    let (fragments, fragment_blobs) = compress_fragments_par(&states, &index, sedimentree_id);
-
-    let (loose_commits, loose_blobs) =
-        collect_loose_commits(&changes, &covered, &states, sedimentree_id);
-
-    let fragment_count = fragments.len();
-    let loose_count = loose_commits.len();
-    let mut blobs = fragment_blobs;
-    blobs.extend(loose_blobs);
-    let sedimentree = Sedimentree::new(fragments, loose_commits);
-
-    Ok(IngestResult {
-        sedimentree,
-        blobs,
-        change_count,
-        covered_count,
-        loose_count,
-        fragment_count,
-    })
-}
-
-/// Pre-indexed change data for efficient per-fragment blob construction.
-///
-/// Built once from the full `get_changes(&[])` output, then shared
-/// across all fragment compressions. Each entry stores the raw bytes
-/// of a change keyed by its hash, in topological order.
-struct ChangeIndex<'a> {
-    /// `(ChangeHash, raw_bytes)` in topological order.
-    entries: Vec<(ChangeHash, &'a [u8])>,
-}
-
-impl<'a> ChangeIndex<'a> {
-    fn new(changes: &'a [automerge::Change]) -> Self {
-        Self {
-            entries: changes.iter().map(|c| (c.hash(), c.raw_bytes())).collect(),
-        }
-    }
-}
-
-/// Compress a single fragment: concatenate only the member changes'
-/// raw bytes, preserving the topological order from `get_changes`.
-///
-/// Previous versions loaded boundary + members into a sub-doc and used
-/// `save_after(boundary)` for compact output. This broke on concurrent
-/// DAGs because `save_after` excludes changes reachable from _any_
-/// boundary head — but in a concurrent DAG, member changes can be
-/// ancestors of boundary commits on a different branch, causing them
-/// to be silently dropped.
-fn compress_one_fragment(
-    state: &FragmentState<OwnedParents>,
-    index: &ChangeIndex<'_>,
-    sedimentree_id: SedimentreeId,
-) -> (sedimentree_core::fragment::Fragment, Blob) {
-    let members: Set<ChangeHash> = state
-        .members()
-        .iter()
-        .map(|d| ChangeHash(*d.as_bytes()))
-        .collect();
-
-    let mut raw = Vec::new();
-    for &(hash, bytes) in &index.entries {
-        if members.contains(&hash) {
-            raw.extend_from_slice(bytes);
-        }
-    }
-
-    let blob = Blob::new(raw);
-    let fragment = state
-        .clone()
-        .to_fragment(sedimentree_id, BlobMeta::new(&blob));
-    (fragment, blob)
-}
-
-/// Sequential fragment compression.
-fn compress_fragments(
-    states: &[FragmentState<OwnedParents>],
-    index: &ChangeIndex<'_>,
-    sedimentree_id: SedimentreeId,
-) -> (Vec<sedimentree_core::fragment::Fragment>, Vec<Blob>) {
-    let mut fragments = Vec::with_capacity(states.len());
-    let mut blobs = Vec::with_capacity(states.len());
-    for state in states {
-        let (fragment, blob) = compress_one_fragment(state, index, sedimentree_id);
-        fragments.push(fragment);
-        blobs.push(blob);
-    }
-    (fragments, blobs)
-}
-
-/// Parallel fragment compression using rayon.
-#[cfg(feature = "rayon")]
-fn compress_fragments_par(
-    states: &[FragmentState<OwnedParents>],
-    index: &ChangeIndex<'_>,
-    sedimentree_id: SedimentreeId,
-) -> (Vec<sedimentree_core::fragment::Fragment>, Vec<Blob>) {
-    use rayon::prelude::*;
-
-    let (fragments, blobs): (Vec<_>, Vec<_>) = states
-        .par_iter()
-        .map(|state| compress_one_fragment(state, index, sedimentree_id))
-        .unzip();
-
-    (fragments, blobs)
-}
-
-/// Collect loose commits (depth-0, not covered by any fragment).
-///
-/// Parent digests that point into a fragment's member set are remapped to the
-/// fragment's head digest. This prevents `Sedimentree::minimize` from
-/// considering the loose commit "covered" by the fragment and pruning it.
-fn collect_loose_commits(
-    changes: &[automerge::Change],
-    covered: &Set<CommitId>,
-    states: &[FragmentState<OwnedParents>],
-    sedimentree_id: SedimentreeId,
-) -> (Vec<LooseCommit>, Vec<Blob>) {
-    // Build a mapping: covered member id → fragment head id.
+    // Loose commits whose parents point at a non-head member of a cached
+    // fragment are remapped to the containing fragment's head, so
+    // Sedimentree::minimize doesn't treat the loose commit as covered and
+    // prune it.
     let mut member_to_head: Map<CommitId, CommitId> = Map::new();
-    for state in states {
-        let head = state.head_id();
-        for member in state.members() {
-            if *member != head {
-                member_to_head.insert(*member, head);
+    for f in &cached {
+        let head = CommitId::new(f.head.0);
+        for m in &f.members {
+            let id = CommitId::new(m.0);
+            if id != head {
+                member_to_head.insert(id, head);
             }
         }
     }
 
-    let mut loose_commits = Vec::new();
-    let mut blobs = Vec::new();
-    for change in changes {
-        let id = CommitId::new(change.hash().0);
-        if covered.contains(&id) {
-            continue;
+    let mut fragments = Vec::with_capacity(cached.len());
+    let mut blobs = Vec::with_capacity(cached.len() + loose.len());
+    let mut covered: Set<CommitId> = Set::new();
+    for (f, raw) in cached.iter().zip(cached_bytes) {
+        for m in &f.members {
+            covered.insert(CommitId::new(m.0));
         }
-        // Remap parents: if a parent is a fragment member, point to
-        // the fragment head instead so minimize doesn't prune us.
-        let parents: BTreeSet<CommitId> = change
-            .deps()
+        let blob = Blob::new(raw);
+        let boundary: BTreeSet<CommitId> =
+            f.boundary.iter().map(|h| CommitId::new(h.0)).collect();
+        let checkpoints: Vec<CommitId> =
+            f.checkpoints.iter().map(|h| CommitId::new(h.0)).collect();
+        let meta = BlobMeta::new(&blob);
+        fragments.push(Fragment::new(
+            sedimentree_id,
+            CommitId::new(f.head.0),
+            boundary,
+            &checkpoints,
+            meta,
+        ));
+        blobs.push(blob);
+    }
+
+    let mut loose_commits = Vec::with_capacity(loose.len());
+    for (f, raw) in loose.iter().zip(loose_bytes) {
+        let head = CommitId::new(f.head.0);
+        let parents: BTreeSet<CommitId> = f
+            .boundary
             .iter()
-            .map(|d| {
-                let dep = CommitId::new(d.0);
+            .map(|p| {
+                let dep = CommitId::new(p.0);
                 member_to_head.get(&dep).copied().unwrap_or(dep)
             })
             .collect();
-        let blob = Blob::new(change.raw_bytes().to_vec());
-        let commit = LooseCommit::new(sedimentree_id, id, parents, BlobMeta::new(&blob));
-        loose_commits.push(commit);
+        let blob = Blob::new(raw);
+        let meta = BlobMeta::new(&blob);
+        loose_commits.push(LooseCommit::new(sedimentree_id, head, parents, meta));
         blobs.push(blob);
     }
-    (loose_commits, blobs)
+
+    let fragment_count = fragments.len();
+    let loose_count = loose_commits.len();
+    let covered_count = covered.len();
+
+    IngestResult {
+        sedimentree: Sedimentree::new(fragments, loose_commits),
+        blobs,
+        fragment_count,
+        loose_count,
+        covered_count,
+        change_count: covered_count + loose_count,
+    }
 }

--- a/automerge_sedimentree/src/lib.rs
+++ b/automerge_sedimentree/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "test-utils")]
 pub mod indexed;
 pub mod ingest;
 

--- a/automerge_sedimentree/tests/fragment_members_disjoint.rs
+++ b/automerge_sedimentree/tests/fragment_members_disjoint.rs
@@ -1,0 +1,111 @@
+//! Regression test: a commit must belong to at most one fragment in the tree.
+//!
+//! Suspected bug in `sedimentree_core::commit::build_fragment_store`: under
+//! high concurrency, the BFS that assigns members to a fragment can include
+//! commits that are *also* members of a fragment reachable through the
+//! current fragment's boundary. A commit appearing as a member of both a
+//! fragment and one of its ancestor fragments would cause that change's ops
+//! to be loaded twice during sedimentree reassembly, or worse, be silently
+//! dropped depending on which path `minimize` follows.
+//!
+//! This test loads each egwalker test vector, runs `build_fragment_store`,
+//! and asserts that for every produced fragment, its `members` set is
+//! disjoint from the union of `members` of all fragments reachable through
+//! its `boundary`.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+
+use automerge::Automerge;
+use automerge_sedimentree::indexed::{IndexedSedimentreeAutomerge, OwnedParents};
+use sedimentree_core::{
+    collections::{Map, Set},
+    commit::{CommitStore, CountLeadingZeroBytes, FragmentState},
+    loose_commit::id::CommitId,
+};
+use testresult::TestResult;
+
+const VECTORS: &[(&str, &[u8])] = &[
+    ("A1", include_bytes!("../test-vectors/A1.am")),
+    ("A2", include_bytes!("../test-vectors/A2.am")),
+    ("C1", include_bytes!("../test-vectors/C1.am")),
+    ("C2", include_bytes!("../test-vectors/C2.am")),
+    ("S1", include_bytes!("../test-vectors/S1.am")),
+    ("S2", include_bytes!("../test-vectors/S2.am")),
+    ("S3", include_bytes!("../test-vectors/S3.am")),
+];
+
+/// Collect the union of `members` across every fragment reachable from
+/// `start`'s boundary (transitively). Only follows boundary keys that are
+/// themselves fragment heads in `known` — boundaries can also point at
+/// depth-0 commits below the deepest level, which are not fragments.
+fn ancestor_members(
+    start: &FragmentState<OwnedParents>,
+    known: &Map<CommitId, FragmentState<OwnedParents>>,
+) -> Set<CommitId> {
+    let mut acc: Set<CommitId> = Set::new();
+    let mut to_visit: Vec<CommitId> = start.boundary().keys().copied().collect();
+    let mut seen: Set<CommitId> = Set::new();
+
+    while let Some(b) = to_visit.pop() {
+        if !seen.insert(b) {
+            continue;
+        }
+        if let Some(anc) = known.get(&b) {
+            acc.extend(anc.members().iter().copied());
+            to_visit.extend(anc.boundary().keys().copied());
+        }
+    }
+
+    acc
+}
+
+#[test]
+fn fragment_members_disjoint_from_ancestor_members() -> TestResult {
+    let mut failures: Vec<String> = Vec::new();
+
+    for (name, bytes) in VECTORS {
+        let doc = Automerge::load(bytes)?;
+        let metadata = doc.get_changes_meta(&[]);
+        let store = IndexedSedimentreeAutomerge::from_metadata(&metadata);
+        let heads: Vec<CommitId> = doc
+            .get_heads()
+            .iter()
+            .map(|h| CommitId::new(h.0))
+            .collect();
+
+        let mut known: Map<CommitId, FragmentState<OwnedParents>> = Map::new();
+        store
+            .build_fragment_store(&heads, &mut known, &CountLeadingZeroBytes)
+            .expect("build_fragment_store");
+
+        let mut total_overlap = 0usize;
+        let mut sample_overlaps: Vec<(CommitId, CommitId)> = Vec::new();
+
+        for (head, state) in &known {
+            let ancestor = ancestor_members(state, &known);
+            for m in state.members() {
+                if ancestor.contains(m) {
+                    total_overlap += 1;
+                    if sample_overlaps.len() < 5 {
+                        sample_overlaps.push((*head, *m));
+                    }
+                }
+            }
+        }
+
+        if total_overlap > 0 {
+            failures.push(format!(
+                "{name}: {total_overlap} member(s) appear in both a fragment and one of its ancestors. \
+                 Sample (fragment_head, member): {sample_overlaps:?}"
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "fragment members overlap with ancestor fragments:\n  {}",
+        failures.join("\n  ")
+    );
+
+    Ok(())
+}

--- a/automerge_sedimentree/tests/fragments_match_automerge.rs
+++ b/automerge_sedimentree/tests/fragments_match_automerge.rs
@@ -1,0 +1,92 @@
+//! Counterpart to `fragment_members_disjoint.rs`: confirms that the
+//! ancestor-disjointness invariant holds when fragmentation is delegated to
+//! `Automerge::fragments()` instead of `sedimentree_core::build_fragment_store`.
+//!
+//! For each egwalker test vector, asks Automerge for the cached fragments
+//! (level >= 1) and verifies that for every fragment F, none of F's `members`
+//! appear in the `members` of any fragment reachable through F's `boundary`.
+//!
+//! Note: this does NOT assert that every change belongs to exactly one
+//! fragment across the whole tree. Automerge fragments can legitimately
+//! share members across concurrent siblings (changes reachable from two
+//! concurrent fragment heads whose parents don't see them). The bug we're
+//! tracking is specifically the ancestor-overlap case, where a member of
+//! a fragment also appears in one of its own ancestors — that would break
+//! sedimentree's `minimize` and loose-commit parent remapping.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+
+use std::collections::{HashMap, HashSet};
+
+use automerge::{Automerge, ChangeHash};
+use testresult::TestResult;
+
+const VECTORS: &[(&str, &[u8])] = &[
+    ("A1", include_bytes!("../test-vectors/A1.am")),
+    ("A2", include_bytes!("../test-vectors/A2.am")),
+    ("C1", include_bytes!("../test-vectors/C1.am")),
+    ("C2", include_bytes!("../test-vectors/C2.am")),
+    ("S1", include_bytes!("../test-vectors/S1.am")),
+    ("S2", include_bytes!("../test-vectors/S2.am")),
+    ("S3", include_bytes!("../test-vectors/S3.am")),
+];
+
+#[test]
+fn automerge_fragment_members_disjoint_from_ancestor_members() -> TestResult {
+    let mut failures: Vec<String> = Vec::new();
+
+    for (name, bytes) in VECTORS {
+        let doc = Automerge::load(bytes)?;
+
+        // Cached fragments only — level-0 fragments are single-member
+        // loose changes whose boundary points at raw change parents
+        // (not fragment heads), so the ancestor-walk model doesn't apply.
+        let cached = doc.fragments(1..);
+        let by_head: HashMap<ChangeHash, _> =
+            cached.iter().map(|f| (f.head, f)).collect();
+
+        let mut total_overlap = 0usize;
+        let mut sample_overlaps: Vec<(ChangeHash, ChangeHash)> = Vec::new();
+
+        for f in &cached {
+            // Union members of every fragment reachable via boundary.
+            let mut ancestor_members: HashSet<ChangeHash> = HashSet::new();
+            let mut to_visit: Vec<ChangeHash> = f.boundary.clone();
+            let mut seen: HashSet<ChangeHash> = HashSet::new();
+            while let Some(b) = to_visit.pop() {
+                if !seen.insert(b) {
+                    continue;
+                }
+                if let Some(anc) = by_head.get(&b) {
+                    ancestor_members.extend(anc.members.iter().copied());
+                    to_visit.extend(anc.boundary.iter().copied());
+                }
+            }
+
+            for m in &f.members {
+                if ancestor_members.contains(m) {
+                    total_overlap += 1;
+                    if sample_overlaps.len() < 5 {
+                        sample_overlaps.push((f.head, *m));
+                    }
+                }
+            }
+        }
+
+        if total_overlap > 0 {
+            failures.push(format!(
+                "{name}: {total_overlap} member(s) appear in both a fragment and one of its ancestors. \
+                 Sample (fragment_head, member): {sample_overlaps:?}"
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Automerge::fragments() produced overlapping members:\n  {}",
+        failures.join("\n  ")
+    );
+
+    Ok(())
+}
+

--- a/automerge_sedimentree/tests/real_world_ingestion.rs
+++ b/automerge_sedimentree/tests/real_world_ingestion.rs
@@ -474,7 +474,7 @@ fn merge_identical_is_idempotent() {
 fn minimize_preserves_all_items_after_ingestion() {
     let doc = Automerge::load(include_bytes!("../test-vectors/S1.am")).unwrap();
     let sed_id = sed_id(include_bytes!("../test-vectors/S1.am"));
-    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).unwrap();
+    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id);
 
     let before_fragments = result.sedimentree.fragments().count();
     let before_commits = result.sedimentree.loose_commits().count();
@@ -498,7 +498,7 @@ fn minimize_preserves_all_items_after_ingestion() {
 fn fingerprint_summary_includes_all_items_after_ingestion() {
     let doc = Automerge::load(include_bytes!("../test-vectors/S1.am")).unwrap();
     let sed_id = sed_id(include_bytes!("../test-vectors/S1.am"));
-    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).unwrap();
+    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id);
 
     let seed = FingerprintSeed::new(42, 99);
     let summary = result.sedimentree.fingerprint_summarize(&seed);
@@ -525,7 +525,7 @@ fn ingest_minimize_roundtrip(name: &str, bytes: &[u8]) {
     let original_count = doc.get_changes(&[]).len();
 
     let sed_id = sed_id(bytes);
-    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
+    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id);
     let minimized = result.sedimentree.minimize(&CountLeadingZeroBytes);
 
     // `minimize` only prunes Sedimentree entries; blob storage is
@@ -707,9 +707,14 @@ fn egwalker_vector_snapshots() {
 fn egwalker_minimal_hash_snapshots() {
     use sedimentree_core::sedimentree::MinimalTreeHash;
 
-    /// `(name, bytes, expected_hash_hex)` — pinned post-fix.
-    /// If `minimize` ever changes its output for these vectors,
-    /// update the table and explain why in the commit message.
+    /// `(name, bytes, expected_hash_hex)` — pinned after the bundle-format
+    /// rework: per-column DEFLATE in `Bundle`, topo-sorted bundle members
+    /// (small `external` deps list), ingest routed through
+    /// `Automerge::fragments()` instead of `build_fragment_store`.
+    /// The four high-concurrency vectors (A1, A2, C1, C2) re-snapshot
+    /// because fragment blob bytes changed; S1-S3 are unchanged because
+    /// they have no cached fragments and the loose-commit hash structure
+    /// is independent of blob byte format.
     const SNAPSHOTS: &[(&str, &[u8], &str)] = &[
         (
             "S1",
@@ -729,29 +734,29 @@ fn egwalker_minimal_hash_snapshots() {
         (
             "A1",
             include_bytes!("../test-vectors/A1.am"),
-            "55cd0bf902a8f515b50ab8353c8668a89dd1c0a2f38b4e7992ee052eba0b9959",
+            "4098ca35d635e122eb1def270ea61e958dd321e093131c9c1a5a7389c2c2d099",
         ),
         (
             "A2",
             include_bytes!("../test-vectors/A2.am"),
-            "813d197c265e3d72ab7147491ad2d735dc5c5bfad9c351f57891dad45eb6bcfd",
+            "53e6f21b41927101d7b1d669e6c1bc569dd9a7a96d7e53e45cf6ad804cd5438d",
         ),
         (
             "C1",
             include_bytes!("../test-vectors/C1.am"),
-            "1aeb3a9f1f7220af7dc91dcdc62e96005d15a78091e115292d0584e7b0e421ec",
+            "cd8276131bcd6fb67e6763c090cf3a53bd5fb5e43765526d8c17dbe7bbaf1b7b",
         ),
         (
             "C2",
             include_bytes!("../test-vectors/C2.am"),
-            "c2af810d5ceabd50154ed26f81d9f313962de4d9fade24d332d54a9884c3a480",
+            "24b901c5dcf29f37ab66118180cda3233613547f3c65af22820c3742307b872e",
         ),
     ];
 
     for (name, bytes, expected_hex) in SNAPSHOTS {
         let doc = Automerge::load(bytes).expect(name);
         let sed_id = sed_id(bytes);
-        let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
+        let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id);
 
         // Determinism within a single ingest result.
         let h1: MinimalTreeHash = result.sedimentree.minimal_hash(&CountLeadingZeroBytes);
@@ -765,7 +770,7 @@ fn egwalker_minimal_hash_snapshots() {
 
         // Determinism across re-ingest of the same document bytes.
         let result2 =
-            automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("re-ingest");
+            automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id);
         let h3: MinimalTreeHash = result2.sedimentree.minimal_hash(&CountLeadingZeroBytes);
         assert_eq!(
             h1.as_bytes(),
@@ -796,7 +801,7 @@ fn ingest_double_minimize_roundtrip_s1() {
     let original_heads = doc.get_heads();
 
     let sed_id = sed_id(bytes);
-    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
+    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id);
 
     let once = result.sedimentree.minimize(&CountLeadingZeroBytes);
     let twice = once.minimize(&CountLeadingZeroBytes);
@@ -850,7 +855,7 @@ fn ingest_roundtrip_a2() {
     let original_count = doc.get_changes(&[]).len();
 
     let sed_id = sed_id(bytes);
-    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id).expect("ingest");
+    let result = automerge_sedimentree::ingest::ingest_automerge(&doc, sed_id);
 
     // Verify ingest accounting: every change is either covered by a
     // fragment or emitted as a loose commit, with no overlap.

--- a/automerge_subduction_ingest/Cargo.toml
+++ b/automerge_subduction_ingest/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 automerge = { workspace = true }
-automerge_sedimentree = { workspace = true, features = ["rayon"] }
+automerge_sedimentree = { workspace = true }
 bs58 = { version = "0.5", features = ["check"] }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/automerge_subduction_ingest/src/main.rs
+++ b/automerge_subduction_ingest/src/main.rs
@@ -16,7 +16,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use automerge::Automerge;
-use automerge_sedimentree::ingest::{IngestResult, ingest_automerge_par};
+use automerge_sedimentree::ingest::{IngestResult, ingest_automerge};
 use clap::Parser;
 use eyre::{Result, WrapErr, eyre};
 use future_form::Sendable;
@@ -229,7 +229,7 @@ async fn main() -> Result<()> {
 
     // Ingest: automerge → sedimentree.
     eprintln!("ingesting...");
-    let result = ingest_automerge_par(&doc, sed_id).wrap_err("ingestion failed")?;
+    let result = ingest_automerge(&doc, sed_id);
     print_ingest_stats(&result, sed_id);
 
     if args.dry_run {

--- a/sedimentree_core/src/commit.rs
+++ b/sedimentree_core/src/commit.rs
@@ -210,6 +210,27 @@ pub trait CommitStore<'a> {
             }
         }
 
+        // Post-pass: dedupe members against transitive ancestor fragments.
+        //
+        // The BFS in `fragment()` walks parents of any shallower-depth commit,
+        // which in a concurrent DAG can re-enter territory that is already
+        // covered by a deeper ancestor fragment reached through a different
+        // boundary path. The inline strip at the bottom of `fragment()` only
+        // handles direct boundary fragments — it can't see deeper ancestors
+        // because they aren't in `known_fragment_states` yet (the loop above
+        // discovers them later). Now that every fresh fragment is built and
+        // the boundary chain is fully populated, strip any member that also
+        // appears in an ancestor's members.
+        for head in &fresh_heads {
+            let ancestor_members = collect_ancestor_members(*head, known_fragment_states);
+            if ancestor_members.is_empty() {
+                continue;
+            }
+            if let Some(state) = known_fragment_states.get_mut(head) {
+                state.retain_members(|c| !ancestor_members.contains(c));
+            }
+        }
+
         let mut fresh = Vec::with_capacity(fresh_heads.len());
         for h in fresh_heads {
             #[allow(clippy::expect_used)]
@@ -335,6 +356,19 @@ pub trait CommitStore<'a> {
             horizon = next_horizon;
         }
 
+        // Post-pass: dedupe members against transitive ancestor fragments.
+        // See the comment in `build_fragment_store` for rationale — the
+        // parallel variant has the same overlap pattern in concurrent DAGs.
+        for head in &all_heads {
+            let ancestor_members = collect_ancestor_members(*head, known_fragment_states);
+            if ancestor_members.is_empty() {
+                continue;
+            }
+            if let Some(state) = known_fragment_states.get_mut(head) {
+                state.retain_members(|c| !ancestor_members.contains(c));
+            }
+        }
+
         let mut fresh = Vec::with_capacity(all_heads.len());
         for head in all_heads {
             #[allow(clippy::expect_used)]
@@ -426,4 +460,47 @@ impl<T> FragmentState<T> {
             blob_meta,
         )
     }
+
+    /// Drop any member (and checkpoint) for which `predicate` returns false.
+    ///
+    /// Used by [`CommitStore::build_fragment_store`] to dedupe members
+    /// against transitive ancestor fragments after the full tree is built.
+    pub fn retain_members<F>(&mut self, mut predicate: F)
+    where
+        F: FnMut(&CommitId) -> bool,
+    {
+        self.members.retain(|c| predicate(c));
+        self.checkpoints.retain(|c| predicate(c));
+    }
+}
+
+/// Walk the boundary chain transitively from `head` through fragments in
+/// `known` and return the union of all reachable ancestor fragments' members.
+///
+/// "Ancestor" here means: a fragment whose head is reachable from `head` by
+/// following `boundary` keys through fragments present in `known`. Boundary
+/// keys that don't resolve to a fragment in `known` (e.g. depth-0 commits
+/// beyond the deepest level) are ignored.
+fn collect_ancestor_members<T>(
+    head: CommitId,
+    known: &Map<CommitId, FragmentState<T>>,
+) -> Set<CommitId> {
+    let mut acc: Set<CommitId> = Set::new();
+    let mut seen: Set<CommitId> = Set::new();
+    let mut to_visit: Vec<CommitId> = match known.get(&head) {
+        Some(state) => state.boundary().keys().copied().collect(),
+        None => return acc,
+    };
+
+    while let Some(b) = to_visit.pop() {
+        if !seen.insert(b) {
+            continue;
+        }
+        if let Some(anc) = known.get(&b) {
+            acc.extend(anc.members().iter().copied());
+            to_visit.extend(anc.boundary().keys().copied());
+        }
+    }
+
+    acc
 }

--- a/subduction_core/src/handler.rs
+++ b/subduction_core/src/handler.rs
@@ -122,6 +122,29 @@ pub trait Handler<K: FutureForm, C: Clone> {
         Self::as_batch_sync_response(msg).is_some()
     }
 
+    /// Extract the [`SedimentreeId`] of a message that is an incoming
+    /// subscription request (`BatchSyncRequest` with `subscribe: true`).
+    ///
+    /// Returning `Some(id)` tells the listen loop that, after the handler
+    /// has processed the message, the [`Subduction`] instance should
+    /// propagate the subscription to its own upstream peers so that any
+    /// future updates on `id` from those peers can be forwarded back to
+    /// the new subscriber. Returning `None` (the default) suppresses
+    /// propagation.
+    ///
+    /// Implementations for non-sync message types should leave this as
+    /// the default. The standard [`SyncHandler`] overrides it to surface
+    /// `BatchSyncRequest { subscribe: true, .. }`.
+    ///
+    /// [`Subduction`]: crate::subduction::Subduction
+    /// [`SedimentreeId`]: sedimentree_core::id::SedimentreeId
+    /// [`SyncHandler`]: crate::handler::sync::SyncHandler
+    fn as_subscribe_request(
+        _msg: &Self::Message,
+    ) -> Option<sedimentree_core::id::SedimentreeId> {
+        None
+    }
+
     /// Called when a peer's last connection drops.
     ///
     /// Use this hook to clean up per-peer state such as subscription

--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -271,6 +271,24 @@ impl<K: FutureForm, S, C, P, M, R, const N: usize> Handler<K, C>
         }
     }
 
+    fn as_subscribe_request(msg: &Self::Message) -> Option<SedimentreeId> {
+        // We treat any inbound subscribing BatchSyncRequest as an
+        // instruction to also subscribe upstream so updates can be
+        // forwarded back. See [`Subduction::propagate_subscription`].
+        match msg {
+            SyncMessage::BatchSyncRequest(req) if req.subscribe => Some(req.id),
+            SyncMessage::BatchSyncRequest(_)
+            | SyncMessage::BatchSyncResponse(_)
+            | SyncMessage::BlobsRequest { .. }
+            | SyncMessage::BlobsResponse { .. }
+            | SyncMessage::DataRequestRejected(_)
+            | SyncMessage::Fragment { .. }
+            | SyncMessage::LooseCommit { .. }
+            | SyncMessage::RemoveSubscriptions(_)
+            | SyncMessage::HeadsUpdate { .. } => None,
+        }
+    }
+
     fn handle<'a>(
         &'a self,
         conn: &'a Authenticated<C, K>,

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -222,7 +222,7 @@ impl<
     F: SubductionFutureForm<'a, S, C, H::Message, P, Sig, M, N> + 'static,
     S: Storage<F>,
     C: Connection<F, H::Message> + PartialEq + 'a,
-    H: Handler<F, C>,
+    H: Handler<F, C> + RemoteHeadsNotifier,
     P: ConnectionPolicy<F> + StoragePolicy<F>,
     Sig: Signer<F>,
     O: Timeout<F> + Clone,
@@ -648,12 +648,24 @@ where
                             continue;
                         }
 
-                        // Normal path: dispatch to handler
+                        // Normal path: dispatch to handler. If this is
+                        // an inbound `BatchSyncRequest { subscribe: true }`,
+                        // propagate the subscription to our own upstream
+                        // peers once the handler has processed it
+                        // (mirroring the outbound broadcast that
+                        // `SyncHandler` already does for commits/fragments).
                         let h = handler.clone();
                         let conn_clone = conn.clone();
+                        let propagate_target = H::as_subscribe_request(&msg)
+                            .map(|sed_id| (sed_id, peer_id, Arc::clone(&self)));
 
                         in_flight.push(async move {
                             let result = h.handle(&conn_clone, msg).await;
+                            if result.is_ok()
+                                && let Some((sed_id, originator, me)) = propagate_target
+                            {
+                                me.propagate_subscription(sed_id, originator).await;
+                            }
                             (conn_clone, result)
                         });
                     } else {
@@ -1761,6 +1773,74 @@ where
         self.add_built_batch_locally(id, commits, fragments).await?;
         self.sync_with_all_peers(id, true, None).await?;
         Ok(())
+    }
+
+    /// Propagate an inbound subscription request to our own upstream peers.
+    ///
+    /// Called from the listen loop when [`Handler::as_subscribe_request`]
+    /// surfaces a `BatchSyncRequest { subscribe: true, .. }`. For every
+    /// currently-connected peer other than `originator` that we do not
+    /// already have an outgoing subscription to for `id`, we issue
+    /// [`sync_with_peer`](Self::sync_with_peer) with `subscribe = true`.
+    ///
+    /// The result: any updates the upstream peer later pushes for `id`
+    /// reach us, and the outbound broadcast loops in
+    /// [`SyncHandler::recv_commit`] / [`recv_fragment`] forward them
+    /// back to the originator (and any other local subscribers).
+    /// Forwarding updates and forwarding requests stay symmetric — see
+    /// `design/protocol.md`.
+    ///
+    /// Idempotency comes from [`outgoing_subscriptions`]: a successful
+    /// `sync_with_peer(subscribe = true)` records `(peer, id)` there,
+    /// and the per-peer check below skips peers already covered. Loops
+    /// between mutually-subscribed servers self-quench after one round.
+    ///
+    /// Errors from individual upstream calls are logged and ignored;
+    /// subscription propagation is best-effort.
+    ///
+    /// [`Handler::as_subscribe_request`]: crate::handler::Handler::as_subscribe_request
+    /// [`SyncHandler::recv_commit`]: crate::handler::sync::SyncHandler
+    /// [`recv_fragment`]: crate::handler::sync::SyncHandler
+    /// [`outgoing_subscriptions`]: Self::outgoing_subscriptions
+    pub(crate) async fn propagate_subscription(
+        self: &Arc<Self>,
+        id: SedimentreeId,
+        originator: PeerId,
+    ) {
+        let peers: Vec<PeerId> = {
+            let conns = self.connections.lock().await;
+            conns
+                .keys()
+                .copied()
+                .filter(|p| *p != originator)
+                .collect()
+        };
+
+        if peers.is_empty() {
+            return;
+        }
+
+        // Snapshot outgoing subscriptions once so the per-peer checks
+        // don't hold the lock across the awaits below.
+        let already_subscribed: Map<PeerId, Set<SedimentreeId>> =
+            self.outgoing_subscriptions.lock().await.clone();
+
+        for peer in peers {
+            if already_subscribed
+                .get(&peer)
+                .is_some_and(|set| set.contains(&id))
+            {
+                continue;
+            }
+            tracing::debug!(
+                "propagating subscription for {id:?} upstream to peer {peer}"
+            );
+            if let Err(e) = self.sync_with_peer(&peer, id, true, None).await {
+                tracing::debug!(
+                    "subscribe propagation to {peer} for {id:?} failed: {e}"
+                );
+            }
+        }
     }
 
     /// Request a batch sync from a given peer for a given sedimentree ID.
@@ -2977,7 +3057,7 @@ pub trait StartListener<
         P::FetchDisallowed: Send + 'static,
         Sig: Signer<Sendable> + Send + Sync + 'a,
         M: DepthMetric + Send + Sync + 'a,
-        H: Handler<Sendable, C, Message = W> + Send + Sync + 'a,
+        H: Handler<Sendable, C, Message = W> + RemoteHeadsNotifier + Send + Sync + 'a,
         H::HandlerError: Into<ListenError<Sendable, S, C, W>> + Send + 'static,
         S::Error: Send + 'static,
         C::DisconnectionError: Send + 'static,
@@ -2990,13 +3070,13 @@ pub trait StartListener<
         P: ConnectionPolicy<Local> + StoragePolicy<Local> + 'a,
         Sig: Signer<Local> + 'a,
         M: DepthMetric + 'a,
-        H: Handler<Local, C, Message = W> + 'a,
+        H: Handler<Local, C, Message = W> + RemoteHeadsNotifier + 'a,
         H::HandlerError: Into<ListenError<Local, S, C, W>>
 )]
 impl<'a, K: FutureForm, C, S, W, H, P, Sig, M, const N: usize>
     StartListener<'a, S, C, W, H, P, Sig, M, N> for K
 where
-    H: Handler<K, C, Message = W>,
+    H: Handler<K, C, Message = W> + RemoteHeadsNotifier,
     H::HandlerError: Into<ListenError<K, S, C, W>>,
     W: Encode + Decode + Clone + Send + core::fmt::Debug + From<SyncMessage> + 'static,
 {

--- a/subduction_core/src/subduction/builder.rs
+++ b/subduction_core/src/subduction/builder.rs
@@ -493,7 +493,7 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
         Sig: Signer<F>,
         Tmr: Timeout<F> + Clone + Send + Sync + 'a,
         Sp: Spawn<F> + Send + Sync + 'static,
-        H: Handler<F, C>,
+        H: Handler<F, C> + crate::remote_heads::RemoteHeadsNotifier,
         H::Message: From<SyncMessage>,
         H::HandlerError: Into<ListenError<F, S, C, H::Message>>,
         crate::connection::managed::ManagedConnection<C, F, Tmr>:
@@ -577,7 +577,7 @@ impl<Sig, Sp, S, P, Tmr, M: DepthMetric, const N: usize>
         Sig: Signer<F>,
         Tmr: Timeout<F> + Clone + Send + Sync + 'a,
         Sp: Spawn<F> + Send + Sync + 'static,
-        H: Handler<F, C>,
+        H: Handler<F, C> + crate::remote_heads::RemoteHeadsNotifier,
         H::Message: From<SyncMessage>,
         H::HandlerError: Into<ListenError<F, S, C, H::Message>>,
         M: Clone,

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -449,3 +449,91 @@ async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResul
 
     Ok(())
 }
+
+/// When A subscribes to R for a sedimentree that R doesn't yet know
+/// about, R must propagate that subscription upstream to B so any
+/// future commits B pushes can be forwarded back through R to A.
+///
+/// This is the symmetric counterpart of the existing outbound
+/// broadcast in `SyncHandler::recv_commit` / `recv_fragment`:
+/// forwarding updates and forwarding subscription requests are now
+/// both done by every node.
+#[tokio::test]
+async fn relay_topology_propagates_subscriptions_upstream() -> TestResult {
+    let (a, r, b, _a_s, r_signer, b_signer) = setup_relay_topology().await?;
+
+    let sed_id = SedimentreeId::new([42u8; 32]);
+
+    // A subscribes to R for `sed_id`. R has no data yet — this is
+    // purely a subscription registration.
+    let r_peer = PeerId::from(r_signer.verifying_key());
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT).await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // The propagation runs after the handler returns, so give the
+    // listen loop a chance to dispatch it.
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    // R should now be subscribed to B for `sed_id` as a result of the
+    // propagation.
+    let b_peer = PeerId::from(b_signer.verifying_key());
+    let r_subscribed_to_b = r.get_peer_subscriptions(b_peer).await;
+    assert!(
+        r_subscribed_to_b.contains(&sed_id),
+        "R failed to propagate A's subscription upstream to B: {r_subscribed_to_b:?}"
+    );
+
+    // End-to-end: a commit pushed at B must reach A through R, even
+    // though A never subscribed directly to B and B never knew about
+    // A. This exercises the full update path:
+    //   B --LooseCommit--> R (because R subscribed to B above)
+    //   R --LooseCommit--> A (because A subscribed to R first)
+    b.add_commit(sed_id, make_head(99), BTreeSet::new(), make_blob(99))
+        .await?;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    assert_eq!(b.get_commits(sed_id).await.map(|c| c.len()), Some(1));
+    assert_eq!(
+        r.get_commits(sed_id).await.map(|c| c.len()),
+        Some(1),
+        "R did not receive commit from B"
+    );
+    assert_eq!(
+        a.get_commits(sed_id).await.map(|c| c.len()),
+        Some(1),
+        "A did not receive commit relayed from B via R"
+    );
+
+    Ok(())
+}
+
+/// Idempotency: a second subscribe from A for the same sedimentree
+/// must NOT cause R to re-issue its upstream subscribe to B (which
+/// would be wasted wire traffic). We rely on
+/// `outgoing_subscriptions` having recorded the first propagation.
+#[tokio::test]
+async fn relay_topology_repeated_subscribe_does_not_re_propagate() -> TestResult {
+    let (a, r, _b, _a_s, r_signer, b_signer) = setup_relay_topology().await?;
+    let sed_id = SedimentreeId::new([43u8; 32]);
+    let r_peer = PeerId::from(r_signer.verifying_key());
+    let b_peer = PeerId::from(b_signer.verifying_key());
+
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT).await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+    assert!(r.get_peer_subscriptions(b_peer).await.contains(&sed_id));
+
+    // Second subscribe from A. Propagation should short-circuit because
+    // R already has `(B, sed_id)` in `outgoing_subscriptions`. We can't
+    // easily count wire messages here, but verifying the subscription
+    // set hasn't grown (still exactly the same sedimentree) is a
+    // proxy.
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT).await?;
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+
+    let r_subs = r.get_peer_subscriptions(b_peer).await;
+    assert_eq!(r_subs.len(), 1);
+    assert!(r_subs.contains(&sed_id));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Make subscription forwarding symmetric with update forwarding. Previously a Subduction node forwarded `LooseCommit` / `Fragment` updates to its subscribers but did **not** forward inbound `BatchSyncRequest { subscribe: true }` to its own upstream peers. In a relay topology `A — R — B`, that meant a later write at `B` only reached `A` if someone had manually arranged for `R` to subscribe to `B` first. With this change, when `R` accepts a subscribe from `A` for sedimentree `X`, `R` automatically subscribes to every other connected peer for `X` too.

Per discussion with the main author this is not behind a config flag — we want one consistent behaviour across the network rather than speciation.

## How

- `Handler::as_subscribe_request(&Self::Message) -> Option<SedimentreeId>`: new trait method, default `None`. `SyncHandler` returns `Some(req.id)` for `BatchSyncRequest { subscribe: true, .. }`. Lets the listen loop peek inbound subscribes without hard-coding `SyncMessage`.
- `Subduction::propagate_subscription(id, originator)`: snapshots the connection set, filters out the originator, dedups against `outgoing_subscriptions` (idempotency + loop self-quenching in mutually-subscribed pairs), and calls `sync_with_peer(peer, id, subscribe = true, None)` for the survivors. Errors are logged at `debug!`, never bubbled — propagation is best-effort.
- `Subduction::listen()`: peeks `H::as_subscribe_request(&msg)` before dispatch and runs propagation inline in the same `FuturesUnordered` task after the handler future resolves. No new channels or background tasks.
- The propagation calls `sync_with_peer`, which requires `H: RemoteHeadsNotifier`. That bound is added to the impl block holding `new` / `listen` and to the `StartListener` impls (Sendable and Local). All in-tree callers already use `SyncHandler`, which implements it.

## Design notes (intentionally deferred)

- **Loop avoidance:** we rely on `outgoing_subscriptions` self-quenching after one round. No TTL or origin tagging.
- **Disconnect handling:** the existing `on_peer_disconnect` already clears `outgoing_subscriptions` for the dropped peer; subscriptions re-fire on reconnect via the normal restoration path.
- **Wire amplification:** in a fully-connected mesh this fans out one inbound subscribe to (N−1) outbound subscribes per node, but each upstream dedups on its own `outgoing_subscriptions`, so steady-state cost is bounded.

## Test plan

- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy -p subduction_core --all-targets` clean
- [x] `cargo test -p subduction_core --test relay_topology_sync` — 10/10 pass, including two new tests:
  - `relay_topology_propagates_subscriptions_upstream` — A subscribes to R for a fresh sedimentree, then a commit pushed at B reaches A through R end-to-end. Also asserts R's `get_peer_subscriptions(B)` contains the sedimentree.
  - `relay_topology_repeated_subscribe_does_not_re_propagate` — a second subscribe from A doesn't grow R's outgoing subscription set; exercises the `outgoing_subscriptions` dedup.
- [x] Full `cargo test -p subduction_core` is green except for the pre-existing failure in the untracked `tests/heads_coalescing.rs` (verified by stashing and re-running on the baseline branch — it fails identically without these changes).

Made with [Cursor](https://cursor.com)