### PR TITLE
Turn off keyhive storage recovery by default

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -72,6 +72,14 @@ exclude_re = [
     # input can exercise, so the `+ -> -` / `+ -> *` mutants there
     # cannot be killed by any test.
     "subduction_crypto/src/signed.rs:255:.*Signed<T>::try_decode",
+
+    # subduction_keyhive/src/runtime.rs::run_local_keyhive is !Send runtime
+    # orchestration: it generates a keyhive, spawns the actor + cache-refresh
+    # tasks, calls policy_setup, and blocks on cancellation. Like the excluded
+    # subduction_cli server.rs above, it is wiring with no return value or
+    # branch logic to assert; replacing the body with () cannot be killed
+    # without a full threaded integration harness.
+    "subduction_keyhive/src/runtime\.rs:.*run_local_keyhive",
 ]
 
 # Be a little patient with builds. The workspace is large, and the

--- a/subduction_cli/src/keyhive.rs
+++ b/subduction_cli/src/keyhive.rs
@@ -3,7 +3,10 @@
 //! CLI-specific types: filesystem storage ([`FsKeyhiveStorage`]) and
 //! connection adapter ([`CliConnKeyhiveAdapter`]).
 
-use core::convert::Infallible;
+use core::{
+    convert::Infallible,
+    sync::atomic::{AtomicU64, Ordering},
+};
 use std::{io, path::PathBuf};
 
 use future_form::Sendable;
