### PR TITLE
Consistent `store_*` vs `add_*` APIs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,5 +47,18 @@ jobs:
     - name: Clippy
       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+    - name: Install wasm32 target
+      run: rustup target add wasm32-unknown-unknown
+
+    - name: Clippy (wasm32 target)
+      # The host clippy above never sees `#![cfg(target_arch = "wasm32")]`
+      # code, so lint the wasm cdylib crates against wasm32 too. A per-crate
+      # loop (not `--workspace --target wasm32`) because the non-wasm members
+      # (tokio transports, CLI, …) do not build for wasm32.
+      run: |
+        for crate in subduction_wasm sedimentree_wasm automerge_subduction_wasm subduction_wasm_bootstrap; do
+          cargo clippy -p "$crate" --target wasm32-unknown-unknown --all-targets --all-features -- -D warnings
+        done
+
     - name: Lint wasm_bindgen &mut boundaries
       run: ./scripts/lint-wasm-mut.sh --github-annotations

--- a/automerge_subduction_ingest/src/main.rs
+++ b/automerge_subduction_ingest/src/main.rs
@@ -370,8 +370,9 @@ async fn main() -> Result<()> {
     let timeout_dur = std::time::Duration::from_secs(args.timeout);
     tokio::time::timeout(timeout_dur, async {
         subduction
-            .add_sedimentree(sed_id, result.sedimentree, result.blobs)
+            .add_sedimentree(sed_id, result.sedimentree, result.blobs, None)
             .await
+            .map(|_per_peer| ())
             .map_err(|e| eyre!("upload failed: {e}"))
     })
     .await

--- a/sedimentree_fs_storage/tests/relay_topology_fs.rs
+++ b/sedimentree_fs_storage/tests/relay_topology_fs.rs
@@ -204,7 +204,8 @@ async fn fs_relay_single_client_repeated_add_built_batch_converges() -> TestResu
     let total = 10_u8;
     for seed in 1..=total {
         let pair = make_commit_pair(sed_id, seed);
-        h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+        h.a.add_built_batch(sed_id, vec![pair], Vec::new(), None)
+            .await?;
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
 
@@ -239,10 +240,12 @@ async fn fs_relay_two_clients_add_built_batch_converge_via_relay() -> TestResult
     for i in 0..total_pairs {
         if i % 2 == 0 {
             let pair = make_commit_pair(sed_id, i + 1);
-            h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+            h.a.add_built_batch(sed_id, vec![pair], Vec::new(), None)
+                .await?;
         } else {
             let pair = make_commit_pair(sed_id, 100 + i);
-            h.b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+            h.b.add_built_batch(sed_id, vec![pair], Vec::new(), None)
+                .await?;
         }
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
@@ -280,10 +283,12 @@ async fn fs_relay_two_clients_rapid_fire_converges() -> TestResult {
     for i in 0..total_u8 {
         if i % 2 == 0 {
             let pair = make_commit_pair(sed_id, i + 1);
-            h.a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+            h.a.add_built_batch(sed_id, vec![pair], Vec::new(), None)
+                .await?;
         } else {
             let pair = make_commit_pair(sed_id, 100 + i);
-            h.b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+            h.b.add_built_batch(sed_id, vec![pair], Vec::new(), None)
+                .await?;
         }
     }
 
@@ -322,7 +327,7 @@ async fn fs_relay_concurrent_add_built_batch_calls_converge() -> TestResult {
         let a_clone = h.a.clone();
         handles.push(tokio::spawn(async move {
             a_clone
-                .add_built_batch(sed_id, vec![pair], Vec::new())
+                .add_built_batch(sed_id, vec![pair], Vec::new(), None)
                 .await
         }));
     }

--- a/sedimentree_wasm/tests/fingerprint_stability_wasm.rs
+++ b/sedimentree_wasm/tests/fingerprint_stability_wasm.rs
@@ -9,6 +9,9 @@
 
 #![cfg(target_arch = "wasm32")]
 #![allow(missing_docs)]
+// `test_seed` is a test helper; whether it can be `const` depends on the
+// active feature set, so don't force it.
+#![allow(clippy::missing_const_for_fn)]
 
 use sedimentree_core::{
     crypto::fingerprint::{Fingerprint, FingerprintSeed},

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -67,7 +67,7 @@ use crate::{
         Connection,
         backoff::Backoff,
         id::ConnectionId,
-        managed::{ManagedCall, ManagedConnection},
+        managed::{CallError, ManagedCall, ManagedConnection},
         manager::{Command, ConnectionManager, RunManager, Spawn},
         message::{
             BatchSyncRequest, BatchSyncResponse, DataRequestRejected, RequestedData, SyncDiff,
@@ -220,7 +220,107 @@ pub struct Subduction<
     _phantom: core::marker::PhantomData<&'a Async>,
 }
 
-/// A single fragment for [`Subduction::add_fragments_batch`].
+/// Per-peer outcome of a broadcast / sync round, keyed by [`PeerId`].
+///
+/// Returned by [`sync_with_all_peers`](Subduction::sync_with_all_peers) and
+/// the round-trip `add_*` combinators
+/// ([`add_built_batch`](Subduction::add_built_batch),
+/// [`add_sedimentree`](Subduction::add_sedimentree)) so callers can observe
+/// which peers acked and which failed.
+///
+/// Each entry's value is `(succeeded, stats, per-connection call errors)`.
+/// The newtype [`Deref`]s to the underlying [`Map`], so `.get(&peer)`,
+/// `.iter()`, `.is_empty()`, etc. work directly; it also implements
+/// [`IntoIterator`] and [`FromIterator`].
+pub struct PerPeerSync<Conn: Clone, Async: FutureForm, SendErr: core::error::Error>(
+    Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)>,
+);
+
+impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> PerPeerSync<Conn, Async, SendErr> {
+    /// The inner per-peer map.
+    #[must_use]
+    pub const fn as_map(
+        &self,
+    ) -> &Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)> {
+        &self.0
+    }
+
+    /// Consume into the inner per-peer map.
+    #[must_use]
+    pub fn into_map(
+        self,
+    ) -> Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)> {
+        self.0
+    }
+}
+
+impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> core::fmt::Debug
+    for PerPeerSync<Conn, Async, SendErr>
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PerPeerSync")
+            .field("peers", &self.0.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> Default
+    for PerPeerSync<Conn, Async, SendErr>
+{
+    fn default() -> Self {
+        Self(Map::new())
+    }
+}
+
+impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> core::ops::Deref
+    for PerPeerSync<Conn, Async, SendErr>
+{
+    type Target =
+        Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> IntoIterator
+    for PerPeerSync<Conn, Async, SendErr>
+{
+    type Item = (
+        PeerId,
+        (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
+    );
+    type IntoIter = <Map<
+        PeerId,
+        (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
+    > as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error>
+    FromIterator<(
+        PeerId,
+        (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
+    )> for PerPeerSync<Conn, Async, SendErr>
+{
+    fn from_iter<
+        T: IntoIterator<
+                Item = (
+                    PeerId,
+                    (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
+                ),
+            >,
+    >(
+        iter: T,
+    ) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+/// A single fragment for [`Subduction::store_fragments_batch`].
 #[derive(Debug, Clone)]
 pub struct FragmentBatchItem {
     /// The head commit of the fragment.
@@ -1326,10 +1426,64 @@ where
      * INCREMENTAL CHANGES *
      ***********************/
 
+    /// Persist a new (incremental) commit locally — **no network**.
+    ///
+    /// The persistence half of [`add_commit`](Self::add_commit): constructs
+    /// and signs the commit, inserts it into local storage and the
+    /// in-memory tree, and re-minimizes. It never contacts peers, so it
+    /// returns as soon as the write is durable. Propagate later via
+    /// [`add_commit`](Self::add_commit) (which pushes the delta) or a sync.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(None)` if the commit is not on a fragment boundary.
+    /// * `Ok(Some(FragmentRequested))` if the commit is on a [`Fragment`]
+    ///   boundary — create the requested fragment and call
+    ///   [`store_fragment`](Self::store_fragment) / [`add_fragment`](Self::add_fragment).
+    ///
+    /// # Errors
+    ///
+    /// * [`WriteError::Io`] (`IoError::Storage`) if a storage error occurs.
+    ///
+    /// Note: `WriteError::PutDisallowed` is unreachable for local writes.
+    pub async fn store_commit(
+        &self,
+        id: SedimentreeId,
+        head: CommitId,
+        parents: BTreeSet<CommitId>,
+        blob: Blob,
+    ) -> Result<
+        Option<FragmentRequested>,
+        WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>,
+    > {
+        let putter = self.storage.local_putter::<Async>(id);
+
+        let verified_blob = VerifiedBlobMeta::new(blob);
+        let verified_meta: VerifiedMeta<LooseCommit> =
+            VerifiedMeta::seal::<Async, _>(&self.signer, (id, head, parents), verified_blob).await;
+        let commit_head = verified_meta.payload().head();
+
+        self.insert_commit_locally(&putter, verified_meta)
+            .await
+            .map_err(|e| WriteError::Io(IoError::Storage(e)))?;
+
+        self.minimize_tree(id).await;
+
+        let depth = self.depth_metric.to_depth(commit_head);
+        Ok(depth
+            .is_boundary()
+            .then(|| FragmentRequested::new(commit_head, depth)))
+    }
+
     /// Add a new (incremental) commit locally and propagate it to all connected peers.
     ///
     /// The commit is constructed internally from the provided parts, ensuring
     /// that the blob metadata is computed correctly from the blob.
+    ///
+    /// This is the store+propagate combinator for a single commit;
+    /// propagation is a best-effort push (`Connection::send`) to authorized
+    /// subscribers, so it does not block on peer acks. For a durable write
+    /// with no propagation, use [`store_commit`](Self::store_commit).
     ///
     /// # Returns
     ///
@@ -1429,10 +1583,56 @@ where
         Ok(maybe_requested_fragment)
     }
 
+    /// Persist a new (incremental) fragment locally — **no network**.
+    ///
+    /// The persistence half of [`add_fragment`](Self::add_fragment):
+    /// constructs and signs the fragment, inserts it into local storage and
+    /// the in-memory tree, and re-minimizes. It never contacts peers, so it
+    /// returns as soon as the write is durable. Propagate later via
+    /// [`add_fragment`](Self::add_fragment) or a sync.
+    ///
+    /// NOTE this performs no integrity checks; we assume this is a good
+    /// fragment at the right depth.
+    ///
+    /// # Errors
+    ///
+    /// * [`WriteError::Io`] (`IoError::Storage`) if a storage error occurs.
+    pub async fn store_fragment(
+        &self,
+        id: SedimentreeId,
+        head: CommitId,
+        boundary: BTreeSet<CommitId>,
+        checkpoints: &[CommitId],
+        blob: Blob,
+    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
+        let verified_blob = VerifiedBlobMeta::new(blob);
+        let putter = self.storage.local_putter::<Async>(id);
+
+        let verified_meta: VerifiedMeta<Fragment> = VerifiedMeta::seal::<Async, _>(
+            &self.signer,
+            (id, head, boundary, checkpoints.to_vec()),
+            verified_blob,
+        )
+        .await;
+
+        self.insert_fragment_locally(&putter, verified_meta)
+            .await
+            .map_err(|e| WriteError::Io(IoError::Storage(e)))?;
+
+        self.minimize_tree(id).await;
+
+        Ok(())
+    }
+
     /// Add a new (incremental) fragment locally and propagate it to all connected peers.
     ///
     /// The fragment is constructed internally from the provided parts, ensuring
     /// that the blob metadata is computed correctly from the blob.
+    ///
+    /// This is the store+propagate combinator for a single fragment;
+    /// propagation is a best-effort push (`Connection::send`) to authorized
+    /// subscribers, so it does not block on peer acks. For a durable write
+    /// with no propagation, use [`store_fragment`](Self::store_fragment).
     ///
     /// NOTE this performs no integrity checks;
     /// we assume this is a good fragment at the right depth
@@ -1552,7 +1752,7 @@ where
     ///
     /// Note: `WriteError::PutDisallowed` is unreachable for local writes
     /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
-    pub async fn add_commits_batch(
+    pub async fn store_commits_batch(
         &self,
         id: SedimentreeId,
         commits: Vec<(CommitId, BTreeSet<CommitId>, Blob)>,
@@ -1615,7 +1815,7 @@ where
     ///
     /// Note: `WriteError::PutDisallowed` is unreachable for local writes
     /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
-    pub async fn add_fragments_batch(
+    pub async fn store_fragments_batch(
         &self,
         id: SedimentreeId,
         fragments: Vec<FragmentBatchItem>,
@@ -1667,16 +1867,17 @@ where
         Ok(())
     }
 
-    /// Bulk-insert already-built [`LooseCommit`] and [`Fragment`] payloads
-    /// alongside their blobs into local storage and the in-memory tree only.
+    /// Persist already-built [`LooseCommit`] and [`Fragment`] payloads
+    /// alongside their blobs to local storage and the in-memory tree —
+    /// **no network**.
     ///
-    /// This is the local-only counterpart to
-    /// [`add_built_batch`](Self::add_built_batch): it signs each payload,
-    /// flushes to storage in a single `save_batch` call, applies the in-memory
-    /// updates under one shard lock, and minimizes once — but does *not*
-    /// follow up with [`sync_with_all_peers`](Self::sync_with_all_peers). Use
-    /// when the caller will trigger sync explicitly (or never), e.g. from a
-    /// background ingestion path.
+    /// The persistence half of [`add_built_batch`](Self::add_built_batch):
+    /// it signs each payload, flushes to storage in a single `save_batch`
+    /// call, applies the in-memory updates under one shard lock, and
+    /// minimizes once. It never contacts peers, so it returns the instant
+    /// the write is durable — a wedged peer cannot stall it. Pair with
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers) (or let the host
+    /// drive it in the background) to propagate.
     ///
     /// Commits are inserted before fragments. Passing two empty vectors is a
     /// no-op (no minimize).
@@ -1694,7 +1895,7 @@ where
     ///
     /// Note: `WriteError::PutDisallowed` is unreachable for local writes
     /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
-    pub async fn add_built_batch_locally(
+    pub async fn store_built_batch(
         &self,
         id: SedimentreeId,
         commits: Vec<(LooseCommit, Blob)>,
@@ -1907,15 +2108,24 @@ where
             SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
         >,
 {
-    /// Add a new sedimentree locally and propagate it to all connected peers.
+    /// Persist a whole sedimentree (its commits and fragments, paired with
+    /// `blobs`) to local storage and the in-memory tree — **no network**.
+    ///
+    /// The persistence half of [`add_sedimentree`](Self::add_sedimentree):
+    /// it signs each item, pairs it with its blob, and flushes locally. It
+    /// never contacts peers, so it returns as soon as the write is durable.
+    /// Pair with [`sync_with_all_peers`](Self::sync_with_all_peers) to
+    /// propagate.
     ///
     /// # Errors
     ///
-    /// * [`WriteError::Io`] if a storage or network error occurs.
+    /// * [`WriteError::MissingBlob`] if a commit/fragment references a blob
+    ///   not present in `blobs`.
+    /// * [`WriteError::Io`] if a storage error occurs.
     ///
     /// Note: `WriteError::PutDisallowed` is unreachable for local writes
     /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
-    pub async fn add_sedimentree(
+    pub async fn store_sedimentree(
         &self,
         id: SedimentreeId,
         sedimentree: Sedimentree,
@@ -1961,24 +2171,67 @@ where
             .await
             .map_err(|e| WriteError::Io(IoError::Storage(e)))?;
 
-        self.sync_with_all_peers(id, true, None).await?;
         Ok(())
     }
 
-    /// Bulk-insert already-built [`LooseCommit`] and [`Fragment`] payloads
-    /// alongside their blobs, signing each, then minimize once and broadcast.
+    /// Persist a whole sedimentree **and** propagate it to peers — the
+    /// convenience combinator of
+    /// [`store_sedimentree`](Self::store_sedimentree) +
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers).
     ///
-    /// This is the underlying "do everything in one round-trip" entrypoint used
-    /// by callers that already have payloads in their canonical, post-truncation
-    /// form (notably the Wasm bindings, which carry [`Fragment`] values whose
-    /// checkpoints are already truncated). Unlike
-    /// [`add_commits_batch`](Self::add_commits_batch) and
-    /// [`add_fragments_batch`](Self::add_fragments_batch), this method also
-    /// performs a single [`sync_with_all_peers`](Self::sync_with_all_peers) at
-    /// the end so callers don't need to follow up with a separate broadcast.
+    /// Awaits the broadcast and returns its per-peer outcome
+    /// ([`PerPeerSync`]); a wedged peer can stall this for up to `timeout`
+    /// (`None` = configured `default_call_timeout`). For a durable write
+    /// that does not wait on peers, use
+    /// [`store_sedimentree`](Self::store_sedimentree) and drive sync
+    /// separately.
+    ///
+    /// # Errors
+    ///
+    /// * [`WriteError::MissingBlob`] / [`WriteError::Io`] as for
+    ///   [`store_sedimentree`](Self::store_sedimentree). Per-peer transport
+    ///   failures are reported in the returned map, not as `Err`.
+    ///
+    /// Note: `WriteError::PutDisallowed` is unreachable for local writes.
+    pub async fn add_sedimentree(
+        &self,
+        id: SedimentreeId,
+        sedimentree: Sedimentree,
+        blobs: Vec<Blob>,
+        timeout: Option<Duration>,
+    ) -> Result<
+        PerPeerSync<Conn, Async, <Conn as Connection<Async, Hdl::Message>>::SendError>,
+        WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>,
+    > {
+        self.store_sedimentree(id, sedimentree, blobs).await?;
+        let per_peer = self
+            .sync_with_all_peers(id, true, timeout)
+            .await
+            .map_err(WriteError::Io)?;
+        Ok(per_peer)
+    }
+
+    /// Persist already-built [`LooseCommit`] and [`Fragment`] payloads
+    /// **and** propagate them to peers — the convenience combinator of
+    /// [`store_built_batch`](Self::store_built_batch) +
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers).
+    ///
+    /// Used by callers that already have payloads in their canonical,
+    /// post-truncation form (notably the Wasm bindings, which carry
+    /// [`Fragment`] values whose checkpoints are already truncated) and
+    /// want both phases in one call.
+    ///
+    /// This **awaits the broadcast** and returns its per-peer outcome
+    /// ([`PerPeerSync`]). A byte-connected but protocol-unresponsive peer
+    /// can therefore stall this call for up to `timeout` (or the configured
+    /// `default_call_timeout` when `timeout` is `None`). Callers that need
+    /// the durable write to return *without* waiting on peers should call
+    /// [`store_built_batch`](Self::store_built_batch) and drive
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers) separately (or let
+    /// the host run it in the background).
     ///
     /// Commits are inserted before fragments. Passing two empty vectors is a
-    /// no-op (no minimize, no broadcast).
+    /// no-op (no minimize, no broadcast) and yields an empty map.
     ///
     /// # Errors
     ///
@@ -1994,14 +2247,10 @@ where
     ///   digest does not match its payload's claimed
     ///   [`BlobMeta`](sedimentree_core::blob::BlobMeta).
     ///
-    /// Per-peer transport failures during the trailing broadcast are *not*
-    /// surfaced as `Err`. [`sync_with_all_peers`](Self::sync_with_all_peers)
-    /// reports those out-of-band in its `Ok` value (a per-peer map of
-    /// successes and per-connection [`CallError`](crate::connection::managed::CallError)s);
-    /// this method discards that map. If a caller needs to observe peer-level
-    /// sync outcomes, prefer driving the local insert via
-    /// [`add_built_batch_locally`](Self::add_built_batch_locally) and calling
-    /// [`sync_with_all_peers`](Self::sync_with_all_peers) directly.
+    /// Per-peer transport failures during the broadcast are *not* surfaced as
+    /// `Err`; they appear in the returned [`PerPeerSync`] map (per-peer
+    /// success flag + per-connection
+    /// [`CallError`](crate::connection::managed::CallError)s).
     ///
     /// Note: `WriteError::PutDisallowed` is unreachable for local writes
     /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
@@ -2010,16 +2259,23 @@ where
         id: SedimentreeId,
         commits: Vec<(LooseCommit, Blob)>,
         fragments: Vec<(Fragment, Blob)>,
-    ) -> Result<(), WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>> {
+        timeout: Option<Duration>,
+    ) -> Result<
+        PerPeerSync<Conn, Async, <Conn as Connection<Async, Hdl::Message>>::SendError>,
+        WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>,
+    > {
         if commits.is_empty() && fragments.is_empty() {
-            return Ok(());
+            return Ok(PerPeerSync::default());
         }
 
         // Storage write first (cancel-safety: storage is the source of truth;
         // a cancel between this and the broadcast self-heals on rehydrate).
-        self.add_built_batch_locally(id, commits, fragments).await?;
-        self.sync_with_all_peers(id, true, None).await?;
-        Ok(())
+        self.store_built_batch(id, commits, fragments).await?;
+        let per_peer = self
+            .sync_with_all_peers(id, true, timeout)
+            .await
+            .map_err(WriteError::Io)?;
+        Ok(per_peer)
     }
 
     /// Forward an inbound subscription for `id` to every connected peer
@@ -2386,19 +2642,7 @@ where
         subscribe: bool,
         timeout: Option<Duration>,
     ) -> Result<
-        Map<
-            PeerId,
-            (
-                bool,
-                SyncStats,
-                Vec<(
-                    Authenticated<Conn, Async>,
-                    crate::connection::managed::CallError<
-                        <Conn as Connection<Async, Hdl::Message>>::SendError,
-                    >,
-                )>,
-            ),
-        >,
+        PerPeerSync<Conn, Async, <Conn as Connection<Async, Hdl::Message>>::SendError>,
         IoError<Async, Store, Conn, Hdl::Message>,
     > {
         tracing::info!(
@@ -2668,7 +2912,7 @@ where
                 }
             }
         }
-        Ok(out)
+        Ok(PerPeerSync(out))
     }
 
     /// Sync all known [`Sedimentree`]s with a single peer.

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -858,12 +858,11 @@ where
             }
         };
 
-        match detached {
-            Some(muxes) => self.teardown_peer(&peer_id, muxes, 1).await,
-            None => {
-                #[cfg(feature = "metrics")]
-                crate::metrics::connection_closed();
-            }
+        if let Some(muxes) = detached {
+            self.teardown_peer(&peer_id, muxes, 1).await;
+        } else {
+            #[cfg(feature = "metrics")]
+            crate::metrics::connection_closed();
         }
 
         conn.disconnect().await.map(|()| true)
@@ -2263,6 +2262,104 @@ where
         // Storage write first (cancel-safety: storage is the source of truth;
         // a cancel between this and the broadcast self-heals on rehydrate).
         self.store_built_batch(id, commits, fragments).await?;
+        let per_peer = self
+            .sync_with_all_peers(id, true, timeout)
+            .await
+            .map_err(WriteError::Io)?;
+        Ok(per_peer)
+    }
+
+    /// Bulk-insert commits **and** propagate them to peers — the convenience
+    /// combinator of [`store_commits_batch`](Self::store_commits_batch) +
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers).
+    ///
+    /// Prefer this over looping [`add_commit`](Self::add_commit): the batch
+    /// path runs a single `save_batch` and one `minimize`, then a single
+    /// broadcast, instead of re-minimizing and pushing per commit.
+    ///
+    /// This **awaits the broadcast** and returns its per-peer outcome
+    /// ([`PerPeerSync`]); a byte-connected but protocol-unresponsive peer can
+    /// stall the call for up to `timeout` (or the configured
+    /// `default_call_timeout` when `timeout` is `None`). Callers that want the
+    /// durable write to return *without* waiting on peers should call
+    /// [`store_commits_batch`](Self::store_commits_batch) and drive
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers) separately. An empty
+    /// list is a no-op (no minimize, no broadcast) and yields an empty map.
+    ///
+    /// # Errors
+    ///
+    /// * [`WriteError::Io`] (`IoError::Storage`) if a local storage error
+    ///   occurs while persisting the batch, or if ingestion during the
+    ///   trailing broadcast hits a storage error.
+    ///
+    /// Per-peer transport failures during the broadcast are *not* surfaced as
+    /// `Err`; they appear in the returned [`PerPeerSync`] map.
+    ///
+    /// Note: `WriteError::PutDisallowed` is unreachable for local writes
+    /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
+    pub async fn add_commits_batch(
+        &self,
+        id: SedimentreeId,
+        commits: Vec<(CommitId, BTreeSet<CommitId>, Blob)>,
+        timeout: Option<Duration>,
+    ) -> Result<
+        PerPeerSync<Conn, Async, <Conn as Connection<Async, Hdl::Message>>::SendError>,
+        WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>,
+    > {
+        if commits.is_empty() {
+            return Ok(PerPeerSync::default());
+        }
+
+        self.store_commits_batch(id, commits).await?;
+        let per_peer = self
+            .sync_with_all_peers(id, true, timeout)
+            .await
+            .map_err(WriteError::Io)?;
+        Ok(per_peer)
+    }
+
+    /// Bulk-insert fragments **and** propagate them to peers — the convenience
+    /// combinator of [`store_fragments_batch`](Self::store_fragments_batch) +
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers).
+    ///
+    /// Prefer this over looping [`add_fragment`](Self::add_fragment): the
+    /// batch path runs a single `save_batch` and one `minimize`, then a single
+    /// broadcast, instead of re-minimizing and pushing per fragment.
+    ///
+    /// This **awaits the broadcast** and returns its per-peer outcome
+    /// ([`PerPeerSync`]); a byte-connected but protocol-unresponsive peer can
+    /// stall the call for up to `timeout` (or the configured
+    /// `default_call_timeout` when `timeout` is `None`). Callers that want the
+    /// durable write to return *without* waiting on peers should call
+    /// [`store_fragments_batch`](Self::store_fragments_batch) and drive
+    /// [`sync_with_all_peers`](Self::sync_with_all_peers) separately. An empty
+    /// list is a no-op (no minimize, no broadcast) and yields an empty map.
+    ///
+    /// # Errors
+    ///
+    /// * [`WriteError::Io`] (`IoError::Storage`) if a local storage error
+    ///   occurs while persisting the batch, or if ingestion during the
+    ///   trailing broadcast hits a storage error.
+    ///
+    /// Per-peer transport failures during the broadcast are *not* surfaced as
+    /// `Err`; they appear in the returned [`PerPeerSync`] map.
+    ///
+    /// Note: `WriteError::PutDisallowed` is unreachable for local writes
+    /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
+    pub async fn add_fragments_batch(
+        &self,
+        id: SedimentreeId,
+        fragments: Vec<FragmentBatchItem>,
+        timeout: Option<Duration>,
+    ) -> Result<
+        PerPeerSync<Conn, Async, <Conn as Connection<Async, Hdl::Message>>::SendError>,
+        WriteError<Async, Store, Conn, Hdl::Message, Auth::PutDisallowed>,
+    > {
+        if fragments.is_empty() {
+            return Ok(PerPeerSync::default());
+        }
+
+        self.store_fragments_batch(id, fragments).await?;
         let per_peer = self
             .sync_with_all_peers(id, true, timeout)
             .await

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -1114,7 +1114,7 @@ where
     /// Cancel the pending calls on a set of detached multiplexers.
     ///
     /// Resolves any awaiting `sync_with_*` callers with
-    /// [`CallError::ResponseDropped`](crate::connection::managed::CallError::ResponseDropped)
+    /// [`CallError::ResponseDropped`]
     /// immediately rather than letting them wait out the per-call timeout.
     /// Call this *after* the `connections` lock has been released (see
     /// [`detach_peer_muxes_locked`](Self::detach_peer_muxes_locked)).
@@ -2241,7 +2241,7 @@ where
     /// Per-peer transport failures during the broadcast are *not* surfaced as
     /// `Err`; they appear in the returned [`PerPeerSync`] map (per-peer
     /// success flag + per-connection
-    /// [`CallError`](crate::connection::managed::CallError)s).
+    /// [`CallError`]s).
     ///
     /// Note: `WriteError::PutDisallowed` is unreachable for local writes
     /// (the node trusts itself via [`local_putter`](crate::storage::powerbox::StoragePowerbox::local_putter)).
@@ -2442,8 +2442,12 @@ where
     ///
     /// # Returns
     ///
-    /// * `Ok(true)` if at least one sync was successful.
-    /// * `Ok(false)` if no syncs were performed (e.g., no connections, or they all timed out).
+    /// A tuple `(succeeded, stats, per-connection call errors)`: `succeeded`
+    /// is `true` if at least one connection to the peer synced successfully;
+    /// `stats` aggregates the sync; and the [`Vec`] carries per-connection
+    /// [`CallError`]s for connections
+    /// that failed. `succeeded = false` with an empty error list means no
+    /// connections to the peer were available.
     ///
     /// # Errors
     ///
@@ -2466,9 +2470,7 @@ where
             SyncStats,
             Vec<(
                 Authenticated<Conn, Async>,
-                crate::connection::managed::CallError<
-                    <Conn as Connection<Async, Hdl::Message>>::SendError,
-                >,
+                CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
             )>,
         ),
         IoError<Async, Store, Conn, Hdl::Message>,
@@ -2517,10 +2519,7 @@ where
                 tracing::debug!(
                     "multiplexer for peer {to_ask:?} gone (concurrent teardown); skipping"
                 );
-                conn_errs.push((
-                    conn.clone(),
-                    crate::connection::managed::CallError::ResponseDropped,
-                ));
+                conn_errs.push((conn.clone(), CallError::ResponseDropped));
                 continue;
             };
             let managed = ManagedConnection::new(conn.clone(), mux, self.timer.clone());
@@ -2713,8 +2712,12 @@ where
     ///
     /// # Returns
     ///
-    /// * `Ok(true)` if at least one sync was successful.
-    /// * `Ok(false)` if no syncs were performed (e.g., no peers connected or they all timed out).
+    /// A [`PerPeerSync`] map keyed by [`PeerId`]; each entry is
+    /// `(succeeded, stats, per-connection call errors)`, so callers can see
+    /// which peers acked and which failed. Peers that could not be reached
+    /// appear with `succeeded = false` and/or per-connection
+    /// [`CallError`]s. An empty map
+    /// means no peers were connected.
     ///
     /// # Errors
     ///
@@ -2786,7 +2789,7 @@ where
                             );
                             conn_errs.push((
                                 conn.clone(),
-                                crate::connection::managed::CallError::ResponseDropped,
+                                CallError::ResponseDropped,
                             ));
                             continue;
                         };
@@ -3024,9 +3027,7 @@ where
         SyncStats,
         Vec<(
             Authenticated<Conn, Async>,
-            crate::connection::managed::CallError<
-                <Conn as Connection<Async, Hdl::Message>>::SendError,
-            >,
+            CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
         )>,
         Vec<(SedimentreeId, IoError<Async, Store, Conn, Hdl::Message>)>,
     ) {
@@ -3085,9 +3086,7 @@ where
         SyncStats,
         Vec<(
             Authenticated<Conn, Async>,
-            crate::connection::managed::CallError<
-                <Conn as Connection<Async, Hdl::Message>>::SendError,
-            >,
+            CallError<<Conn as Connection<Async, Hdl::Message>>::SendError>,
         )>,
         Vec<(SedimentreeId, IoError<Async, Store, Conn, Hdl::Message>)>,
     ) {

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -220,6 +220,17 @@ pub struct Subduction<
     _phantom: core::marker::PhantomData<&'a Async>,
 }
 
+/// The per-peer value in a [`PerPeerSync`]: `(succeeded, stats, per-connection
+/// call errors)`.
+pub type PeerSyncEntry<Conn, Async, SendErr> = (
+    bool,
+    SyncStats,
+    Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>,
+);
+
+/// The underlying map of a [`PerPeerSync`], keyed by [`PeerId`].
+pub type PerPeerSyncMap<Conn, Async, SendErr> = Map<PeerId, PeerSyncEntry<Conn, Async, SendErr>>;
+
 /// Per-peer outcome of a broadcast / sync round, keyed by [`PeerId`].
 ///
 /// Returned by [`sync_with_all_peers`](Subduction::sync_with_all_peers) and
@@ -228,28 +239,25 @@ pub struct Subduction<
 /// [`add_sedimentree`](Subduction::add_sedimentree)) so callers can observe
 /// which peers acked and which failed.
 ///
-/// Each entry's value is `(succeeded, stats, per-connection call errors)`.
-/// The newtype [`Deref`]s to the underlying [`Map`], so `.get(&peer)`,
-/// `.iter()`, `.is_empty()`, etc. work directly; it also implements
-/// [`IntoIterator`] and [`FromIterator`].
+/// Each entry's value is a [`PeerSyncEntry`]. The newtype [`Deref`]s to the
+/// underlying [`Map`], so `.get(&peer)`, `.iter()`, `.is_empty()`, etc. work
+/// directly; it also implements [`IntoIterator`] and [`FromIterator`].
 pub struct PerPeerSync<Conn: Clone, Async: FutureForm, SendErr: core::error::Error>(
-    Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)>,
+    PerPeerSyncMap<Conn, Async, SendErr>,
 );
 
-impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> PerPeerSync<Conn, Async, SendErr> {
+impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error>
+    PerPeerSync<Conn, Async, SendErr>
+{
     /// The inner per-peer map.
     #[must_use]
-    pub const fn as_map(
-        &self,
-    ) -> &Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)> {
+    pub const fn as_map(&self) -> &PerPeerSyncMap<Conn, Async, SendErr> {
         &self.0
     }
 
     /// Consume into the inner per-peer map.
     #[must_use]
-    pub fn into_map(
-        self,
-    ) -> Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)> {
+    pub fn into_map(self) -> PerPeerSyncMap<Conn, Async, SendErr> {
         self.0
     }
 }
@@ -275,8 +283,7 @@ impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> Default
 impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> core::ops::Deref
     for PerPeerSync<Conn, Async, SendErr>
 {
-    type Target =
-        Map<PeerId, (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>)>;
+    type Target = PerPeerSyncMap<Conn, Async, SendErr>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -286,14 +293,8 @@ impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> core::ops::Der
 impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> IntoIterator
     for PerPeerSync<Conn, Async, SendErr>
 {
-    type Item = (
-        PeerId,
-        (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
-    );
-    type IntoIter = <Map<
-        PeerId,
-        (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
-    > as IntoIterator>::IntoIter;
+    type Item = (PeerId, PeerSyncEntry<Conn, Async, SendErr>);
+    type IntoIter = <PerPeerSyncMap<Conn, Async, SendErr> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -301,19 +302,10 @@ impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error> IntoIterator
 }
 
 impl<Conn: Clone, Async: FutureForm, SendErr: core::error::Error>
-    FromIterator<(
-        PeerId,
-        (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
-    )> for PerPeerSync<Conn, Async, SendErr>
+    FromIterator<(PeerId, PeerSyncEntry<Conn, Async, SendErr>)>
+    for PerPeerSync<Conn, Async, SendErr>
 {
-    fn from_iter<
-        T: IntoIterator<
-                Item = (
-                    PeerId,
-                    (bool, SyncStats, Vec<(Authenticated<Conn, Async>, CallError<SendErr>)>),
-                ),
-            >,
-    >(
+    fn from_iter<T: IntoIterator<Item = (PeerId, PeerSyncEntry<Conn, Async, SendErr>)>>(
         iter: T,
     ) -> Self {
         Self(iter.into_iter().collect())

--- a/subduction_core/tests/add_sedimentree.rs
+++ b/subduction_core/tests/add_sedimentree.rs
@@ -116,7 +116,7 @@ async fn add_sedimentree_stores_all_items() -> TestResult {
     ];
 
     let sedimentree = Sedimentree::new(fragments.clone(), commits.clone());
-    sd.add_sedimentree(sed_id, sedimentree, blobs).await?;
+    sd.add_sedimentree(sed_id, sedimentree, blobs, None).await?;
 
     // Check in-memory state
     let stored_commits = sd.get_commits(sed_id).await;
@@ -159,7 +159,7 @@ async fn add_sedimentree_survives_minimize() -> TestResult {
     let sedimentree = Sedimentree::new(vec![frag1.clone()], vec![c1, c2, c3]);
     let blobs = vec![frag1_blob, c1_blob, c2_blob, c3_blob];
 
-    sd.add_sedimentree(sed_id, sedimentree, blobs).await?;
+    sd.add_sedimentree(sed_id, sedimentree, blobs, None).await?;
 
     // Verify all items survive in the in-memory tree.
     let commits = sd.get_commits(sed_id).await.unwrap_or_default();

--- a/subduction_core/tests/addbatch_storage_durability.rs
+++ b/subduction_core/tests/addbatch_storage_durability.rs
@@ -1,0 +1,230 @@
+//! Durability must not be held hostage by a wedged peer.
+//!
+//! These tests port PR #198's `addbatch_storage_durability` coverage to
+//! this branch's `store_*` / `add_*` API split:
+//!
+//! * [`store_built_batch`](Subduction::store_built_batch) is the durable,
+//!   peer-independent write. With a byte-connected-but-wedged peer attached,
+//!   it must return well under the configured per-call timeout — proving it
+//!   never touches the network. (This is the exact regression #198's Fix B
+//!   targeted, re-expressed via the persist-only verb.)
+//! * [`add_built_batch`](Subduction::add_built_batch) is the convenience
+//!   combinator that *does* await the broadcast. Against a wedged peer it must
+//!   bound at the per-call timeout (not hang forever) and surface that peer in
+//!   the returned [`PerPeerSync`] as `succeeded = false` — proving the durable
+//!   write still landed and the propagation outcome is observable.
+//!
+//! The wedged peer is simulated with [`PausableChannelTransport::pause`]: it
+//! stays byte-connected but never reads inbound messages, so A's
+//! `BatchSyncRequest` sits in the channel unanswered.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    commit::CountLeadingZeroBytes,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+};
+use subduction_core::{
+    authenticated::Authenticated,
+    connection::test_utils::{PausableChannelTransport, TokioSpawn, TokioTimeout},
+    handler::sync::SyncHandler,
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    storage::memory::MemoryStorage,
+    subduction::{Subduction, builder::SubductionBuilder},
+    transport::message::MessageTransport,
+};
+use subduction_crypto::signer::memory::MemorySigner;
+use testresult::TestResult;
+
+type Conn = MessageTransport<PausableChannelTransport>;
+
+type TestSyncHandler =
+    SyncHandler<Sendable, MemoryStorage, Conn, OpenPolicy, CountLeadingZeroBytes>;
+
+type TestSubduction = Arc<
+    Subduction<
+        'static,
+        Sendable,
+        MemoryStorage,
+        Conn,
+        TestSyncHandler,
+        OpenPolicy,
+        MemorySigner,
+        TokioTimeout,
+    >,
+>;
+
+/// Long enough that the per-call default timeout cannot mask a missing
+/// decoupling: a `store_built_batch` that (wrongly) waited on the peer
+/// would block for the full [`LONG_PER_CALL_TIMEOUT`], far past [`BOUND`].
+const LONG_PER_CALL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Upper bound for the durable-write path: `store_built_batch` must return
+/// far faster than [`LONG_PER_CALL_TIMEOUT`], even with a wedged peer.
+const BOUND: Duration = Duration::from_secs(3);
+
+/// Per-call timeout used for the `add_built_batch` combinator test, kept
+/// short so the bounded broadcast resolves the test quickly. The combinator
+/// is *expected* to wait roughly this long against a wedged peer.
+const SHORT_PER_CALL_TIMEOUT: Duration = Duration::from_millis(500);
+
+fn make_signer(seed: u8) -> MemorySigner {
+    MemorySigner::from_bytes(&[seed; 32])
+}
+
+fn make_node(signer: MemorySigner) -> TestSubduction {
+    let (sd, _h, listener, manager) = SubductionBuilder::new()
+        .signer(signer)
+        .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(TokioTimeout)
+        .build::<Sendable, Conn>();
+    tokio::spawn(listener);
+    tokio::spawn(manager);
+    sd
+}
+
+async fn connect_pair(
+    a: &TestSubduction,
+    a_signer: &MemorySigner,
+    b: &TestSubduction,
+    b_signer: &MemorySigner,
+) -> TestResult<(PausableChannelTransport, PausableChannelTransport)> {
+    let (t_a, t_b) = PausableChannelTransport::pair();
+
+    let conn_a = MessageTransport::new(t_a.clone());
+    let conn_b = MessageTransport::new(t_b.clone());
+
+    let peer_a = PeerId::from(a_signer.verifying_key());
+    let peer_b = PeerId::from(b_signer.verifying_key());
+
+    let auth_a: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_a, peer_b);
+    let auth_b: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_b, peer_a);
+
+    a.add_connection(auth_a).await?;
+    b.add_connection(auth_b).await?;
+
+    Ok((t_a, t_b))
+}
+
+fn make_blob(seed: u8) -> Blob {
+    let data: Vec<u8> = (0..64).map(|i| seed.wrapping_add(i)).collect();
+    Blob::new(data)
+}
+
+/// Build a `(LooseCommit, Blob)` pair whose `BlobMeta` matches its blob.
+fn make_commit(id: SedimentreeId, head: u8, blob_seed: u8) -> (LooseCommit, Blob) {
+    let blob = make_blob(blob_seed);
+    let blob_meta = BlobMeta::new(&blob);
+    let commit = LooseCommit::new(id, CommitId::new([head; 32]), BTreeSet::new(), blob_meta);
+    (commit, blob)
+}
+
+/// `store_built_batch` is the durability path: with a wedged peer attached,
+/// it must complete far under the long per-call timeout. A pass can only come
+/// from the write never touching the network, not from the timeout firing.
+#[tokio::test(flavor = "current_thread")]
+async fn store_built_batch_does_not_stall_on_wedged_peer() -> TestResult {
+    let a_signer = make_signer(40);
+    let b_signer = make_signer(50);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    let (_t_a, t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Wedge B: byte-connected but never reads inbound messages.
+    t_b.pause();
+
+    let sed_id = SedimentreeId::new([1u8; 32]);
+    let commits: Vec<(LooseCommit, Blob)> =
+        (0..5).map(|i| make_commit(sed_id, i + 100, i)).collect();
+
+    let a_clone = a.clone();
+    let store_handle =
+        tokio::spawn(async move { a_clone.store_built_batch(sed_id, commits, Vec::new()).await });
+
+    let result = tokio::time::timeout(BOUND, store_handle).await;
+    assert!(
+        result.is_ok(),
+        "store_built_batch did not return within {BOUND:?} with a wedged \
+         peer connected; the durable write must never wait on the network \
+         (it was probably blocked behind the {LONG_PER_CALL_TIMEOUT:?} \
+         per-call timeout)"
+    );
+    result.expect("join error").expect("task panicked")?;
+
+    // The write must actually be durable.
+    let stored = a.get_commits(sed_id).await;
+    assert_eq!(
+        stored.as_ref().map(Vec::len),
+        Some(5),
+        "all commits should be persisted by store_built_batch"
+    );
+
+    Ok(())
+}
+
+/// `add_built_batch` is the store-then-broadcast combinator. Against a wedged
+/// peer it must bound at the per-call timeout (not hang forever), persist the
+/// data, and report the wedged peer in the returned `PerPeerSync` as failed.
+#[tokio::test(flavor = "current_thread")]
+async fn add_built_batch_bounds_at_timeout_and_reports_wedged_peer() -> TestResult {
+    let a_signer = make_signer(41);
+    let b_signer = make_signer(51);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    let (_t_a, t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    t_b.pause();
+
+    let sed_id = SedimentreeId::new([2u8; 32]);
+    let commits: Vec<(LooseCommit, Blob)> =
+        (0..5).map(|i| make_commit(sed_id, i + 100, i)).collect();
+
+    let a_clone = a.clone();
+    let add_handle = tokio::spawn(async move {
+        a_clone
+            .add_built_batch(sed_id, commits, Vec::new(), Some(SHORT_PER_CALL_TIMEOUT))
+            .await
+    });
+
+    // Generous outer bound: the combinator awaits the broadcast, which is
+    // capped by SHORT_PER_CALL_TIMEOUT. It must resolve well before BOUND.
+    let result = tokio::time::timeout(BOUND, add_handle).await;
+    assert!(
+        result.is_ok(),
+        "add_built_batch did not return within {BOUND:?}; the bounded \
+         broadcast should resolve by ~{SHORT_PER_CALL_TIMEOUT:?}"
+    );
+    let per_peer = result.expect("join error").expect("task panicked")?;
+
+    // Durability still holds even though the broadcast could not reach B.
+    let stored = a.get_commits(sed_id).await;
+    assert_eq!(
+        stored.as_ref().map(Vec::len),
+        Some(5),
+        "add_built_batch must persist the batch even when the peer is wedged"
+    );
+
+    // The wedged peer must be reported as not-succeeded in the per-peer map,
+    // rather than silently dropped or causing an Err.
+    let b_peer = PeerId::from(b_signer.verifying_key());
+    let (success, _stats, _conn_errs) = per_peer
+        .get(&b_peer)
+        .expect("wedged peer must be present in the per-peer result map");
+    assert!(
+        !success,
+        "wedged peer must be reported as failed in the returned PerPeerSync"
+    );
+
+    Ok(())
+}

--- a/subduction_core/tests/addbatch_storage_durability.rs
+++ b/subduction_core/tests/addbatch_storage_durability.rs
@@ -36,7 +36,7 @@ use subduction_core::{
     peer::id::PeerId,
     policy::open::OpenPolicy,
     storage::memory::MemoryStorage,
-    subduction::{Subduction, builder::SubductionBuilder},
+    subduction::{FragmentBatchItem, Subduction, builder::SubductionBuilder},
     transport::message::MessageTransport,
 };
 use subduction_crypto::signer::memory::MemorySigner;
@@ -60,9 +60,12 @@ type TestSubduction = Arc<
     >,
 >;
 
-/// Long enough that the per-call default timeout cannot mask a missing
-/// decoupling: a `store_built_batch` that (wrongly) waited on the peer
-/// would block for the full [`LONG_PER_CALL_TIMEOUT`], far past [`BOUND`].
+/// Wired into the node via [`SubductionBuilder::roundtrip_timeout`] in
+/// [`make_node`], so it *is* the node's configured per-call timeout (not just
+/// a constant referenced in messages). Long enough that a `store_built_batch`
+/// which (wrongly) waited on the peer would block for the full
+/// [`LONG_PER_CALL_TIMEOUT`], far past [`BOUND`] — making a regression into a
+/// network roundtrip impossible to miss.
 const LONG_PER_CALL_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Upper bound for the durable-write path: `store_built_batch` must return
@@ -84,6 +87,10 @@ fn make_node(signer: MemorySigner) -> TestSubduction {
         .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
         .spawner(TokioSpawn)
         .timer(TokioTimeout)
+        // Make the documented margin real: any (regressed) network roundtrip
+        // from store_built_batch would inherit this 60s default and blow past
+        // BOUND. The add_* combinator tests override it per-call.
+        .roundtrip_timeout(LONG_PER_CALL_TIMEOUT)
         .build::<Sendable, Conn>();
     tokio::spawn(listener);
     tokio::spawn(manager);
@@ -217,6 +224,115 @@ async fn add_built_batch_bounds_at_timeout_and_reports_wedged_peer() -> TestResu
 
     // The wedged peer must be reported as not-succeeded in the per-peer map,
     // rather than silently dropped or causing an Err.
+    let b_peer = PeerId::from(b_signer.verifying_key());
+    let (success, _stats, _conn_errs) = per_peer
+        .get(&b_peer)
+        .expect("wedged peer must be present in the per-peer result map");
+    assert!(
+        !success,
+        "wedged peer must be reported as failed in the returned PerPeerSync"
+    );
+
+    Ok(())
+}
+
+/// `add_commits_batch` is the parts-based store-then-broadcast combinator.
+/// Against a wedged peer it must bound at the per-call timeout, persist the
+/// commits, and report the peer as failed in the returned `PerPeerSync`.
+#[tokio::test(flavor = "current_thread")]
+async fn add_commits_batch_bounds_at_timeout_and_reports_wedged_peer() -> TestResult {
+    let a_signer = make_signer(42);
+    let b_signer = make_signer(52);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    let (_t_a, t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    t_b.pause();
+
+    let sed_id = SedimentreeId::new([3u8; 32]);
+    let commits: Vec<(CommitId, BTreeSet<CommitId>, Blob)> = (0..5u8)
+        .map(|i| (CommitId::new([i + 100; 32]), BTreeSet::new(), make_blob(i)))
+        .collect();
+
+    let a_clone = a.clone();
+    let add_handle = tokio::spawn(async move {
+        a_clone
+            .add_commits_batch(sed_id, commits, Some(SHORT_PER_CALL_TIMEOUT))
+            .await
+    });
+
+    let result = tokio::time::timeout(BOUND, add_handle).await;
+    assert!(
+        result.is_ok(),
+        "add_commits_batch did not return within {BOUND:?}; the bounded \
+         broadcast should resolve by ~{SHORT_PER_CALL_TIMEOUT:?}"
+    );
+    let per_peer = result.expect("join error").expect("task panicked")?;
+
+    assert_eq!(
+        a.get_commits(sed_id).await.as_ref().map(Vec::len),
+        Some(5),
+        "add_commits_batch must persist the batch even when the peer is wedged"
+    );
+
+    let b_peer = PeerId::from(b_signer.verifying_key());
+    let (success, _stats, _conn_errs) = per_peer
+        .get(&b_peer)
+        .expect("wedged peer must be present in the per-peer result map");
+    assert!(
+        !success,
+        "wedged peer must be reported as failed in the returned PerPeerSync"
+    );
+
+    Ok(())
+}
+
+/// `add_fragments_batch` mirror of the commits combinator test above.
+#[tokio::test(flavor = "current_thread")]
+async fn add_fragments_batch_bounds_at_timeout_and_reports_wedged_peer() -> TestResult {
+    let a_signer = make_signer(43);
+    let b_signer = make_signer(53);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    let (_t_a, t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    t_b.pause();
+
+    let sed_id = SedimentreeId::new([4u8; 32]);
+    let fragments: Vec<FragmentBatchItem> = (0..3u8)
+        .map(|i| FragmentBatchItem {
+            head: CommitId::new([i + 50; 32]),
+            boundary: BTreeSet::from([CommitId::new([i + 150; 32])]),
+            checkpoints: Vec::new(),
+            blob: make_blob(i),
+        })
+        .collect();
+
+    let a_clone = a.clone();
+    let add_handle = tokio::spawn(async move {
+        a_clone
+            .add_fragments_batch(sed_id, fragments, Some(SHORT_PER_CALL_TIMEOUT))
+            .await
+    });
+
+    let result = tokio::time::timeout(BOUND, add_handle).await;
+    assert!(
+        result.is_ok(),
+        "add_fragments_batch did not return within {BOUND:?}; the bounded \
+         broadcast should resolve by ~{SHORT_PER_CALL_TIMEOUT:?}"
+    );
+    let per_peer = result.expect("join error").expect("task panicked")?;
+
+    assert_eq!(
+        a.get_fragments(sed_id).await.as_ref().map(Vec::len),
+        Some(3),
+        "add_fragments_batch must persist the batch even when the peer is wedged"
+    );
+
     let b_peer = PeerId::from(b_signer.verifying_key());
     let (success, _stats, _conn_errs) = per_peer
         .get(&b_peer)

--- a/subduction_core/tests/batch_ingest.rs
+++ b/subduction_core/tests/batch_ingest.rs
@@ -1,4 +1,4 @@
-//! Tests for `add_commits_batch` and `add_fragments_batch`.
+//! Tests for `store_commits_batch` and `store_fragments_batch`.
 
 use std::collections::BTreeSet;
 
@@ -12,7 +12,7 @@ fn make_blob(seed: u8) -> Blob {
 }
 
 #[tokio::test]
-async fn add_commits_batch_stores_all_commits() -> TestResult {
+async fn store_commits_batch_stores_all_commits() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
 
     let sed_id = SedimentreeId::new([1u8; 32]);
@@ -22,7 +22,7 @@ async fn add_commits_batch_stores_all_commits() -> TestResult {
         .map(|i| (CommitId::new([i + 100; 32]), BTreeSet::new(), make_blob(i)))
         .collect();
 
-    sd.add_commits_batch(sed_id, commits).await?;
+    sd.store_commits_batch(sed_id, commits).await?;
 
     let stored = sd.get_commits(sed_id).await;
     assert!(
@@ -41,12 +41,12 @@ async fn add_commits_batch_stores_all_commits() -> TestResult {
 }
 
 #[tokio::test]
-async fn add_commits_batch_empty_is_noop() -> TestResult {
+async fn store_commits_batch_empty_is_noop() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
 
     let sed_id = SedimentreeId::new([2u8; 32]);
 
-    sd.add_commits_batch(sed_id, Vec::new()).await?;
+    sd.store_commits_batch(sed_id, Vec::new()).await?;
 
     let stored = sd.get_commits(sed_id).await;
     assert!(
@@ -58,7 +58,7 @@ async fn add_commits_batch_empty_is_noop() -> TestResult {
 }
 
 #[tokio::test]
-async fn add_fragments_batch_stores_all_fragments() -> TestResult {
+async fn store_fragments_batch_stores_all_fragments() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
 
     let sed_id = SedimentreeId::new([3u8; 32]);
@@ -73,7 +73,7 @@ async fn add_fragments_batch_stores_all_fragments() -> TestResult {
         })
         .collect();
 
-    sd.add_fragments_batch(sed_id, fragments).await?;
+    sd.store_fragments_batch(sed_id, fragments).await?;
 
     let stored = sd.get_fragments(sed_id).await;
     assert!(
@@ -92,12 +92,12 @@ async fn add_fragments_batch_stores_all_fragments() -> TestResult {
 }
 
 #[tokio::test]
-async fn add_fragments_batch_empty_is_noop() -> TestResult {
+async fn store_fragments_batch_empty_is_noop() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
 
     let sed_id = SedimentreeId::new([4u8; 32]);
 
-    sd.add_fragments_batch(sed_id, Vec::new()).await?;
+    sd.store_fragments_batch(sed_id, Vec::new()).await?;
 
     let stored = sd.get_fragments(sed_id).await;
     assert!(

--- a/subduction_core/tests/built_batch.rs
+++ b/subduction_core/tests/built_batch.rs
@@ -1,4 +1,4 @@
-//! Tests for `add_built_batch` and `add_built_batch_locally`.
+//! Tests for `add_built_batch` and `store_built_batch`.
 //!
 //! Coverage:
 //! - empty input is a true no-op (no sedimentree row, no panics)
@@ -48,12 +48,11 @@ fn make_fragment(
 }
 
 #[tokio::test]
-async fn add_built_batch_locally_empty_is_noop() -> TestResult {
+async fn store_built_batch_empty_is_noop() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
     let sed_id = SedimentreeId::new([1u8; 32]);
 
-    sd.add_built_batch_locally(sed_id, Vec::new(), Vec::new())
-        .await?;
+    sd.store_built_batch(sed_id, Vec::new(), Vec::new()).await?;
 
     assert!(
         sd.get_commits(sed_id).await.is_none(),
@@ -69,7 +68,8 @@ async fn add_built_batch_empty_is_noop_no_broadcast() -> TestResult {
     let sed_id = SedimentreeId::new([2u8; 32]);
 
     // No connected peers, no work to do — should be a clean no-op.
-    sd.add_built_batch(sed_id, Vec::new(), Vec::new()).await?;
+    sd.add_built_batch(sed_id, Vec::new(), Vec::new(), None)
+        .await?;
 
     assert!(
         sd.get_commits(sed_id).await.is_none(),
@@ -80,7 +80,7 @@ async fn add_built_batch_empty_is_noop_no_broadcast() -> TestResult {
 }
 
 #[tokio::test]
-async fn add_built_batch_locally_stores_commits_and_fragments() -> TestResult {
+async fn store_built_batch_stores_commits_and_fragments() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
     let sed_id = SedimentreeId::new([3u8; 32]);
 
@@ -90,8 +90,7 @@ async fn add_built_batch_locally_stores_commits_and_fragments() -> TestResult {
         .map(|i| make_fragment(sed_id, i + 200, i + 220, i + 240))
         .collect();
 
-    sd.add_built_batch_locally(sed_id, commits, fragments)
-        .await?;
+    sd.store_built_batch(sed_id, commits, fragments).await?;
 
     let stored_commits = sd.get_commits(sed_id).await;
     assert_eq!(
@@ -111,7 +110,7 @@ async fn add_built_batch_locally_stores_commits_and_fragments() -> TestResult {
 }
 
 #[tokio::test]
-async fn add_built_batch_locally_rejects_mismatched_commit_blob() -> TestResult {
+async fn store_built_batch_rejects_mismatched_commit_blob() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
     let sed_id = SedimentreeId::new([4u8; 32]);
 
@@ -127,7 +126,7 @@ async fn add_built_batch_locally_rejects_mismatched_commit_blob() -> TestResult 
     let actual = make_blob(0xBB); // different bytes -> different digest
 
     let result = sd
-        .add_built_batch_locally(sed_id, vec![(commit, actual)], Vec::new())
+        .store_built_batch(sed_id, vec![(commit, actual)], Vec::new())
         .await;
 
     assert!(
@@ -145,7 +144,7 @@ async fn add_built_batch_locally_rejects_mismatched_commit_blob() -> TestResult 
 }
 
 #[tokio::test]
-async fn add_built_batch_locally_rejects_mismatched_fragment_blob() -> TestResult {
+async fn store_built_batch_rejects_mismatched_fragment_blob() -> TestResult {
     let (sd, _listener, _manager) = new_test_subduction();
     let sed_id = SedimentreeId::new([5u8; 32]);
 
@@ -157,7 +156,7 @@ async fn add_built_batch_locally_rejects_mismatched_fragment_blob() -> TestResul
     let actual = make_blob(0xDD);
 
     let result = sd
-        .add_built_batch_locally(sed_id, Vec::new(), vec![(fragment, actual)])
+        .store_built_batch(sed_id, Vec::new(), vec![(fragment, actual)])
         .await;
 
     assert!(

--- a/subduction_core/tests/policy_rejection.rs
+++ b/subduction_core/tests/policy_rejection.rs
@@ -170,7 +170,7 @@ async fn local_add_sedimentree_bypasses_put_policy() {
     let blobs = Vec::new();
 
     // Local operations succeed even with a rejecting put policy
-    let result = subduction.add_sedimentree(id, tree, blobs).await;
+    let result = subduction.add_sedimentree(id, tree, blobs, None).await;
     assert!(result.is_ok(), "Local add_sedimentree should bypass policy");
 
     let ids = subduction.sedimentree_ids().await;
@@ -214,11 +214,13 @@ async fn local_adds_bypass_id_specific_policy() -> TestResult {
     // Local operations succeed for both IDs — policy only applies to remote data
     let tree = Sedimentree::default();
     let result = subduction
-        .add_sedimentree(allowed_id, tree.clone(), Vec::new())
+        .add_sedimentree(allowed_id, tree.clone(), Vec::new(), None)
         .await;
     assert!(result.is_ok(), "Local add to allowed ID should succeed");
 
-    let result = subduction.add_sedimentree(other_id, tree, Vec::new()).await;
+    let result = subduction
+        .add_sedimentree(other_id, tree, Vec::new(), None)
+        .await;
     assert!(
         result.is_ok(),
         "Local add to other ID should also succeed (policy bypassed)"
@@ -246,7 +248,7 @@ async fn local_add_stores_data_despite_rejecting_policy() {
     let tree = Sedimentree::default();
 
     // Local add succeeds (policy bypassed)
-    let result = subduction.add_sedimentree(id, tree, Vec::new()).await;
+    let result = subduction.add_sedimentree(id, tree, Vec::new(), None).await;
     assert!(result.is_ok());
 
     // Data was stored
@@ -325,7 +327,7 @@ async fn multiple_local_adds_succeed_despite_rejecting_policy() {
     for i in 0..5u8 {
         let id = SedimentreeId::new([i; 32]);
         let tree = Sedimentree::default();
-        let result = subduction.add_sedimentree(id, tree, Vec::new()).await;
+        let result = subduction.add_sedimentree(id, tree, Vec::new(), None).await;
         assert!(result.is_ok(), "Local add {i} should succeed");
     }
 

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -420,8 +420,13 @@ async fn relay_topology_add_built_batch_each_call_is_incremental() -> TestResult
     let mut prior_count = 0usize;
     for seed in 1..=10_u8 {
         let n = seed as usize;
-        a.add_built_batch(sed_id, vec![make_commit_pair(sed_id, seed)], Vec::new())
-            .await?;
+        a.add_built_batch(
+            sed_id,
+            vec![make_commit_pair(sed_id, seed)],
+            Vec::new(),
+            None,
+        )
+        .await?;
         tokio::time::sleep(PROPAGATION_PAUSE).await;
 
         let a_count = a.get_commits(sed_id).await.map_or(0, |c| c.len());
@@ -444,8 +449,13 @@ async fn relay_topology_repeated_add_built_batch_then_sync_is_empty() -> TestRes
     tokio::time::sleep(PROPAGATION_PAUSE).await;
 
     for seed in 1..=10_u8 {
-        a.add_built_batch(sed_id, vec![make_commit_pair(sed_id, seed)], Vec::new())
-            .await?;
+        a.add_built_batch(
+            sed_id,
+            vec![make_commit_pair(sed_id, seed)],
+            Vec::new(),
+            None,
+        )
+        .await?;
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
 
@@ -476,10 +486,12 @@ async fn relay_topology_two_clients_add_built_batch_converge_via_relay() -> Test
     for i in 0..total_pairs {
         if i % 2 == 0 {
             let pair = make_commit_pair(sed_id, i + 1);
-            a.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+            a.add_built_batch(sed_id, vec![pair], Vec::new(), None)
+                .await?;
         } else {
             let pair = make_commit_pair(sed_id, 100 + i);
-            b.add_built_batch(sed_id, vec![pair], Vec::new()).await?;
+            b.add_built_batch(sed_id, vec![pair], Vec::new(), None)
+                .await?;
         }
         tokio::time::sleep(PROPAGATION_PAUSE).await;
     }
@@ -518,7 +530,7 @@ async fn relay_topology_concurrent_add_built_batch_calls_converge() -> TestResul
         let a_clone = a.clone();
         handles.push(tokio::spawn(async move {
             a_clone
-                .add_built_batch(sed_id, vec![pair], Vec::new())
+                .add_built_batch(sed_id, vec![pair], Vec::new(), None)
                 .await
         }));
     }

--- a/subduction_core/tests/sedimentree_operations.rs
+++ b/subduction_core/tests/sedimentree_operations.rs
@@ -12,7 +12,7 @@ async fn test_add_sedimentree_increases_count() -> TestResult {
     let tree = Sedimentree::default();
     let blobs = Vec::new();
 
-    subduction.add_sedimentree(id, tree, blobs).await?;
+    subduction.add_sedimentree(id, tree, blobs, None).await?;
 
     let ids = subduction.sedimentree_ids().await;
     assert_eq!(ids.len(), 1);
@@ -38,7 +38,7 @@ async fn test_get_commits_returns_empty_for_empty_tree() -> TestResult {
     let tree = Sedimentree::default();
     let blobs = Vec::new();
 
-    subduction.add_sedimentree(id, tree, blobs).await?;
+    subduction.add_sedimentree(id, tree, blobs, None).await?;
 
     let commits = subduction.get_commits(id).await;
     assert_eq!(commits, Some(Vec::new()));
@@ -63,7 +63,7 @@ async fn test_get_fragments_returns_empty_for_empty_tree() -> TestResult {
     let tree = Sedimentree::default();
     let blobs = Vec::new();
 
-    subduction.add_sedimentree(id, tree, blobs).await?;
+    subduction.add_sedimentree(id, tree, blobs, None).await?;
 
     let fragments = subduction.get_fragments(id).await;
     assert_eq!(fragments, Some(Vec::new()));
@@ -79,7 +79,7 @@ async fn test_remove_sedimentree_removes_from_ids() -> TestResult {
     let tree = Sedimentree::default();
     let blobs = Vec::new();
 
-    subduction.add_sedimentree(id, tree, blobs).await?;
+    subduction.add_sedimentree(id, tree, blobs, None).await?;
     assert_eq!(subduction.sedimentree_ids().await.len(), 1);
 
     subduction.remove_sedimentree(id).await?;

--- a/subduction_core/tests/store_add_combinators.rs
+++ b/subduction_core/tests/store_add_combinators.rs
@@ -1,0 +1,181 @@
+//! Local-only behavior of the `store_*` / `add_*` write tiers that does not
+//! require a connected peer:
+//!
+//! * `add_commits_batch` / `add_fragments_batch` (the round-trip combinators
+//!   added alongside the `store_*` split): empty input is a no-op yielding an
+//!   empty per-peer map; non-empty input persists everything. The wedged-peer
+//!   propagation behavior of these combinators is covered in
+//!   `addbatch_storage_durability.rs`.
+//! * `store_commit`'s `FragmentRequested` boundary signal: `Some(..)` when the
+//!   commit lands on a fragment boundary, `None` otherwise.
+
+#![allow(clippy::expect_used)]
+
+use std::collections::BTreeSet;
+
+use sedimentree_core::{blob::Blob, id::SedimentreeId, loose_commit::id::CommitId};
+use subduction_core::{connection::test_utils::new_test_subduction, subduction::FragmentBatchItem};
+use testresult::TestResult;
+
+fn make_blob(seed: u8) -> Blob {
+    let data: Vec<u8> = (0..64).map(|i| seed.wrapping_add(i)).collect();
+    Blob::new(data)
+}
+
+// ---------------------------------------------------------------------------
+// add_commits_batch
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn add_commits_batch_empty_is_noop_and_empty_map() -> TestResult {
+    let (sd, _listener, _manager) = new_test_subduction();
+    let sed_id = SedimentreeId::new([1u8; 32]);
+
+    let per_peer = sd.add_commits_batch(sed_id, Vec::new(), None).await?;
+
+    assert!(
+        per_peer.is_empty(),
+        "empty batch must yield an empty per-peer map"
+    );
+    assert!(
+        sd.get_commits(sed_id).await.is_none(),
+        "empty batch should not create a sedimentree"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_commits_batch_persists_all_commits() -> TestResult {
+    let (sd, _listener, _manager) = new_test_subduction();
+    let sed_id = SedimentreeId::new([2u8; 32]);
+
+    // Non-boundary heads (first byte != 0) so nothing minimizes into a fragment.
+    let inputs: Vec<(CommitId, BTreeSet<CommitId>, Blob)> = (0..5u8)
+        .map(|i| (CommitId::new([i + 100; 32]), BTreeSet::new(), make_blob(i)))
+        .collect();
+    let expected_ids: BTreeSet<CommitId> = inputs.iter().map(|(id, _, _)| *id).collect();
+
+    // No peers connected → an empty per-peer map, but the data must persist.
+    let per_peer = sd.add_commits_batch(sed_id, inputs, None).await?;
+    assert!(
+        per_peer.is_empty(),
+        "no connected peers → empty per-peer map"
+    );
+
+    let stored = sd.get_commits(sed_id).await.expect("sedimentree must exist");
+    let stored_ids: BTreeSet<CommitId> = stored.iter().map(|c| c.head()).collect();
+    assert_eq!(
+        stored_ids, expected_ids,
+        "exactly the input commits must be stored (by identity, not just count)"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// add_fragments_batch
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn add_fragments_batch_empty_is_noop_and_empty_map() -> TestResult {
+    let (sd, _listener, _manager) = new_test_subduction();
+    let sed_id = SedimentreeId::new([3u8; 32]);
+
+    let per_peer = sd.add_fragments_batch(sed_id, Vec::new(), None).await?;
+
+    assert!(
+        per_peer.is_empty(),
+        "empty batch must yield an empty per-peer map"
+    );
+    assert!(
+        sd.get_fragments(sed_id).await.is_none(),
+        "empty batch should not create a sedimentree"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_fragments_batch_persists_all_fragments() -> TestResult {
+    let (sd, _listener, _manager) = new_test_subduction();
+    let sed_id = SedimentreeId::new([4u8; 32]);
+
+    let fragments: Vec<FragmentBatchItem> = (0..3u8)
+        .map(|i| FragmentBatchItem {
+            head: CommitId::new([i + 50; 32]),
+            boundary: BTreeSet::from([CommitId::new([i + 150; 32])]),
+            checkpoints: Vec::new(),
+            blob: make_blob(i),
+        })
+        .collect();
+    let expected_heads: BTreeSet<CommitId> = fragments.iter().map(|f| f.head).collect();
+
+    let per_peer = sd.add_fragments_batch(sed_id, fragments, None).await?;
+    assert!(
+        per_peer.is_empty(),
+        "no connected peers → empty per-peer map"
+    );
+
+    let stored = sd
+        .get_fragments(sed_id)
+        .await
+        .expect("sedimentree must exist");
+    let stored_heads: BTreeSet<CommitId> = stored.iter().map(|f| f.head()).collect();
+    assert_eq!(
+        stored_heads, expected_heads,
+        "exactly the input fragments must be stored (by head identity)"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// store_commit FragmentRequested boundary signal
+// ---------------------------------------------------------------------------
+
+/// A boundary commit (depth > 0 under `CountLeadingZeroBytes`, i.e. a leading
+/// zero byte) must yield `Some(FragmentRequested)` for the same head.
+#[tokio::test]
+async fn store_commit_signals_fragment_requested_on_boundary() -> TestResult {
+    let (sd, _listener, _manager) = new_test_subduction();
+    let sed_id = SedimentreeId::new([5u8; 32]);
+
+    // Leading 0x00 byte → depth >= 1 → boundary.
+    let head = CommitId::new([0u8, 0xAB, 0xCD, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]);
+
+    let requested = sd
+        .store_commit(sed_id, head, BTreeSet::new(), make_blob(1))
+        .await?;
+
+    let fragment_requested =
+        requested.expect("a boundary commit must request a fragment (Some)");
+    assert_eq!(
+        fragment_requested.head(),
+        head,
+        "FragmentRequested must reference the boundary commit's head"
+    );
+
+    Ok(())
+}
+
+/// A non-boundary commit (depth 0, no leading zero byte) must yield `None`.
+#[tokio::test]
+async fn store_commit_no_fragment_requested_off_boundary() -> TestResult {
+    let (sd, _listener, _manager) = new_test_subduction();
+    let sed_id = SedimentreeId::new([6u8; 32]);
+
+    // First byte non-zero → depth 0 → not a boundary.
+    let head = CommitId::new([0xFFu8; 32]);
+
+    let requested = sd
+        .store_commit(sed_id, head, BTreeSet::new(), make_blob(2))
+        .await?;
+
+    assert!(
+        requested.is_none(),
+        "a non-boundary commit must not request a fragment (None)"
+    );
+
+    Ok(())
+}

--- a/subduction_core/tests/store_add_combinators.rs
+++ b/subduction_core/tests/store_add_combinators.rs
@@ -63,8 +63,14 @@ async fn add_commits_batch_persists_all_commits() -> TestResult {
         "no connected peers → empty per-peer map"
     );
 
-    let stored = sd.get_commits(sed_id).await.expect("sedimentree must exist");
-    let stored_ids: BTreeSet<CommitId> = stored.iter().map(|c| c.head()).collect();
+    let stored = sd
+        .get_commits(sed_id)
+        .await
+        .expect("sedimentree must exist");
+    let stored_ids: BTreeSet<CommitId> = stored
+        .iter()
+        .map(sedimentree_core::loose_commit::LooseCommit::head)
+        .collect();
     assert_eq!(
         stored_ids, expected_ids,
         "exactly the input commits must be stored (by identity, not just count)"
@@ -121,7 +127,10 @@ async fn add_fragments_batch_persists_all_fragments() -> TestResult {
         .get_fragments(sed_id)
         .await
         .expect("sedimentree must exist");
-    let stored_heads: BTreeSet<CommitId> = stored.iter().map(|f| f.head()).collect();
+    let stored_heads: BTreeSet<CommitId> = stored
+        .iter()
+        .map(sedimentree_core::fragment::Fragment::head)
+        .collect();
     assert_eq!(
         stored_heads, expected_heads,
         "exactly the input fragments must be stored (by head identity)"
@@ -142,14 +151,16 @@ async fn store_commit_signals_fragment_requested_on_boundary() -> TestResult {
     let sed_id = SedimentreeId::new([5u8; 32]);
 
     // Leading 0x00 byte → depth >= 1 → boundary.
-    let head = CommitId::new([0u8, 0xAB, 0xCD, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]);
+    let head = CommitId::new([
+        0u8, 0xAB, 0xCD, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+        22, 23, 24, 25, 26, 27, 28, 29,
+    ]);
 
     let requested = sd
         .store_commit(sed_id, head, BTreeSet::new(), make_blob(1))
         .await?;
 
-    let fragment_requested =
-        requested.expect("a boundary commit must request a fragment (Some)");
+    let fragment_requested = requested.expect("a boundary commit must request a fragment (Some)");
     assert_eq!(
         fragment_requested.head(),
         head,

--- a/subduction_core/tests/store_is_broadcast_free.rs
+++ b/subduction_core/tests/store_is_broadcast_free.rs
@@ -165,12 +165,12 @@ async fn store_built_batch_does_not_broadcast() -> TestResult {
     // Positive control: an explicit sync from B pulls the data, confirming
     // the link works and the negative assertion above wasn't vacuous.
     let a_peer = PeerId::from(a_signer.verifying_key());
-    b.sync_with_peer(&a_peer, sed_id, true, SYNC_TIMEOUT).await?;
+    b.sync_with_peer(&a_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
 
-    let converged = wait_until(|| async {
-        b.get_commits(sed_id).await.as_ref().map(Vec::len) == Some(5)
-    })
-    .await;
+    let converged =
+        wait_until(|| async { b.get_commits(sed_id).await.as_ref().map(Vec::len) == Some(5) })
+            .await;
     assert!(
         converged,
         "after an explicit sync_with_peer, B must receive all 5 commits \
@@ -194,8 +194,13 @@ async fn store_commit_does_not_broadcast() -> TestResult {
     let sed_id = SedimentreeId::new([2u8; 32]);
 
     // Non-boundary head so this is a plain loose commit.
-    a.store_commit(sed_id, CommitId::new([0xAB; 32]), BTreeSet::new(), make_blob(1))
-        .await?;
+    a.store_commit(
+        sed_id,
+        CommitId::new([0xAB; 32]),
+        BTreeSet::new(),
+        make_blob(1),
+    )
+    .await?;
 
     assert_eq!(
         a.get_commits(sed_id).await.as_ref().map(Vec::len),

--- a/subduction_core/tests/store_is_broadcast_free.rs
+++ b/subduction_core/tests/store_is_broadcast_free.rs
@@ -1,0 +1,213 @@
+//! The defining contract of the `store_*` tier: it never touches the network.
+//!
+//! Two responsive nodes A and B are connected over `ChannelTransport`. After
+//! `store_built_batch` on A, B must still hold nothing for that sedimentree —
+//! proving the durable write did not broadcast. As a positive control (so the
+//! "B got nothing" assertion can't pass merely because the harness never
+//! propagates anything), the same data is then made to reach B via an explicit
+//! `sync_with_peer`, which must succeed.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    commit::CountLeadingZeroBytes,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+};
+use subduction_core::{
+    authenticated::Authenticated,
+    connection::test_utils::{ChannelTransport, InstantTimeout, TokioSpawn},
+    handler::sync::SyncHandler,
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    storage::memory::MemoryStorage,
+    subduction::{Subduction, builder::SubductionBuilder},
+    transport::message::MessageTransport,
+};
+use subduction_crypto::signer::memory::MemorySigner;
+use testresult::TestResult;
+
+type Conn = MessageTransport<ChannelTransport>;
+
+type TestSyncHandler =
+    SyncHandler<Sendable, MemoryStorage, Conn, OpenPolicy, CountLeadingZeroBytes>;
+
+type TestSubduction = Arc<
+    Subduction<
+        'static,
+        Sendable,
+        MemoryStorage,
+        Conn,
+        TestSyncHandler,
+        OpenPolicy,
+        MemorySigner,
+        InstantTimeout,
+    >,
+>;
+
+const SYNC_TIMEOUT: Option<Duration> = Some(Duration::from_millis(500));
+
+/// Time allowed for any (unwanted) broadcast to land before we assert it
+/// did not. Generous relative to the in-process channel latency so a
+/// "B got nothing" pass reflects no-broadcast, not a too-short wait.
+const PROPAGATION_PAUSE: Duration = Duration::from_millis(100);
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn wait_until<F, Fut>(mut cond: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: core::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + WAIT_TIMEOUT;
+    loop {
+        if cond().await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+fn make_signer(seed: u8) -> MemorySigner {
+    MemorySigner::from_bytes(&[seed; 32])
+}
+
+fn make_node(signer: MemorySigner) -> TestSubduction {
+    let (sd, _h, listener, manager) = SubductionBuilder::new()
+        .signer(signer)
+        .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, Conn>();
+    tokio::spawn(listener);
+    tokio::spawn(manager);
+    sd
+}
+
+fn make_blob(seed: u8) -> Blob {
+    let data: Vec<u8> = (0..64).map(|i| seed.wrapping_add(i)).collect();
+    Blob::new(data)
+}
+
+fn make_commit(id: SedimentreeId, head: u8, blob_seed: u8) -> (LooseCommit, Blob) {
+    let blob = make_blob(blob_seed);
+    let blob_meta = BlobMeta::new(&blob);
+    let commit = LooseCommit::new(id, CommitId::new([head; 32]), BTreeSet::new(), blob_meta);
+    (commit, blob)
+}
+
+async fn connect_pair(
+    a: &TestSubduction,
+    a_signer: &MemorySigner,
+    b: &TestSubduction,
+    b_signer: &MemorySigner,
+) -> TestResult {
+    let (t_a, t_b) = ChannelTransport::pair();
+
+    let conn_a = MessageTransport::new(t_a);
+    let conn_b = MessageTransport::new(t_b);
+
+    let peer_a = PeerId::from(a_signer.verifying_key());
+    let peer_b = PeerId::from(b_signer.verifying_key());
+
+    let auth_a: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_a, peer_b);
+    let auth_b: Authenticated<Conn, Sendable> = Authenticated::new_for_test(conn_b, peer_a);
+
+    a.add_connection(auth_a).await?;
+    b.add_connection(auth_b).await?;
+
+    Ok(())
+}
+
+/// `store_built_batch` must not propagate: with a responsive peer connected,
+/// B receives nothing. The positive control then pulls the data via
+/// `sync_with_peer`, proving the harness *can* observe propagation (so the
+/// negative assertion is meaningful).
+#[tokio::test]
+async fn store_built_batch_does_not_broadcast() -> TestResult {
+    let a_signer = make_signer(60);
+    let b_signer = make_signer(70);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let sed_id = SedimentreeId::new([1u8; 32]);
+    let commits: Vec<(LooseCommit, Blob)> =
+        (0..5).map(|i| make_commit(sed_id, i + 100, i)).collect();
+
+    // Durable, local-only write.
+    a.store_built_batch(sed_id, commits, Vec::new()).await?;
+
+    // A holds the data.
+    assert_eq!(
+        a.get_commits(sed_id).await.as_ref().map(Vec::len),
+        Some(5),
+        "A must hold the stored commits"
+    );
+
+    // Give any (unwanted) broadcast ample time to land, then assert B is
+    // still empty for this sedimentree.
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+    assert!(
+        b.get_commits(sed_id).await.is_none(),
+        "store_built_batch must NOT broadcast: B should have received nothing"
+    );
+
+    // Positive control: an explicit sync from B pulls the data, confirming
+    // the link works and the negative assertion above wasn't vacuous.
+    let a_peer = PeerId::from(a_signer.verifying_key());
+    b.sync_with_peer(&a_peer, sed_id, true, SYNC_TIMEOUT).await?;
+
+    let converged = wait_until(|| async {
+        b.get_commits(sed_id).await.as_ref().map(Vec::len) == Some(5)
+    })
+    .await;
+    assert!(
+        converged,
+        "after an explicit sync_with_peer, B must receive all 5 commits \
+         (positive control for the no-broadcast assertion)"
+    );
+
+    Ok(())
+}
+
+/// `store_commit` (single, local-only) likewise must not broadcast.
+#[tokio::test]
+async fn store_commit_does_not_broadcast() -> TestResult {
+    let a_signer = make_signer(61);
+    let b_signer = make_signer(71);
+    let a = make_node(a_signer.clone());
+    let b = make_node(b_signer.clone());
+
+    connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let sed_id = SedimentreeId::new([2u8; 32]);
+
+    // Non-boundary head so this is a plain loose commit.
+    a.store_commit(sed_id, CommitId::new([0xAB; 32]), BTreeSet::new(), make_blob(1))
+        .await?;
+
+    assert_eq!(
+        a.get_commits(sed_id).await.as_ref().map(Vec::len),
+        Some(1),
+        "A must hold the stored commit"
+    );
+
+    tokio::time::sleep(PROPAGATION_PAUSE).await;
+    assert!(
+        b.get_commits(sed_id).await.is_none(),
+        "store_commit must NOT broadcast: B should have received nothing"
+    );
+
+    Ok(())
+}

--- a/subduction_wasm/src/batch_input.rs
+++ b/subduction_wasm/src/batch_input.rs
@@ -24,9 +24,11 @@ use wasm_bindgen::prelude::*;
 /// One unsigned commit + its blob, ready for bulk insertion.
 ///
 /// Construct with `new CommitInput(looseCommit, blob)` from JavaScript;
-/// pass arrays of these to
-/// [`addBatch`](crate::subduction::WasmSubduction::add_batch) or
-/// [`addCommitsBatch`](crate::subduction::WasmSubduction::add_commits_batch).
+/// pass arrays of these to the batch write methods
+/// ([`addBatch`](crate::subduction::WasmSubduction::add_batch) /
+/// [`storeBuiltBatch`](crate::subduction::WasmSubduction::store_built_batch),
+/// [`addCommitsBatch`](crate::subduction::WasmSubduction::add_commits_batch) /
+/// [`storeCommitsBatch`](crate::subduction::WasmSubduction::store_commits_batch)).
 #[wasm_bindgen(js_name = CommitInput)]
 #[derive(Debug, Clone)]
 pub struct WasmCommitInput {
@@ -86,9 +88,11 @@ impl WasmCommitInput {
 /// One unsigned fragment + its blob, ready for bulk insertion.
 ///
 /// Construct with `new FragmentInput(fragment, blob)` from JavaScript;
-/// pass arrays of these to
-/// [`addBatch`](crate::subduction::WasmSubduction::add_batch) or
-/// [`addFragmentsBatch`](crate::subduction::WasmSubduction::add_fragments_batch).
+/// pass arrays of these to the batch write methods
+/// ([`addBatch`](crate::subduction::WasmSubduction::add_batch) /
+/// [`storeBuiltBatch`](crate::subduction::WasmSubduction::store_built_batch),
+/// [`addFragmentsBatch`](crate::subduction::WasmSubduction::add_fragments_batch) /
+/// [`storeFragmentsBatch`](crate::subduction::WasmSubduction::store_fragments_batch)).
 #[wasm_bindgen(js_name = FragmentInput)]
 #[derive(Debug, Clone)]
 pub struct WasmFragmentInput {

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -504,7 +504,9 @@ impl WasmSubduction {
     ///
     /// # Errors
     ///
-    /// Returns [`WasmWriteError`] if there is a problem with storage or policy.
+    /// Returns [`WasmWriteError`] if a referenced blob is missing or storage
+    /// I/O fails. This local-only path uses the trusting local putter, so no
+    /// network policy is consulted.
     #[wasm_bindgen(js_name = storeSedimentree)]
     pub async fn store_sedimentree(
         &self,
@@ -539,9 +541,11 @@ impl WasmSubduction {
     ///
     /// # Errors
     ///
-    /// Returns [`WasmWriteError`] if there is a problem with storage or policy.
-    /// Per-peer transport failures are reported inside the returned map, not as
-    /// an error.
+    /// Returns [`WasmWriteError`] if a referenced blob is missing, or on
+    /// storage I/O — including storage errors hit while ingesting inbound data
+    /// during the trailing sync. The local store uses the trusting local
+    /// putter (no network policy check). Per-peer transport failures during
+    /// the broadcast are reported inside the returned map, not as an error.
     #[wasm_bindgen(js_name = addSedimentree)]
     pub async fn add_sedimentree(
         &self,
@@ -989,7 +993,8 @@ impl WasmSubduction {
     ///
     /// # Errors
     ///
-    /// Returns a [`WasmWriteError`] if storage or policy fail.
+    /// Returns a [`WasmWriteError`] on storage I/O failure. This local-only
+    /// path uses the trusting local putter, so no network policy is consulted.
     #[wasm_bindgen(js_name = storeCommit)]
     #[allow(clippy::needless_pass_by_value)] // wasm_bindgen needs to take Vecs not slices
     pub async fn store_commit(
@@ -1066,7 +1071,8 @@ impl WasmSubduction {
     ///
     /// # Errors
     ///
-    /// Returns a [`WasmWriteError`] if storage or policy fail.
+    /// Returns a [`WasmWriteError`] on storage I/O failure. This local-only
+    /// path uses the trusting local putter, so no network policy is consulted.
     #[wasm_bindgen(js_name = storeFragment)]
     #[allow(clippy::needless_pass_by_value)] // wasm_bindgen needs to take Vecs not slices
     pub async fn store_fragment(

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -514,6 +514,7 @@ impl WasmSubduction {
                     .into_iter()
                     .map(|bytes| bytes.to_vec().into())
                     .collect(),
+                None,
             )
             .await?;
         Ok(())
@@ -1050,7 +1051,7 @@ impl WasmSubduction {
             .collect();
 
         self.core
-            .add_built_batch(core_id, core_commits, core_fragments)
+            .add_built_batch(core_id, core_commits, core_fragments, None)
             .await?;
         Ok(())
     }
@@ -1083,7 +1084,7 @@ impl WasmSubduction {
             .collect();
 
         self.core
-            .add_built_batch_locally(core_id, core_commits, Vec::new())
+            .store_built_batch(core_id, core_commits, Vec::new())
             .await?;
         Ok(())
     }
@@ -1114,7 +1115,7 @@ impl WasmSubduction {
             .collect();
 
         self.core
-            .add_built_batch_locally(core_id, Vec::new(), core_fragments)
+            .store_built_batch(core_id, Vec::new(), core_fragments)
             .await?;
         Ok(())
     }

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -494,19 +494,65 @@ impl WasmSubduction {
         })
     }
 
-    /// Add a Sedimentree.
+    /// Persist a whole [`Sedimentree`](sedimentree_wasm::WasmSedimentree)
+    /// locally **without** broadcasting (the `store_*` tier).
+    ///
+    /// Durability only: never waits on a peer. Drive
+    /// [`syncWithAllPeers`](Self::sync_with_all_peers) yourself to propagate.
+    /// Use [`addSedimentree`](Self::add_sedimentree) for the
+    /// store-and-broadcast combinator.
     ///
     /// # Errors
     ///
-    /// Returns [`WasmWriteError`] if there is a problem with storage, networking, or policy.
-    #[wasm_bindgen(js_name = addSedimentree)]
-    pub async fn add_sedimentree(
+    /// Returns [`WasmWriteError`] if there is a problem with storage or policy.
+    #[wasm_bindgen(js_name = storeSedimentree)]
+    pub async fn store_sedimentree(
         &self,
         id: &WasmSedimentreeId,
         sedimentree: &WasmSedimentree,
         blobs: Vec<Uint8Array>,
     ) -> Result<(), WasmWriteError> {
         self.core
+            .store_sedimentree(
+                id.clone().into(),
+                sedimentree.clone().into(),
+                blobs
+                    .into_iter()
+                    .map(|bytes| bytes.to_vec().into())
+                    .collect(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Persist a whole [`Sedimentree`](sedimentree_wasm::WasmSedimentree)
+    /// **and** broadcast it to all connected peers (the `add_*` combinator =
+    /// [`storeSedimentree`](Self::store_sedimentree) +
+    /// [`syncWithAllPeers`](Self::sync_with_all_peers)).
+    ///
+    /// Returns the per-peer broadcast outcome as a
+    /// [`PeerResultMap`](WasmPeerResultMap). This **awaits the broadcast**, so
+    /// an unresponsive peer can stall the call for up to `timeout_milliseconds`
+    /// (or the configured default when omitted); callers wanting a
+    /// non-blocking durable write should use
+    /// [`storeSedimentree`](Self::store_sedimentree) instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmWriteError`] if there is a problem with storage or policy.
+    /// Per-peer transport failures are reported inside the returned map, not as
+    /// an error.
+    #[wasm_bindgen(js_name = addSedimentree)]
+    pub async fn add_sedimentree(
+        &self,
+        id: &WasmSedimentreeId,
+        sedimentree: &WasmSedimentree,
+        blobs: Vec<Uint8Array>,
+        timeout_milliseconds: Option<u64>,
+    ) -> Result<WasmPeerResultMap, WasmWriteError> {
+        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let per_peer = self
+            .core
             .add_sedimentree(
                 id.clone().into(),
                 sedimentree.clone().into(),
@@ -514,10 +560,10 @@ impl WasmSubduction {
                     .into_iter()
                     .map(|bytes| bytes.to_vec().into())
                     .collect(),
-                None,
+                timeout,
             )
             .await?;
-        Ok(())
+        Ok(per_peer.into())
     }
 
     /// Remove a Sedimentree and all associated data.
@@ -929,10 +975,57 @@ impl WasmSubduction {
         }
     }
 
-    /// Add a commit with its associated blob to the storage.
+    /// Persist a single commit with its blob locally **without** broadcasting
+    /// (the `store_*` tier).
     ///
     /// The commit metadata (including `BlobMeta`) is computed internally from
     /// the provided blob, ensuring consistency by construction.
+    ///
+    /// Durability only: never waits on a peer. Use
+    /// [`addCommit`](Self::add_commit) for the store-and-push combinator.
+    ///
+    /// Returns the [`WasmFragmentRequested`] signal when the commit lands on a
+    /// fragment boundary, exactly as [`addCommit`](Self::add_commit) does.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WasmWriteError`] if storage or policy fail.
+    #[wasm_bindgen(js_name = storeCommit)]
+    #[allow(clippy::needless_pass_by_value)] // wasm_bindgen needs to take Vecs not slices
+    pub async fn store_commit(
+        &self,
+        id: &WasmSedimentreeId,
+        head: &WasmCommitId,
+        parents: Vec<JsCommitId>,
+        blob: &Uint8Array,
+    ) -> Result<Option<WasmFragmentRequested>, WasmWriteError> {
+        let core_id: SedimentreeId = id.clone().into();
+        let core_head = CommitId::from(head);
+        let core_parents: BTreeSet<CommitId> = parents
+            .iter()
+            .map(|p| CommitId::from(WasmCommitId::from(p)))
+            .collect();
+        let blob: Blob = blob.clone().to_vec().into();
+
+        let maybe_fragment_requested = self
+            .core
+            .store_commit(core_id, core_head, core_parents, blob)
+            .await?;
+
+        Ok(maybe_fragment_requested.map(WasmFragmentRequested::from))
+    }
+
+    /// Add a commit with its associated blob to the storage, then push it to
+    /// authorized subscribers (the `add_*` combinator =
+    /// [`storeCommit`](Self::store_commit) + best-effort push).
+    ///
+    /// The commit metadata (including `BlobMeta`) is computed internally from
+    /// the provided blob, ensuring consistency by construction.
+    ///
+    /// Propagation is a best-effort `send` to subscribers; it does not block
+    /// on peer acks (no per-peer result is produced for single-item pushes).
+    /// For a durable write with no propagation, use
+    /// [`storeCommit`](Self::store_commit).
     ///
     /// # Errors
     ///
@@ -962,10 +1055,57 @@ impl WasmSubduction {
         Ok(maybe_fragment_requested.map(WasmFragmentRequested::from))
     }
 
-    /// Add a fragment with its associated blob to the storage.
+    /// Persist a single fragment with its blob locally **without**
+    /// broadcasting (the `store_*` tier).
     ///
     /// The fragment metadata (including `BlobMeta`) is computed internally from
     /// the provided blob, ensuring consistency by construction.
+    ///
+    /// Durability only: never waits on a peer. Use
+    /// [`addFragment`](Self::add_fragment) for the store-and-push combinator.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WasmWriteError`] if storage or policy fail.
+    #[wasm_bindgen(js_name = storeFragment)]
+    #[allow(clippy::needless_pass_by_value)] // wasm_bindgen needs to take Vecs not slices
+    pub async fn store_fragment(
+        &self,
+        id: &WasmSedimentreeId,
+        head: &WasmCommitId,
+        boundary: Vec<JsCommitId>,
+        checkpoints: Vec<JsCommitId>,
+        blob: &Uint8Array,
+    ) -> Result<(), WasmWriteError> {
+        let core_id: SedimentreeId = id.clone().into();
+        let core_head = CommitId::from(head);
+        let core_boundary: BTreeSet<CommitId> = boundary
+            .iter()
+            .map(|p| CommitId::from(WasmCommitId::from(p)))
+            .collect();
+        let core_checkpoints: Vec<CommitId> = checkpoints
+            .iter()
+            .map(|p| CommitId::from(WasmCommitId::from(p)))
+            .collect();
+        let blob: Blob = blob.clone().to_vec().into();
+
+        self.core
+            .store_fragment(core_id, core_head, core_boundary, &core_checkpoints, blob)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Add a fragment with its associated blob to the storage, then push it to
+    /// authorized subscribers (the `add_*` combinator =
+    /// [`storeFragment`](Self::store_fragment) + best-effort push).
+    ///
+    /// The fragment metadata (including `BlobMeta`) is computed internally from
+    /// the provided blob, ensuring consistency by construction.
+    ///
+    /// Propagation is a best-effort `send` to subscribers; it does not block
+    /// on peer acks. For a durable write with no propagation, use
+    /// [`storeFragment`](Self::store_fragment).
     ///
     /// # Errors
     ///
@@ -999,42 +1139,31 @@ impl WasmSubduction {
         Ok(())
     }
 
-    /// Bulk-insert commits and fragments into a sedimentree, then broadcast.
+    /// Bulk-insert commits and fragments into a sedimentree **without**
+    /// broadcasting (the `store_*` tier).
     ///
-    /// Unlike [`add_commit`](Self::add_commit) and
-    /// [`add_fragment`](Self::add_fragment) — which each re-minimize the tree
-    /// and broadcast to peers per call — this method inserts everything first,
-    /// runs `minimize_tree` once at the end, and then performs a single
-    /// `sync_with_all_peers` to propagate the new state. For workloads that
-    /// add many commits or fragments at once this avoids `O(N²)` minimize work
-    /// and `N` redundant broadcasts.
+    /// Inserts everything first and runs `minimize_tree` once at the end —
+    /// avoiding the `O(N²)` minimize work of looping
+    /// [`storeCommit`](Self::store_commit) — but performs **no** network
+    /// propagation. Useful for ingestion paths (local replay, hydration from
+    /// another store) where the caller drives sync separately or not at all.
     ///
     /// Each [`WasmCommitInput`] bundles an unsigned
     /// [`LooseCommit`](sedimentree_core::loose_commit::LooseCommit) with its
     /// blob; each [`WasmFragmentInput`] bundles an unsigned
     /// [`Fragment`](sedimentree_core::fragment::Fragment) with its blob.
-    /// Either list may be empty; passing two empty lists is a no-op (no
-    /// minimize, no broadcast).
+    /// Either list may be empty; two empty lists is a no-op.
+    ///
+    /// Use [`addBatch`](Self::add_batch) for the store-and-broadcast
+    /// combinator.
     ///
     /// # Errors
     ///
     /// Returns a [`WasmWriteError`] if any blob does not match its claimed
-    /// [`BlobMeta`](sedimentree_core::blob::BlobMeta), or if a local
-    /// [`Storage`](sedimentree_wasm::storage::JsStorage) error is hit while
-    /// persisting the batch or while ingesting inbound data during the
-    /// trailing broadcast.
-    ///
-    /// Per-peer transport failures during the trailing broadcast are *not*
-    /// surfaced as `Err`: peers that can't be reached (closed connections,
-    /// timeouts) are reported by `sync_with_all_peers` as data inside its
-    /// per-peer result map, which this method discards. If you need to
-    /// observe peer-level sync outcomes, drive the local insert via
-    /// [`addCommitsBatch`](Self::add_commits_batch) /
-    /// [`addFragmentsBatch`](Self::add_fragments_batch) and call
-    /// [`syncWithAllPeers`](Self::sync_with_all_peers) directly.
-    #[wasm_bindgen(js_name = addBatch)]
+    /// [`BlobMeta`](sedimentree_core::blob::BlobMeta), or if storage fails.
+    #[wasm_bindgen(js_name = storeBuiltBatch)]
     #[allow(clippy::needless_pass_by_value)] // wasm_bindgen takes owned Vecs.
-    pub async fn add_batch(
+    pub async fn store_built_batch(
         &self,
         id: &WasmSedimentreeId,
         commits: Vec<WasmCommitInput>,
@@ -1051,28 +1180,85 @@ impl WasmSubduction {
             .collect();
 
         self.core
-            .add_built_batch(core_id, core_commits, core_fragments, None)
+            .store_built_batch(core_id, core_commits, core_fragments)
             .await?;
         Ok(())
     }
 
-    /// Bulk-insert commits into a sedimentree without broadcasting.
+    /// Bulk-insert commits and fragments into a sedimentree, then broadcast
+    /// (the `add_*` combinator = [`storeBuiltBatch`](Self::store_built_batch) +
+    /// [`syncWithAllPeers`](Self::sync_with_all_peers)).
     ///
-    /// Like [`addBatch`](Self::add_batch) for the commits half only, but
-    /// skips the trailing `sync_with_all_peers` step. Useful for ingestion
-    /// paths (e.g. local replay, hydration from another store) where the
-    /// caller will trigger sync separately or not at all.
+    /// Unlike [`addCommit`](Self::add_commit) and
+    /// [`addFragment`](Self::add_fragment) — which each re-minimize the tree
+    /// and push to peers per call — this method inserts everything first,
+    /// runs `minimize_tree` once at the end, and then performs a single
+    /// `sync_with_all_peers` to propagate the new state. For workloads that
+    /// add many commits or fragments at once this avoids `O(N²)` minimize work
+    /// and `N` redundant broadcasts.
     ///
-    /// Each [`WasmCommitInput`] bundles an unsigned commit with its blob;
-    /// an empty list is a no-op.
+    /// Returns the per-peer broadcast outcome as a
+    /// [`PeerResultMap`](WasmPeerResultMap). This **awaits the broadcast**, so
+    /// an unresponsive peer can stall the call for up to `timeout_milliseconds`
+    /// (or the configured default when omitted); callers wanting a
+    /// non-blocking durable write should use
+    /// [`storeBuiltBatch`](Self::store_built_batch) instead.
+    ///
+    /// Either list may be empty; passing two empty lists is a no-op (no
+    /// minimize, no broadcast) and yields an empty map.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WasmWriteError`] if any blob does not match its claimed
+    /// [`BlobMeta`](sedimentree_core::blob::BlobMeta), or if a local
+    /// [`Storage`](sedimentree_wasm::storage::JsStorage) error is hit while
+    /// persisting the batch or while ingesting inbound data during the
+    /// trailing broadcast. Per-peer transport failures are reported inside the
+    /// returned map, not as an error.
+    #[wasm_bindgen(js_name = addBatch)]
+    #[allow(clippy::needless_pass_by_value)] // wasm_bindgen takes owned Vecs.
+    pub async fn add_batch(
+        &self,
+        id: &WasmSedimentreeId,
+        commits: Vec<WasmCommitInput>,
+        fragments: Vec<WasmFragmentInput>,
+        timeout_milliseconds: Option<u64>,
+    ) -> Result<WasmPeerResultMap, WasmWriteError> {
+        let core_id: SedimentreeId = id.clone().into();
+        let core_commits = commits
+            .into_iter()
+            .map(WasmCommitInput::into_core)
+            .collect();
+        let core_fragments = fragments
+            .into_iter()
+            .map(WasmFragmentInput::into_core)
+            .collect();
+        let timeout = timeout_milliseconds.map(Duration::from_millis);
+
+        let per_peer = self
+            .core
+            .add_built_batch(core_id, core_commits, core_fragments, timeout)
+            .await?;
+        Ok(per_peer.into())
+    }
+
+    /// Bulk-insert commits into a sedimentree **without** broadcasting (the
+    /// `store_*` tier).
+    ///
+    /// Like [`storeBuiltBatch`](Self::store_built_batch) for the commits half
+    /// only. Each [`WasmCommitInput`] bundles an unsigned commit with its
+    /// blob; an empty list is a no-op.
+    ///
+    /// Use [`addCommitsBatch`](Self::add_commits_batch) for the
+    /// store-and-broadcast combinator.
     ///
     /// # Errors
     ///
     /// Returns a [`WasmWriteError`] if any blob does not match its claimed
     /// [`BlobMeta`](sedimentree_core::blob::BlobMeta), or if storage fails.
-    #[wasm_bindgen(js_name = addCommitsBatch)]
+    #[wasm_bindgen(js_name = storeCommitsBatch)]
     #[allow(clippy::needless_pass_by_value)] // wasm_bindgen takes owned Vecs.
-    pub async fn add_commits_batch(
+    pub async fn store_commits_batch(
         &self,
         id: &WasmSedimentreeId,
         commits: Vec<WasmCommitInput>,
@@ -1089,21 +1275,60 @@ impl WasmSubduction {
         Ok(())
     }
 
-    /// Bulk-insert fragments into a sedimentree without broadcasting.
+    /// Bulk-insert commits into a sedimentree, then broadcast (the `add_*`
+    /// combinator = [`storeCommitsBatch`](Self::store_commits_batch) +
+    /// [`syncWithAllPeers`](Self::sync_with_all_peers)).
     ///
-    /// Like [`addBatch`](Self::add_batch) for the fragments half only, but
-    /// skips the trailing `sync_with_all_peers` step.
-    ///
-    /// Each [`WasmFragmentInput`] bundles an unsigned fragment with its
-    /// blob; an empty list is a no-op.
+    /// Like [`addBatch`](Self::add_batch) for the commits half only. Returns
+    /// the per-peer broadcast outcome as a
+    /// [`PeerResultMap`](WasmPeerResultMap) and **awaits the broadcast** (an
+    /// unresponsive peer can stall the call for up to `timeout_milliseconds`).
+    /// An empty list is a no-op and yields an empty map.
     ///
     /// # Errors
     ///
     /// Returns a [`WasmWriteError`] if any blob does not match its claimed
     /// [`BlobMeta`](sedimentree_core::blob::BlobMeta), or if storage fails.
-    #[wasm_bindgen(js_name = addFragmentsBatch)]
+    /// Per-peer transport failures are reported inside the returned map.
+    #[wasm_bindgen(js_name = addCommitsBatch)]
     #[allow(clippy::needless_pass_by_value)] // wasm_bindgen takes owned Vecs.
-    pub async fn add_fragments_batch(
+    pub async fn add_commits_batch(
+        &self,
+        id: &WasmSedimentreeId,
+        commits: Vec<WasmCommitInput>,
+        timeout_milliseconds: Option<u64>,
+    ) -> Result<WasmPeerResultMap, WasmWriteError> {
+        let core_id: SedimentreeId = id.clone().into();
+        let core_commits = commits
+            .into_iter()
+            .map(WasmCommitInput::into_core)
+            .collect();
+        let timeout = timeout_milliseconds.map(Duration::from_millis);
+
+        let per_peer = self
+            .core
+            .add_built_batch(core_id, core_commits, Vec::new(), timeout)
+            .await?;
+        Ok(per_peer.into())
+    }
+
+    /// Bulk-insert fragments into a sedimentree **without** broadcasting (the
+    /// `store_*` tier).
+    ///
+    /// Like [`storeBuiltBatch`](Self::store_built_batch) for the fragments
+    /// half only. Each [`WasmFragmentInput`] bundles an unsigned fragment with
+    /// its blob; an empty list is a no-op.
+    ///
+    /// Use [`addFragmentsBatch`](Self::add_fragments_batch) for the
+    /// store-and-broadcast combinator.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WasmWriteError`] if any blob does not match its claimed
+    /// [`BlobMeta`](sedimentree_core::blob::BlobMeta), or if storage fails.
+    #[wasm_bindgen(js_name = storeFragmentsBatch)]
+    #[allow(clippy::needless_pass_by_value)] // wasm_bindgen takes owned Vecs.
+    pub async fn store_fragments_batch(
         &self,
         id: &WasmSedimentreeId,
         fragments: Vec<WasmFragmentInput>,
@@ -1118,6 +1343,43 @@ impl WasmSubduction {
             .store_built_batch(core_id, Vec::new(), core_fragments)
             .await?;
         Ok(())
+    }
+
+    /// Bulk-insert fragments into a sedimentree, then broadcast (the `add_*`
+    /// combinator = [`storeFragmentsBatch`](Self::store_fragments_batch) +
+    /// [`syncWithAllPeers`](Self::sync_with_all_peers)).
+    ///
+    /// Like [`addBatch`](Self::add_batch) for the fragments half only. Returns
+    /// the per-peer broadcast outcome as a
+    /// [`PeerResultMap`](WasmPeerResultMap) and **awaits the broadcast** (an
+    /// unresponsive peer can stall the call for up to `timeout_milliseconds`).
+    /// An empty list is a no-op and yields an empty map.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WasmWriteError`] if any blob does not match its claimed
+    /// [`BlobMeta`](sedimentree_core::blob::BlobMeta), or if storage fails.
+    /// Per-peer transport failures are reported inside the returned map.
+    #[wasm_bindgen(js_name = addFragmentsBatch)]
+    #[allow(clippy::needless_pass_by_value)] // wasm_bindgen takes owned Vecs.
+    pub async fn add_fragments_batch(
+        &self,
+        id: &WasmSedimentreeId,
+        fragments: Vec<WasmFragmentInput>,
+        timeout_milliseconds: Option<u64>,
+    ) -> Result<WasmPeerResultMap, WasmWriteError> {
+        let core_id: SedimentreeId = id.clone().into();
+        let core_fragments = fragments
+            .into_iter()
+            .map(WasmFragmentInput::into_core)
+            .collect();
+        let timeout = timeout_milliseconds.map(Duration::from_millis);
+
+        let per_peer = self
+            .core
+            .add_built_batch(core_id, Vec::new(), core_fragments, timeout)
+            .await?;
+        Ok(per_peer.into())
     }
 
     /// Compute the [`WasmDepth`] of a commit identifier under this node's
@@ -1210,24 +1472,7 @@ impl WasmSubduction {
             .sync_with_all_peers(id.clone().into(), subscribe, timeout)
             .await?;
         tracing::debug!("WasmSubduction::sync_with_all_peers - done");
-        Ok(WasmPeerResultMap(
-            peer_map
-                .into_iter()
-                .map(|(peer_id, (success, stats, conn_errs))| {
-                    (
-                        peer_id,
-                        (
-                            success,
-                            stats.into(),
-                            conn_errs
-                                .into_iter()
-                                .map(|(conn, err)| (conn.into_inner(), WasmCallError::from(err)))
-                                .collect::<Vec<_>>(),
-                        ),
-                    )
-                })
-                .collect(),
-        ))
+        Ok(peer_map.into())
     }
 
     /// Sync all known Sedimentree IDs with a single peer.
@@ -1551,6 +1796,43 @@ pub struct WasmPeerResultMap(
         ),
     >,
 );
+
+impl
+    From<
+        subduction_core::subduction::PerPeerSync<
+            WasmConn,
+            Local,
+            crate::transport::JsTransportError,
+        >,
+    > for WasmPeerResultMap
+{
+    fn from(
+        per_peer: subduction_core::subduction::PerPeerSync<
+            WasmConn,
+            Local,
+            crate::transport::JsTransportError,
+        >,
+    ) -> Self {
+        Self(
+            per_peer
+                .into_iter()
+                .map(|(peer_id, (success, stats, conn_errs))| {
+                    (
+                        peer_id,
+                        (
+                            success,
+                            stats.into(),
+                            conn_errs
+                                .into_iter()
+                                .map(|(conn, err)| (conn.into_inner(), WasmCallError::from(err)))
+                                .collect::<Vec<_>>(),
+                        ),
+                    )
+                })
+                .collect(),
+        )
+    }
+}
 
 #[wasm_bindgen(js_class = PeerResultMap)]
 impl WasmPeerResultMap {

--- a/subduction_wasm/tests/message_port_reentry.rs
+++ b/subduction_wasm/tests/message_port_reentry.rs
@@ -2,6 +2,9 @@
 
 #![cfg(target_arch = "wasm32")]
 #![allow(missing_docs)]
+// Test setup deliberately panics on a broken environment (missing
+// `MessageChannel`, etc.) — that *is* the failure signal for a test.
+#![allow(clippy::expect_used, clippy::panic)]
 
 use js_sys::{Function, Reflect};
 use subduction_wasm::transport::message_port::WasmMessagePortTransport;


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

- A different solution to (the second half of) #198 
- TLDR
  - Retain the `add_*` APIs (but make their shape consistent)
  - Provide decoupled `store_*` APIs (no rebroadcast)
  - Leave the internal `*_locally` methods alone

The basic idea is that _if_ you want more control over how data is added to Subduction, you can use the lower level APIs. This lets you do things like:

- Not wait for network propagation (to time out) by fire-and-forgetting
- Wait to store many bits of data, and network sync on a wall-clock schedule
- Run in an offline mode without dropping connections (e.g. UI "sync off" switch but retain e.g. comments/ephemeral messaging/etc)

I believe that this is a solution for #198, with added flexibility — the APIs currently on `main` have bothered me for a while, and the problem that DXOS ran into here is one symptom of the missing APIs.

### Alternatives

I also considered a few other designs, but ultimately rejected them. One included receiving a `impl Future` back from `add_*`, which would let the caller defer `await`ing it (or letting them `drop` it if they wanted). Others involved queues, channels, cancellation tokens, etc. This PR is more flexible than these, though there is always a matter of taste involved (in this case preferring composition plus convenience methods over typed tickets and/or cancellation)

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [x] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [ ] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