@@ -22,6 +25,11 @@ use crate::{handler::CliConn, transport::TransportSendError, wire::CliWireMessag
 const ARCHIVES_SUBDIR: &str = "archives";
 const OPS_SUBDIR: &str = "ops";
 const TMP_SUBDIR: &str = "tmp";
+
+/// Monotonic per-process counter for temp filenames. A unique temp path per
+/// save lets concurrent saves of the same hash proceed without sharing a
+/// temp file.
+static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
 
 /// Filesystem-backed [`KeyhiveStorage`].
 ///
@@ -71,10 +79,30 @@ impl FsKeyhiveStorage {
         data: Vec<u8>,
     ) -> io::Result<()> {
         let filename = format!("{}.bin", hash.to_hex());
-        let tmp = self.tmp_dir().join(&filename);
         let dest = parent_dir.join(&filename);
+
+        let tmp_id = NEXT_TMP_ID.fetch_add(1, Ordering::Relaxed);
+        let tmp = self.tmp_dir().join(format!(
+            "{}.{}.{tmp_id}.tmp",
+            hash.to_hex(),
+            std::process::id()
+        ));
+
         tokio::fs::write(&tmp, data).await?;
-        tokio::fs::rename(&tmp, &dest).await
+        match tokio::fs::rename(&tmp, &dest).await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Best-effort cleanup of the temp file after a failed rename.
+                let _ = tokio::fs::remove_file(&tmp).await;
+                // Content is hash-addressed. If `dest` already exists, an
+                // equivalent save already stored it, so treat this as success.
+                if tokio::fs::try_exists(&dest).await.unwrap_or(false) {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            }
+        }
     }
 
     async fn load_dir(dir: PathBuf) -> io::Result<Vec<(StorageHash, Vec<u8>)>> {

--- a/subduction_cli/src/keyhive.rs
+++ b/subduction_cli/src/keyhive.rs
@@ -93,7 +93,7 @@ impl FsKeyhiveStorage {
             Ok(()) => Ok(()),
             Err(e) => {
                 // Best-effort cleanup of the temp file after a failed rename.
-                let _ = tokio::fs::remove_file(&tmp).await;
+                drop(tokio::fs::remove_file(&tmp).await);
                 // Content is hash-addressed. If `dest` already exists, an
                 // equivalent save already stored it, so treat this as success.
                 if tokio::fs::try_exists(&dest).await.unwrap_or(false) {

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -97,6 +97,11 @@ where
     peers: Mutex<Map<KeyhivePeerId, Conn>>,
     contact_card: ContactCard,
     archive_config: Option<(usize, StorageHash)>,
+    /// Whether to reload and re-ingest the store when events remain pending
+    /// after ingestion.
+    ///
+    /// False by default. Enable it with [`Self::with_storage_recovery`].
+    attempt_storage_recovery: bool,
     syncpoints: Mutex<SyncpointMap>,
     cache: Mutex<PeriodicEventCache>,
     _marker: core::marker::PhantomData<Async>,
@@ -155,6 +160,7 @@ where
             peers: Mutex::new(Map::new()),
             contact_card,
             archive_config: None,
+            attempt_storage_recovery: false,
             syncpoints: Mutex::new(SyncpointMap::new()),
             cache: Mutex::new(PeriodicEventCache::new()),
             _marker: core::marker::PhantomData,
@@ -170,6 +176,13 @@ where
         storage_id: StorageHash,
     ) -> Self {
         self.archive_config = Some((threshold, storage_id));
+        self
+    }
+
+    /// Enable storage recovery when events remain pending after ingestion.
+    #[must_use]
+    pub const fn with_storage_recovery(mut self) -> Self {
+        self.attempt_storage_recovery = true;
         self
     }
 
@@ -1061,15 +1074,22 @@ where
         };
 
         if !pending.is_empty() {
-            tracing::warn!(
-                count = pending.len(),
-                "some events pending after ingestion, attempting storage recovery"
-            );
-
-            if let Err(e) = self.try_storage_recovery(event_bytes_list).await {
+            if self.attempt_storage_recovery {
                 tracing::warn!(
-                    error = %e,
-                    "storage recovery failed"
+                    count = pending.len(),
+                    "events pending after ingestion, attempting storage recovery"
+                );
+
+                if let Err(e) = self.try_storage_recovery(event_bytes_list).await {
+                    tracing::warn!(
+                        error = %e,
+                        "storage recovery failed"
+                    );
+                }
+            } else {
+                tracing::warn!(
+                    count = pending.len(),
+                    "events pending after ingestion; storage recovery disabled"
                 );
             }
         }

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -2034,6 +2034,118 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn ingest_events_triggers_recovery_only_when_enabled() {
+        // `other` creates a group, then adds a member. The add-member
+        // delegation depends on the group-creation delegation, so feeding
+        // only the former to a fresh keyhive leaves it pending.
+        //
+        // Storage holds `other`'s full archive. A pending event should
+        // trigger a reload from storage only when recovery is enabled, so
+        // the destination keyhive's op count grows only in that case. This
+        // pins both the `with_storage_recovery` wiring and the pending
+        // guard in `ingest_events`.
+        let other = make_keyhive().await;
+        let member = make_keyhive().await;
+        let member_id = keyhive_peer_id(&member);
+        let member_cc = member.contact_card().await.unwrap();
+        other.receive_contact_card(&member_cc).await.unwrap();
+
+        let other_id = keyhive_peer_id(&other);
+        let other_cc = other.contact_card().await.unwrap();
+        let other_proto = TestProtocol::new(
+            Arc::new(Mutex::new(other.clone())),
+            MemoryKeyhiveStorage::new(),
+            other_id.clone(),
+            other_cc,
+        );
+
+        // Group-creation delegation.
+        let group = other.generate_group(vec![]).await.unwrap();
+        let group_id = group.lock().await.group_id();
+        let before_add: Vec<EventHash> = other_proto
+            .get_events_for_agent(&other_id)
+            .await
+            .unwrap()
+            .expect("other resolves to an agent")
+            .into_keys()
+            .collect();
+        assert!(
+            !before_add.is_empty(),
+            "group creation should produce a delegation"
+        );
+
+        // Add-member delegation, which depends on the group-creation one.
+        let agent = other
+            .get_agent(member_id.to_identifier().unwrap())
+            .await
+            .unwrap();
+        other
+            .add_member(
+                agent,
+                &Membered::Group(group_id, group.clone()),
+                Access::Read,
+                &[],
+            )
+            .await
+            .unwrap();
+        let dependent: Vec<EventBytes> = other_proto
+            .get_events_for_agent(&other_id)
+            .await
+            .unwrap()
+            .expect("other resolves to an agent")
+            .into_iter()
+            .filter(|(hash, _)| !before_add.contains(hash))
+            .map(|(_, (bytes, _))| bytes)
+            .collect();
+        assert!(
+            !dependent.is_empty(),
+            "add_member should introduce a dependent delegation"
+        );
+
+        // Store `other`'s full archive so recovery has deps to reload.
+        let storage = MemoryKeyhiveStorage::new();
+        let storage_id = crate::storage::StorageHash::new([9u8; 32]);
+        let archive = other.into_archive().await;
+        crate::storage_ops::save_keyhive_archive::<_, _, Local>(&storage, storage_id, &archive)
+            .await
+            .unwrap();
+
+        // Recovery disabled: the pending event ingests nothing and no
+        // reload happens, so the op count is unchanged.
+        let dst_off = make_keyhive().await;
+        let proto_off = TestProtocol::new(
+            Arc::new(Mutex::new(dst_off.clone())),
+            storage.clone(),
+            keyhive_peer_id(&dst_off),
+            dst_off.contact_card().await.unwrap(),
+        );
+        let before_off = proto_off.total_ops().await;
+        proto_off.ingest_events(&dependent).await.unwrap();
+        assert_eq!(
+            proto_off.total_ops().await,
+            before_off,
+            "with recovery off, a pending event must not change the op count"
+        );
+
+        // Recovery enabled: the pending event triggers a reload of the
+        // archive, raising the op count.
+        let dst_on = make_keyhive().await;
+        let proto_on = TestProtocol::new(
+            Arc::new(Mutex::new(dst_on.clone())),
+            storage.clone(),
+            keyhive_peer_id(&dst_on),
+            dst_on.contact_card().await.unwrap(),
+        )
+        .with_storage_recovery();
+        let before_on = proto_on.total_ops().await;
+        proto_on.ingest_events(&dependent).await.unwrap();
+        assert!(
+            proto_on.total_ops().await > before_on,
+            "with recovery on, a pending event must reload the archive and raise the op count"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn handle_sync_response_serves_requested_from_cached_pair() {
         // Regression test for the byte-fetch divergence between ARK and
         // Subduction (see

--- a/subduction_keyhive/src/runtime.rs
+++ b/subduction_keyhive/src/runtime.rs
@@ -57,6 +57,12 @@ pub type SendableRuntimeKeyhive = Keyhive<
 pub struct RuntimeConfig {
     /// Interval between periodic cache refreshes.
     pub cache_refresh_interval: Duration,
+
+    /// Whether to reload and re-ingest the store when events remain pending
+    /// after ingestion.
+    ///
+    /// False by default.
+    pub attempt_storage_recovery: bool,
     // /// Minimum interval between outbound sync requests to the same peer.
     // ///
     // TODO: Implement
@@ -88,10 +94,10 @@ impl Default for RuntimeConfig {
     fn default() -> Self {
         Self {
             cache_refresh_interval: Duration::from_secs(2),
+            attempt_storage_recovery: false,
             // min_sync_request_interval: Duration::from_secs(1),
             // min_sync_response_interval: Duration::from_secs(1),
             // batch_interval: None,
-            // attempt_storage_recovery: true,
             // suppress_writes_during_ingest: false,
         }
     }
@@ -225,17 +231,17 @@ async fn run_local_keyhive<C, Conn, Store, ConnAdapter, PolicySetup>(
 
     let shared = Arc::new(AsyncMutex::new(keyhive));
     let policy_keyhive = Arc::clone(&shared);
-    let protocol = Arc::new(KeyhiveProtocol::<
-        _,
-        Vec<u8>,
-        Vec<u8>,
-        _,
-        _,
-        _,
-        Conn,
-        Store,
-        future_form::Local,
-    >::new(shared, storage, peer_id, contact_card));
+    let mut protocol =
+        KeyhiveProtocol::<_, Vec<u8>, Vec<u8>, _, _, _, Conn, Store, future_form::Local>::new(
+            shared,
+            storage,
+            peer_id,
+            contact_card,
+        );
+    if config.attempt_storage_recovery {
+        protocol = protocol.with_storage_recovery();
+    }
+    let protocol = Arc::new(protocol);
 
     if let Err(e) = protocol.ingest_from_storage().await {
         tracing::warn!("keyhive ingest_from_storage failed: {e}");


### PR DESCRIPTION
This configuration option was meant for scenarios where we are coordinating across tabs in a browser and not for sync servers. We may remove this behavior altogether but for now I'm turning it off by default and making it configurable so that the sync server doesn't behave this way.

I've also included a small fix to how we're handling temp files for renames in keyhive storage.