### PR TITLE
WIP: Transport-based timeout

### DIFF
--- a/subduction_core/benches/subduction.rs
+++ b/subduction_core/benches/subduction.rs
@@ -999,6 +999,56 @@ mod display {
     }
 }
 
+mod multiplexer {
+    use core::time::Duration;
+
+    use criterion::{Criterion, black_box};
+    use futures::executor::block_on;
+    use subduction_core::multiplexer::Multiplexer;
+
+    use super::generators::{batch_sync_response_from_seed, peer_id_from_seed};
+
+    /// Microbenchmarks for the request-response multiplexer hot path.
+    ///
+    /// **Intent**: Quantify the per-request overhead of the progress-aware
+    /// ("idle") timeout machinery — specifically the `completion_epoch`
+    /// read/bump added to `resolve_pending`. The register → resolve
+    /// round-trip is on the critical path for every sync response.
+    ///
+    /// **Expected performance**: Sub-microsecond; dominated by the
+    /// `async_lock::Mutex` round-trip on the pending map, with the atomic
+    /// epoch bump being a negligible addition.
+    pub fn bench_multiplexer(c: &mut Criterion) {
+        let mut group = c.benchmark_group("multiplexer");
+
+        // The completion-epoch read performed by a waiting `call` on each
+        // idle window. Must be cheap — it can be hit frequently under load.
+        group.bench_function("completion_epoch_read", |b| {
+            let mux = Multiplexer::new(peer_id_from_seed(1), Duration::from_secs(30));
+            b.iter(|| black_box(mux.completion_epoch()));
+        });
+
+        // Full register + resolve round-trip (includes the epoch bump).
+        // This is the per-response hot path the GRACE change touches.
+        group.bench_function("register_resolve_roundtrip", |b| {
+            let mux = Multiplexer::new(peer_id_from_seed(2), Duration::from_secs(30));
+            let resp = batch_sync_response_from_seed(7, 0, 0, 0);
+            b.iter(|| {
+                block_on(async {
+                    let req_id = mux.next_request_id();
+                    // Use a response whose req_id matches the freshly minted id.
+                    let mut r = resp.clone();
+                    r.req_id = req_id;
+                    let _rx = mux.register_pending(req_id).await;
+                    black_box(mux.resolve_pending(&r).await);
+                });
+            });
+        });
+
+        group.finish();
+    }
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(997, Output::Flamegraph(None)));
@@ -1007,6 +1057,7 @@ criterion_group! {
         id::bench_storage_key,
         message::bench_message_construction,
         message::bench_message_request_id,
+        multiplexer::bench_multiplexer,
         sync::bench_sync_diff,
         sync::bench_batch_sync,
         collections::bench_collections,

--- a/subduction_core/src/connection/managed.rs
+++ b/subduction_core/src/connection/managed.rs
@@ -192,29 +192,50 @@ where
         Conn::SendError: Send + 'static,
         WireMsg: Encode + Decode + From<SyncMessage> + Send,
     {
-        let time_limit = timeout.unwrap_or(self.multiplexer.default_time_limit());
+        let idle_timeout = timeout.unwrap_or(self.multiplexer.default_idle_timeout());
         async move {
             let req_id = req.req_id;
-            let rx = self.multiplexer.register_pending(req_id).await;
+            let mut rx = self.multiplexer.register_pending(req_id).await;
 
             let wire_msg: WireMsg = SyncMessage::BatchSyncRequest(req).into();
             Connection::<Sendable, WireMsg>::send(&self.authenticated, &wire_msg)
                 .await
                 .map_err(CallError::Send)?;
 
-            match self.timer.timeout(time_limit, rx.boxed()).await {
-                Ok(Ok(resp)) => {
-                    tracing::debug!("request {req_id:?} completed");
-                    Ok(resp)
-                }
-                Ok(Err(_)) => {
-                    tracing::error!("request {req_id:?} response dropped");
-                    Err(CallError::ResponseDropped)
-                }
-                Err(TimedOut) => {
-                    tracing::error!("request {req_id:?} timed out");
-                    self.multiplexer.cancel_pending(&req_id).await;
-                    Err(CallError::Timeout)
+            // Progress-aware idle wait. Each iteration waits up to
+            // `idle_timeout` for our response. If that window elapses
+            // without our response, we time out *only if the connection
+            // made no progress* during it — i.e. no other request
+            // completed (the completion epoch is unchanged). If some other
+            // request did complete, the connection is alive and we re-arm,
+            // keeping a request queued behind a draining batch patient.
+            let mut last_epoch = self.multiplexer.completion_epoch();
+            loop {
+                match self.timer.timeout(idle_timeout, (&mut rx).boxed()).await {
+                    Ok(Ok(resp)) => {
+                        tracing::debug!("request {req_id:?} completed");
+                        return Ok(resp);
+                    }
+                    Ok(Err(_)) => {
+                        tracing::debug!("request {req_id:?} response channel dropped");
+                        return Err(CallError::ResponseDropped);
+                    }
+                    Err(TimedOut) => {
+                        let epoch = self.multiplexer.completion_epoch();
+                        if epoch != last_epoch {
+                            last_epoch = epoch;
+                            tracing::trace!(
+                                "request {req_id:?} idle window elapsed but connection \
+                                 made progress; re-arming"
+                            );
+                            continue;
+                        }
+                        tracing::warn!(
+                            "request {req_id:?} timed out (connection idle for {idle_timeout:?})"
+                        );
+                        self.multiplexer.cancel_pending(&req_id).await;
+                        return Err(CallError::Timeout);
+                    }
                 }
             }
         }
@@ -261,29 +282,50 @@ where
         Conn: Connection<Local, WireMsg> + PartialEq,
         WireMsg: Encode + Decode + From<SyncMessage>,
     {
-        let time_limit = timeout.unwrap_or(self.multiplexer.default_time_limit());
+        let idle_timeout = timeout.unwrap_or(self.multiplexer.default_idle_timeout());
         async move {
             let req_id = req.req_id;
-            let rx = self.multiplexer.register_pending(req_id).await;
+            let mut rx = self.multiplexer.register_pending(req_id).await;
 
             let wire_msg: WireMsg = SyncMessage::BatchSyncRequest(req).into();
             Connection::<Local, WireMsg>::send(&self.authenticated, &wire_msg)
                 .await
                 .map_err(CallError::Send)?;
 
-            match self.timer.timeout(time_limit, rx.boxed_local()).await {
-                Ok(Ok(resp)) => {
-                    tracing::debug!("request {req_id:?} completed");
-                    Ok(resp)
-                }
-                Ok(Err(_)) => {
-                    tracing::error!("request {req_id:?} response dropped");
-                    Err(CallError::ResponseDropped)
-                }
-                Err(TimedOut) => {
-                    tracing::error!("request {req_id:?} timed out");
-                    self.multiplexer.cancel_pending(&req_id).await;
-                    Err(CallError::Timeout)
+            // Progress-aware idle wait — see the `Sendable` variant for the
+            // full rationale. Re-arm on connection progress (completion
+            // epoch advanced); fail only after a full silent idle window.
+            let mut last_epoch = self.multiplexer.completion_epoch();
+            loop {
+                match self
+                    .timer
+                    .timeout(idle_timeout, (&mut rx).boxed_local())
+                    .await
+                {
+                    Ok(Ok(resp)) => {
+                        tracing::debug!("request {req_id:?} completed");
+                        return Ok(resp);
+                    }
+                    Ok(Err(_)) => {
+                        tracing::debug!("request {req_id:?} response channel dropped");
+                        return Err(CallError::ResponseDropped);
+                    }
+                    Err(TimedOut) => {
+                        let epoch = self.multiplexer.completion_epoch();
+                        if epoch != last_epoch {
+                            last_epoch = epoch;
+                            tracing::trace!(
+                                "request {req_id:?} idle window elapsed but connection \
+                                 made progress; re-arming"
+                            );
+                            continue;
+                        }
+                        tracing::warn!(
+                            "request {req_id:?} timed out (connection idle for {idle_timeout:?})"
+                        );
+                        self.multiplexer.cancel_pending(&req_id).await;
+                        return Err(CallError::Timeout);
+                    }
                 }
             }
         }

--- a/subduction_core/src/multiplexer.rs
+++ b/subduction_core/src/multiplexer.rs
@@ -24,22 +24,65 @@ use async_lock::Mutex;
 use futures::channel::oneshot;
 use sedimentree_core::collections::Map;
 
+use alloc::sync::Arc;
+
 use crate::{
     connection::message::{BatchSyncResponse, RequestId},
     peer::id::PeerId,
 };
 
+/// Default per-call idle timeout.
+///
+/// This is an **idle** timeout, not a total-deadline: it is the maximum
+/// tolerable gap between *completions* on a connection, not the total
+/// lifetime of a single request. Each completion on the connection
+/// re-arms it (see [`Multiplexer::completion_epoch`]), so a request
+/// queued behind others that are completing stays patient and only fails
+/// once the connection has been silent for this long.
+///
+/// Single source of truth: the builder default and the Wasm bindings both
+/// reference this constant.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Generic request-response multiplexer.
 ///
-/// Holds the pending-response map, request ID counter, and timeout
-/// strategy. Transport backends embed this and delegate their
-/// request-response impls to it.
+/// Holds the pending-response map, request ID counter, idle-timeout
+/// default, and a shared completion epoch. Transport backends embed this
+/// and delegate their request-response impls to it.
+///
+/// # Progress-aware ("idle") timeouts
+///
+/// A multiplexed connection may carry many concurrent in-flight requests
+/// (e.g. one per document in a large sync). Timing each request out on an
+/// *absolute* deadline since-send is wrong: a request merely queued
+/// behind others that are completing would false-fire even though the
+/// connection is healthy and making progress.
+///
+/// Instead, completions advance a shared [`completion_epoch`]. A waiting
+/// `call` snapshots the epoch and waits in `idle_timeout`-sized windows;
+/// if the epoch advanced over a window, the connection made progress
+/// (some request completed) and the caller re-arms rather than failing. A
+/// request times out only after a full window passes with **no**
+/// completion anywhere on the connection.
+///
+/// [`completion_epoch`]: Multiplexer::completion_epoch
 #[derive(Debug)]
 pub struct Multiplexer {
     peer_id: PeerId,
     req_id_counter: AtomicU64,
     pending: Mutex<Map<RequestId, oneshot::Sender<BatchSyncResponse>>>,
-    default_time_limit: Duration,
+    default_idle_timeout: Duration,
+
+    /// Monotonic count of completions (responses matched to a waiting
+    /// caller) on this connection.
+    ///
+    /// Shared (`Arc`) across multiplexer clones so every concurrent caller
+    /// observes the same progress signal. Bumped in
+    /// [`resolve_pending`](Self::resolve_pending); read by waiting `call`s
+    /// to decide whether the connection is alive. This is the
+    /// "reset on progress" fuse: completions re-arm it, idle gaps burn it
+    /// down.
+    completion_epoch: Arc<AtomicU64>,
 }
 
 impl Clone for Multiplexer {
@@ -48,7 +91,8 @@ impl Clone for Multiplexer {
             peer_id: self.peer_id,
             req_id_counter: AtomicU64::new(self.req_id_counter.load(Ordering::Relaxed)),
             pending: Mutex::new(Map::new()),
-            default_time_limit: self.default_time_limit,
+            default_idle_timeout: self.default_idle_timeout,
+            completion_epoch: Arc::clone(&self.completion_epoch),
         }
     }
 }
@@ -77,7 +121,7 @@ impl Multiplexer {
     /// Panics if the platform's random number generator is unavailable.
     #[must_use]
     #[allow(clippy::expect_used)]
-    pub fn new(peer_id: PeerId, default_time_limit: Duration) -> Self {
+    pub fn new(peer_id: PeerId, default_idle_timeout: Duration) -> Self {
         Self {
             peer_id,
             req_id_counter: AtomicU64::new({
@@ -86,7 +130,8 @@ impl Multiplexer {
                 u64::from_be_bytes(buf)
             }),
             pending: Mutex::new(Map::new()),
-            default_time_limit,
+            default_idle_timeout,
+            completion_epoch: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -95,9 +140,23 @@ impl Multiplexer {
         self.peer_id
     }
 
-    /// The default per-call time limit.
-    pub const fn default_time_limit(&self) -> Duration {
-        self.default_time_limit
+    /// The default per-call idle timeout: the maximum tolerable gap
+    /// between completions on this connection before a waiting call gives
+    /// up. See [`DEFAULT_IDLE_TIMEOUT`] and the type-level docs.
+    pub const fn default_idle_timeout(&self) -> Duration {
+        self.default_idle_timeout
+    }
+
+    /// The current completion epoch: a monotonic count of responses
+    /// matched to a waiting caller on this connection.
+    ///
+    /// A waiting `call` compares this across an idle window to decide
+    /// whether the connection made progress (stay patient) or went silent
+    /// (time out). The value itself is meaningless in isolation; only
+    /// *changes* matter.
+    #[must_use]
+    pub fn completion_epoch(&self) -> u64 {
+        self.completion_epoch.load(Ordering::Acquire)
     }
 
     /// Generate the next request ID.
@@ -157,6 +216,13 @@ impl Multiplexer {
         let req_id = resp.req_id;
         let mut pending = self.pending.lock().await;
         if let Some(tx) = pending.remove(&req_id) {
+            // Progress beat: a request completed on this connection. Bump
+            // the shared epoch so any concurrently-waiting `call` observes
+            // that the connection is alive and re-arms its idle window.
+            // Only genuine completions count — `cancel_all_pending` (on
+            // disconnect) deliberately does NOT bump, since a torn-down
+            // connection is not making progress.
+            self.completion_epoch.fetch_add(1, Ordering::Release);
             drop(tx.send(resp.clone()));
             tracing::debug!("routed BatchSyncResponse for {req_id:?} to pending caller");
             true
@@ -170,10 +236,93 @@ impl Multiplexer {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::{
+        connection::message::SyncResult, remote_heads::RemoteHeads,
+    };
     use core::time::Duration;
+    use sedimentree_core::id::SedimentreeId;
 
     fn test_mux() -> Multiplexer {
         Multiplexer::new(PeerId::new([1u8; 32]), Duration::from_secs(5))
+    }
+
+    fn response_for(req_id: RequestId) -> BatchSyncResponse {
+        BatchSyncResponse {
+            req_id,
+            id: SedimentreeId::new([2u8; 32]),
+            result: SyncResult::NotFound,
+            responder_heads: RemoteHeads::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn completion_epoch_starts_at_zero() {
+        let mux = test_mux();
+        assert_eq!(mux.completion_epoch(), 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_pending_advances_completion_epoch() {
+        let mux = test_mux();
+        let req_id = mux.next_request_id();
+        let _rx = mux.register_pending(req_id).await;
+
+        let before = mux.completion_epoch();
+        assert!(mux.resolve_pending(&response_for(req_id)).await);
+        assert_eq!(
+            mux.completion_epoch(),
+            before + 1,
+            "a delivered response must advance the completion epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn unmatched_resolve_does_not_advance_epoch() {
+        let mux = test_mux();
+        let unknown = mux.next_request_id();
+
+        let before = mux.completion_epoch();
+        assert!(!mux.resolve_pending(&response_for(unknown)).await);
+        assert_eq!(
+            mux.completion_epoch(),
+            before,
+            "a response with no pending caller is not progress"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_all_pending_does_not_advance_epoch() {
+        // A torn-down connection is not "making progress" — disconnect
+        // teardown must not look like a completion to waiting callers.
+        let mux = test_mux();
+        let req_id = mux.next_request_id();
+        let _rx = mux.register_pending(req_id).await;
+
+        let before = mux.completion_epoch();
+        mux.cancel_all_pending().await;
+        assert_eq!(
+            mux.completion_epoch(),
+            before,
+            "cancel_all_pending must not advance the completion epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn completion_epoch_is_shared_across_clones() {
+        // The epoch is the cross-caller progress signal; clones (one per
+        // concurrent caller path) must observe the same counter.
+        let mux = test_mux();
+        let clone = mux.clone();
+        let req_id = mux.next_request_id();
+        let _rx = mux.register_pending(req_id).await;
+
+        assert!(mux.resolve_pending(&response_for(req_id)).await);
+        assert_eq!(
+            clone.completion_epoch(),
+            mux.completion_epoch(),
+            "a clone must observe completions resolved on the original"
+        );
+        assert!(clone.completion_epoch() >= 1);
     }
 
     #[tokio::test]

--- a/subduction_core/src/multiplexer.rs
+++ b/subduction_core/src/multiplexer.rs
@@ -236,9 +236,7 @@ impl Multiplexer {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::{
-        connection::message::SyncResult, remote_heads::RemoteHeads,
-    };
+    use crate::{connection::message::SyncResult, remote_heads::RemoteHeads};
     use core::time::Duration;
     use sedimentree_core::id::SedimentreeId;
 

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -201,8 +201,10 @@ pub struct Subduction<
     /// also need `connections` must take `connections` first.
     multiplexers: Arc<Mutex<Map<PeerId, Vec<Arc<Multiplexer>>>>>,
 
-    /// Default timeout for roundtrip calls (`BatchSyncRequest` → `BatchSyncResponse`).
-    default_call_timeout: Duration,
+    /// Default idle timeout for roundtrip calls (`BatchSyncRequest` →
+    /// `BatchSyncResponse`): the maximum gap between completions on a
+    /// connection before a waiting call gives up. See [`Multiplexer`].
+    default_idle_timeout: Duration,
 
     subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
     nonce_tracker: Arc<NonceCache>,
@@ -323,7 +325,7 @@ where
         send_counter: PeerCounter,
         nonce_cache: NonceCache,
         timer: Timer,
-        default_call_timeout: Duration,
+        default_idle_timeout: Duration,
         depth_metric: Metric,
         spawner: Sp,
     ) -> (
@@ -361,7 +363,7 @@ where
             discovery_id,
             signer,
             timer,
-            default_call_timeout,
+            default_idle_timeout,
             depth_metric,
             sedimentrees,
             connections,
@@ -738,7 +740,7 @@ where
                 }
             }
 
-            let mux = Arc::new(Multiplexer::new(peer_id, self.default_call_timeout));
+            let mux = Arc::new(Multiplexer::new(peer_id, self.default_idle_timeout));
             let mut multiplexers = self.multiplexers.lock().await;
             match multiplexers.get_mut(&peer_id) {
                 Some(muxes) => muxes.push(mux),
@@ -1811,7 +1813,7 @@ where
     ///
     /// Awaits the broadcast and returns its per-peer outcome
     /// ([`PerPeerSync`]); a wedged peer can stall this for up to `timeout`
-    /// (`None` = configured `default_call_timeout`). For a durable write
+    /// (`None` = configured `default_idle_timeout`). For a durable write
     /// that does not wait on peers, use
     /// [`store_sedimentree`](Self::store_sedimentree) and drive sync
     /// separately.
@@ -1854,7 +1856,7 @@ where
     /// This **awaits the broadcast** and returns its per-peer outcome
     /// ([`PerPeerSync`]). A byte-connected but protocol-unresponsive peer
     /// can therefore stall this call for up to `timeout` (or the configured
-    /// `default_call_timeout` when `timeout` is `None`). Callers that need
+    /// `default_idle_timeout` when `timeout` is `None`). Callers that need
     /// the durable write to return *without* waiting on peers should call
     /// [`store_built_batch`](Self::store_built_batch) and drive
     /// [`sync_with_all_peers`](Self::sync_with_all_peers) separately (or let
@@ -1919,7 +1921,7 @@ where
     /// This **awaits the broadcast** and returns its per-peer outcome
     /// ([`PerPeerSync`]); a byte-connected but protocol-unresponsive peer can
     /// stall the call for up to `timeout` (or the configured
-    /// `default_call_timeout` when `timeout` is `None`). Callers that want the
+    /// `default_idle_timeout` when `timeout` is `None`). Callers that want the
     /// durable write to return *without* waiting on peers should call
     /// [`store_commits_batch`](Self::store_commits_batch) and drive
     /// [`sync_with_all_peers`](Self::sync_with_all_peers) separately. An empty
@@ -1968,7 +1970,7 @@ where
     /// This **awaits the broadcast** and returns its per-peer outcome
     /// ([`PerPeerSync`]); a byte-connected but protocol-unresponsive peer can
     /// stall the call for up to `timeout` (or the configured
-    /// `default_call_timeout` when `timeout` is `None`). Callers that want the
+    /// `default_idle_timeout` when `timeout` is `None`). Callers that want the
     /// durable write to return *without* waiting on peers should call
     /// [`store_fragments_batch`](Self::store_fragments_batch) and drive
     /// [`sync_with_all_peers`](Self::sync_with_all_peers) separately. An empty

--- a/subduction_core/src/subduction/builder.rs
+++ b/subduction_core/src/subduction/builder.rs
@@ -77,6 +77,7 @@ use crate::{
     },
     handler::{Handler, sync::SyncHandler},
     handshake::audience::DiscoveryId,
+    multiplexer::DEFAULT_IDLE_TIMEOUT,
     nonce_cache::NonceCache,
     peer::{counter::PeerCounter, id::PeerId},
     policy::{connection::ConnectionPolicy, storage::StoragePolicy},
@@ -126,7 +127,7 @@ pub struct SubductionBuilder<
     timer: Timer,
 
     discovery_id: Option<DiscoveryId>,
-    default_call_timeout: Option<Duration>,
+    default_idle_timeout: Option<Duration>,
     depth_metric: Metric,
     nonce_cache: Option<NonceCache>,
     max_pending_blob_requests: usize,
@@ -172,7 +173,7 @@ impl<const SHARDS: usize>
             storage: Unset,
             timer: Unset,
             discovery_id: None,
-            default_call_timeout: None,
+            default_idle_timeout: None,
             depth_metric: CountLeadingZeroBytes,
             nonce_cache: None,
             max_pending_blob_requests: DEFAULT_MAX_PENDING_BLOB_REQUESTS,
@@ -206,7 +207,7 @@ impl<Sp, Store, Timer, Metric, const SHARDS: usize>
             storage: self.storage,
             timer: self.timer,
             discovery_id: self.discovery_id,
-            default_call_timeout: self.default_call_timeout,
+            default_idle_timeout: self.default_idle_timeout,
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
@@ -234,7 +235,7 @@ impl<Sign, Store, Timer, Metric, const SHARDS: usize>
             storage: self.storage,
             timer: self.timer,
             discovery_id: self.discovery_id,
-            default_call_timeout: self.default_call_timeout,
+            default_idle_timeout: self.default_idle_timeout,
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
@@ -262,7 +263,7 @@ impl<Sign, Sp, Timer, Metric, const SHARDS: usize>
             storage: StoragePowerbox::new(storage, policy),
             timer: self.timer,
             discovery_id: self.discovery_id,
-            default_call_timeout: self.default_call_timeout,
+            default_idle_timeout: self.default_idle_timeout,
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
@@ -287,7 +288,7 @@ impl<Sign, Sp, Store, Metric, const SHARDS: usize>
             storage: self.storage,
             timer,
             discovery_id: self.discovery_id,
-            default_call_timeout: self.default_call_timeout,
+            default_idle_timeout: self.default_idle_timeout,
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
@@ -309,15 +310,32 @@ impl<Sign, Sp, Store, Timer, Met, const SHARDS: usize>
         self
     }
 
-    /// Set the default timeout for sync roundtrips
+    /// Set the default **idle timeout** for sync roundtrips
     /// (`BatchSyncRequest` → `BatchSyncResponse`).
+    ///
+    /// This is the maximum tolerable gap between *completions* on a
+    /// connection, not the total lifetime of a single request: each
+    /// response that completes on the connection re-arms the window, so a
+    /// request queued behind a draining batch stays patient and only fails
+    /// once the connection has been silent for this long. See
+    /// [`DEFAULT_IDLE_TIMEOUT`](crate::multiplexer::DEFAULT_IDLE_TIMEOUT).
     ///
     /// Defaults to 30 seconds if not set. Individual calls to
     /// `sync_with_peer` can override this per-request.
     #[must_use]
-    pub const fn roundtrip_timeout(mut self, timeout: Duration) -> Self {
-        self.default_call_timeout = Some(timeout);
+    pub const fn idle_timeout(mut self, timeout: Duration) -> Self {
+        self.default_idle_timeout = Some(timeout);
         self
+    }
+
+    /// Deprecated alias for [`idle_timeout`](Self::idle_timeout).
+    ///
+    /// The timeout was reinterpreted from an absolute per-request deadline
+    /// to a progress-aware idle window; the name changed to match.
+    #[must_use]
+    #[deprecated(since = "0.16.0", note = "renamed to `idle_timeout`")]
+    pub const fn roundtrip_timeout(self, timeout: Duration) -> Self {
+        self.idle_timeout(timeout)
     }
 
     /// Override the depth metric used to assign commit depths.
@@ -333,7 +351,7 @@ impl<Sign, Sp, Store, Timer, Met, const SHARDS: usize>
             storage: self.storage,
             timer: self.timer,
             discovery_id: self.discovery_id,
-            default_call_timeout: self.default_call_timeout,
+            default_idle_timeout: self.default_idle_timeout,
             depth_metric: metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
@@ -506,7 +524,7 @@ impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
             send_counter,
             nonce_cache,
             self.timer,
-            self.default_call_timeout.unwrap_or(Duration::from_secs(30)),
+            self.default_idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT),
             self.depth_metric,
             self.spawner,
         );
@@ -601,7 +619,7 @@ impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
             PeerCounter::default(),
             nonce_cache,
             self.timer,
-            self.default_call_timeout.unwrap_or(Duration::from_secs(30)),
+            self.default_idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT),
             self.depth_metric,
             self.spawner,
         )
@@ -705,7 +723,7 @@ impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
             send_counter,
             nonce_cache,
             self.timer,
-            self.default_call_timeout.unwrap_or(Duration::from_secs(30)),
+            self.default_idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT),
             self.depth_metric,
             self.spawner,
         );

--- a/subduction_core/tests/addbatch_storage_durability.rs
+++ b/subduction_core/tests/addbatch_storage_durability.rs
@@ -61,7 +61,7 @@ type TestSubduction = Arc<
     >,
 >;
 
-/// Wired into the node via [`SubductionBuilder::roundtrip_timeout`] in
+/// Wired into the node via [`SubductionBuilder::idle_timeout`] in
 /// [`make_node`], so it *is* the node's configured per-call timeout (not just
 /// a constant referenced in messages). Long enough that a `store_built_batch`
 /// which (wrongly) waited on the peer would block for the full
@@ -91,7 +91,7 @@ fn make_node(signer: MemorySigner) -> TestSubduction {
         // Make the documented margin real: any (regressed) network roundtrip
         // from store_built_batch would inherit this 60s default and blow past
         // BOUND. The add_* combinator tests override it per-call.
-        .roundtrip_timeout(LONG_PER_CALL_TIMEOUT)
+        .idle_timeout(LONG_PER_CALL_TIMEOUT)
         .build::<Sendable, Conn>();
     tokio::spawn(listener);
     tokio::spawn(manager);

--- a/subduction_core/tests/transport.rs
+++ b/subduction_core/tests/transport.rs
@@ -1,4 +1,5 @@
 //! Tests for the transport layer: [`Multiplexer`] and [`MessageTransport`].
+#![allow(clippy::expect_used)]
 
 use std::{collections::BTreeSet, time::Duration};
 
@@ -297,5 +298,255 @@ mod managed_connection {
             !mux.resolve_pending(&resp).await,
             "pending entry should have been cancelled after timeout"
         );
+    }
+}
+
+// ── Progress-aware ("idle") timeout behavior ────────────────────────────
+
+mod idle_timeout {
+    use std::sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    };
+    use std::time::Duration as StdDuration;
+
+    use futures::future::BoxFuture;
+    use subduction_core::{
+        authenticated::Authenticated,
+        connection::{
+            managed::{CallError, ManagedCall, ManagedConnection},
+            message::BatchSyncRequest,
+            test_utils::ChannelMockConnection,
+        },
+        multiplexer::Multiplexer,
+        timeout::{TimedOut, Timeout},
+    };
+
+    use super::*;
+
+    fn req(id: RequestId) -> BatchSyncRequest {
+        BatchSyncRequest {
+            req_id: id,
+            id: SedimentreeId::new([0xCD; 32]),
+            fingerprint_summary: empty_fingerprint_summary(),
+            subscribe: false,
+        }
+    }
+
+    /// A timeout that fires immediately, but on its first `progress_beats`
+    /// invocations it first records a completion for an unrelated request
+    /// (advancing the connection's completion epoch) — simulating "another
+    /// request completed during our idle window". Once the beats are
+    /// exhausted, subsequent windows see no progress.
+    #[derive(Clone)]
+    struct ProgressingTimeout {
+        mux: Arc<Multiplexer>,
+        remaining: Arc<AtomicU32>,
+    }
+
+    impl Timeout<Sendable> for ProgressingTimeout {
+        fn timeout<'a, T: 'a>(
+            &'a self,
+            _dur: Duration,
+            _fut: BoxFuture<'a, T>,
+        ) -> BoxFuture<'a, Result<T, TimedOut>> {
+            Box::pin(async move {
+                if self
+                    .remaining
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                    .is_ok()
+                {
+                    let other = self.mux.next_request_id();
+                    let rx = self.mux.register_pending(other).await;
+                    self.mux
+                        .resolve_pending(&test_batch_sync_response(other))
+                        .await;
+                    drop(rx);
+                }
+                Err(TimedOut)
+            })
+        }
+    }
+
+    /// A timeout that always fires immediately and never records progress.
+    #[derive(Clone, Copy)]
+    struct AlwaysIdleTimeout;
+
+    impl Timeout<Sendable> for AlwaysIdleTimeout {
+        fn timeout<'a, T: 'a>(
+            &'a self,
+            _dur: Duration,
+            _fut: BoxFuture<'a, T>,
+        ) -> BoxFuture<'a, Result<T, TimedOut>> {
+            Box::pin(async { Err(TimedOut) })
+        }
+    }
+
+    type MockHandle =
+        subduction_core::connection::test_utils::ChannelMockConnectionHandle<SyncMessage>;
+
+    /// Build a managed connection. **Keep the returned handle alive** for
+    /// the duration of the call: dropping it closes the mock's receiver and
+    /// makes `send` fail with `CallError::Send` before the timeout path is
+    /// ever reached.
+    fn managed_with<O: Timeout<Sendable>>(
+        mux: Arc<Multiplexer>,
+        timer: O,
+    ) -> (
+        ManagedConnection<ChannelMockConnection<SyncMessage>, Sendable, O>,
+        MockHandle,
+    ) {
+        let peer_id = mux.peer_id();
+        let (conn, handle) = ChannelMockConnection::<SyncMessage>::new_with_handle(peer_id);
+        let auth = Authenticated::new_for_test(conn, peer_id);
+        (ManagedConnection::new(auth, mux, timer), handle)
+    }
+
+    /// While other requests keep completing on the same connection, a
+    /// waiting call must NOT time out — it re-arms on each progress beat —
+    /// and only fails once progress stops.
+    #[tokio::test]
+    async fn stays_patient_while_connection_makes_progress_then_times_out() {
+        let mux = Arc::new(Multiplexer::new(test_peer_id(), Duration::from_secs(30)));
+        let remaining = Arc::new(AtomicU32::new(3));
+        let timer = ProgressingTimeout {
+            mux: mux.clone(),
+            remaining: remaining.clone(),
+        };
+        let (managed, _handle) = managed_with(mux, timer);
+        let id = managed.next_request_id();
+
+        let result = <ManagedConnection<
+            ChannelMockConnection<SyncMessage>,
+            Sendable,
+            ProgressingTimeout,
+        > as ManagedCall<Sendable, SyncMessage>>::call(&managed, req(id), None)
+        .await;
+
+        assert!(
+            matches!(result, Err(CallError::Timeout)),
+            "expected Timeout once progress stopped, got {result:?}"
+        );
+        assert_eq!(
+            remaining.load(Ordering::SeqCst),
+            0,
+            "the call must have re-armed through every progress beat"
+        );
+    }
+
+    /// With no progress on the connection, the very first idle window
+    /// elapsing yields `Timeout` (no spinning forever).
+    #[tokio::test]
+    async fn times_out_immediately_when_no_progress() {
+        let mux = Arc::new(Multiplexer::new(test_peer_id(), Duration::from_secs(30)));
+        let (managed, _handle) = managed_with(mux, AlwaysIdleTimeout);
+        let id = managed.next_request_id();
+
+        let result = tokio::time::timeout(
+            StdDuration::from_secs(2),
+            <ManagedConnection<
+                ChannelMockConnection<SyncMessage>,
+                Sendable,
+                AlwaysIdleTimeout,
+            > as ManagedCall<Sendable, SyncMessage>>::call(&managed, req(id), None),
+        )
+        .await
+        .expect("call must resolve promptly, not spin");
+
+        assert!(
+            matches!(result, Err(CallError::Timeout)),
+            "expected Timeout with no progress, got {result:?}"
+        );
+    }
+
+    /// End-to-end with a real timer: a short idle window, a slow "batch"
+    /// that keeps completing *other* requests just under the window, and
+    /// our own response arriving last — at a total wait that is several
+    /// times the idle window. The call must succeed (never false-fire),
+    /// which an absolute per-request deadline could not do.
+    ///
+    /// Uses small real durations (idle window 60ms; 5 beats at 40ms) so the
+    /// whole test runs in ~250ms without paused-time support.
+    #[tokio::test]
+    async fn real_timer_survives_long_drain_then_succeeds() {
+        // A tokio-backed idle timer.
+        #[derive(Clone, Copy)]
+        struct TokioIdle;
+        impl Timeout<Sendable> for TokioIdle {
+            fn timeout<'a, T: 'a>(
+                &'a self,
+                dur: Duration,
+                fut: BoxFuture<'a, T>,
+            ) -> BoxFuture<'a, Result<T, TimedOut>> {
+                Box::pin(async move {
+                    match tokio::time::timeout(dur, fut).await {
+                        Ok(v) => Ok(v),
+                        Err(_) => Err(TimedOut),
+                    }
+                })
+            }
+        }
+
+        let idle = Duration::from_millis(60);
+        let mux = Arc::new(Multiplexer::new(test_peer_id(), idle));
+        let (managed, _handle) = managed_with(mux.clone(), TokioIdle);
+        let my_id = managed.next_request_id();
+
+        // Background: emit 5 unrelated completions, each 40ms apart (< 60ms
+        // idle window), then deliver OUR response last at ~240ms — several
+        // idle windows of total wait. An absolute deadline ≤ 240ms would
+        // have killed us; progress keeps re-arming.
+        let bg_mux = mux.clone();
+        let drain = tokio::spawn(async move {
+            for _ in 0..5 {
+                tokio::time::sleep(StdDuration::from_millis(40)).await;
+                let other = bg_mux.next_request_id();
+                let rx = bg_mux.register_pending(other).await;
+                bg_mux
+                    .resolve_pending(&test_batch_sync_response(other))
+                    .await;
+                drop(rx);
+            }
+            tokio::time::sleep(StdDuration::from_millis(20)).await;
+            bg_mux
+                .resolve_pending(&test_batch_sync_response(my_id))
+                .await;
+        });
+
+        let result = <ManagedConnection<
+            ChannelMockConnection<SyncMessage>,
+            Sendable,
+            TokioIdle,
+        > as ManagedCall<Sendable, SyncMessage>>::call(&managed, req(my_id), None)
+        .await;
+
+        drain.await.expect("drain task");
+        assert!(
+            result.is_ok(),
+            "call should have stayed patient through the drain and succeeded, got {result:?}"
+        );
+    }
+
+    /// An explicit per-call idle timeout overrides the connection default.
+    #[tokio::test]
+    async fn explicit_idle_timeout_is_used() {
+        // AlwaysIdleTimeout ignores the duration, but the override path
+        // must still funnel through to a Timeout with no progress.
+        let mux = Arc::new(Multiplexer::new(test_peer_id(), Duration::from_secs(30)));
+        let (managed, _handle) = managed_with(mux, AlwaysIdleTimeout);
+        let id = managed.next_request_id();
+
+        let result = <ManagedConnection<
+            ChannelMockConnection<SyncMessage>,
+            Sendable,
+            AlwaysIdleTimeout,
+        > as ManagedCall<Sendable, SyncMessage>>::call(
+            &managed,
+            req(id),
+            Some(Duration::from_millis(1)),
+        )
+        .await;
+
+        assert!(matches!(result, Err(CallError::Timeout)), "got {result:?}");
     }
 }

--- a/subduction_core/tests/transport.rs
+++ b/subduction_core/tests/transport.rs
@@ -304,11 +304,13 @@ mod managed_connection {
 // ── Progress-aware ("idle") timeout behavior ────────────────────────────
 
 mod idle_timeout {
-    use std::sync::{
-        atomic::{AtomicU32, Ordering},
-        Arc,
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicU32, Ordering},
+        },
+        time::Duration as StdDuration,
     };
-    use std::time::Duration as StdDuration;
 
     use futures::future::BoxFuture;
     use subduction_core::{

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -9,7 +9,7 @@ use alloc::{
 };
 use async_lock::Mutex;
 use core::{fmt::Debug, time::Duration};
-use sedimentree_core::collections::Map;
+use sedimentree_core::collections::{Map, Set};
 
 use from_js_ref::FromJsRef;
 use future_form::Local;
@@ -26,6 +26,7 @@ use sedimentree_core::{
     depth::{Depth, DepthMetric},
     id::SedimentreeId,
     loose_commit::id::CommitId,
+    sedimentree::{Sedimentree, minimized::MinimizedSedimentree},
 };
 use subduction_core::{
     collections::bounded_sharded_map::BoundedShardedMap,
@@ -37,6 +38,7 @@ use subduction_core::{
     storage::powerbox::StoragePowerbox,
     subduction::{
         Subduction,
+        error::HydrationError,
         pending_blob_requests::{DEFAULT_MAX_PENDING_BLOB_REQUESTS, PendingBlobRequests},
         per_peer_sync::PerPeerSync,
     },
@@ -58,7 +60,7 @@ use crate::{
     batch_input::{WasmCommitInput, WasmFragmentInput},
     error::{
         WasmAddConnectionError, WasmConnectError, WasmDisconnectionError, WasmHandshakeError,
-        WasmIoError, WasmLongPollConnectError, WasmWriteError,
+        WasmHydrationError, WasmIoError, WasmLongPollConnectError, WasmWriteError,
     },
     fragment::WasmFragmentRequested,
     peer_id::WasmPeerId,
@@ -274,7 +276,7 @@ impl WasmSubduction {
             send_counter,
             NonceCache::default(),
             JsTimeout,
-            Duration::from_secs(30),
+            subduction_core::multiplexer::DEFAULT_IDLE_TIMEOUT,
             depth_metric,
             WasmSpawn,
         );
@@ -314,6 +316,218 @@ impl WasmSubduction {
             ephemeral_handler: ephemeral_for_wasm,
             keyhive_handler,
         }
+    }
+
+    /// Hydrate a [`Subduction`] instance from external storage.
+    ///
+    /// Loads all sedimentree data from storage and reconstructs the in-memory
+    /// state before initializing the sync engine.
+    ///
+    /// # Arguments
+    ///
+    /// * `signer` - The cryptographic signer for this node's identity
+    /// * `storage` - Storage backend for persisting data
+    /// * `service_name` - Optional service identifier for discovery mode (e.g., `sync.example.com`).
+    ///   When set, clients can connect without knowing the server's peer ID.
+    /// * `hash_metric_override` - Optional custom depth metric function
+    /// * `max_pending_blob_requests` - Optional maximum number of pending blob requests (default: 10,000)
+    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
+    ///   resident in memory (default: 1024). See [`new`](Self::new) for details.
+    /// * `policy` - Optional connection/storage authorization policy.
+    ///   Defaults to allow-all.
+    /// * `ephemeral_policy` - Optional ephemeral message authorization policy.
+    ///   Defaults to allow-all.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `hash_metric_override` is `Some` but the underlying JS value
+    /// cannot be cast to a `Function`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WasmHydrationError`] if hydration fails.
+    #[wasm_bindgen]
+    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+    pub async fn hydrate(
+        signer: JsSigner,
+        storage: JsStorage,
+        service_name: Option<String>,
+        hash_metric_override: Option<JsToDepth>,
+        max_pending_blob_requests: Option<usize>,
+        max_resident_trees: Option<usize>,
+        policy: Option<JsPolicy>,
+        ephemeral_policy: Option<JsEphemeralPolicy>,
+        on_remote_heads: Option<js_sys::Function>,
+        on_ephemeral: Option<js_sys::Function>,
+    ) -> Result<Self, WasmHydrationError> {
+        use subduction_core::storage::traits::Storage as _;
+
+        tracing::debug!("hydrating new Subduction node");
+        let js_storage = <JsStorage as AsRef<JsValue>>::as_ref(&storage).clone();
+        #[allow(clippy::expect_used)]
+        let raw_fn: Option<js_sys::Function> = hash_metric_override.map(|h| {
+            JsValue::from(h)
+                .dyn_into()
+                .expect("hash_metric_override is not a Function")
+        });
+        let discovery_id = service_name.map(|name| DiscoveryId::new(name.as_bytes()));
+        let depth_metric = WasmHashMetric(raw_fn);
+        let max_pending = max_pending_blob_requests.unwrap_or(DEFAULT_MAX_PENDING_BLOB_REQUESTS);
+        // `None` or an explicit `0` falls back to the default cap.
+        let max_resident = match max_resident_trees {
+            Some(n) if n > 0 => n,
+            _ => WASM_DEFAULT_MAX_RESIDENT_TREES,
+        };
+
+        // Load sedimentree IDs from raw storage before wrapping in powerbox
+        let ids: Set<SedimentreeId> = storage
+            .load_all_sedimentree_ids()
+            .await
+            .map_err(HydrationError::LoadAllIdsError)?;
+
+        // Hydrate sedimentrees from storage.
+        //
+        // Each sedimentree is loaded concurrently — commits and fragments
+        // for each ID are independent and can overlap their IndexedDB reads.
+        // Within each sedimentree, commits and fragments are loaded in
+        // parallel via `try_join`.
+        let sedimentrees = Arc::new(BoundedShardedMap::new().with_capacity(max_resident));
+        let loaded: Vec<_> = futures::future::try_join_all(ids.iter().map(|&id| {
+            let storage = &storage;
+            async move {
+                let (commits, fragments) = futures::future::try_join(
+                    async {
+                        storage
+                            .load_loose_commits(id)
+                            .await
+                            .map_err(HydrationError::LoadLooseCommitsError)
+                    },
+                    async {
+                        storage
+                            .load_fragments(id)
+                            .await
+                            .map_err(HydrationError::LoadFragmentsError)
+                    },
+                )
+                .await?;
+
+                let loose_commits: Vec<_> =
+                    commits.into_iter().map(|v| v.payload().clone()).collect();
+                let fragments: Vec<_> =
+                    fragments.into_iter().map(|v| v.payload().clone()).collect();
+
+                Ok::<_, HydrationError<Local, JsStorage>>((
+                    id,
+                    Sedimentree::new(fragments, loose_commits),
+                ))
+            }
+        }))
+        .await?;
+
+        // Merge + minimize sequentially (per-entry access is &mut).
+        for (id, sedimentree) in loaded {
+            sedimentrees
+                .with_entry_or_default(id, |tree: &mut MinimizedSedimentree| {
+                    tree.merge(sedimentree);
+                })
+                .await;
+            sedimentrees
+                .with_entry(&id, |tree| {
+                    tree.ensure_minimized(&depth_metric);
+                })
+                .await;
+        }
+
+        let policy = policy.unwrap_or_else(make_open_policy);
+
+        let connections = Arc::new(Mutex::new(Map::new()));
+        let subscriptions = Arc::new(Mutex::new(Map::new()));
+        let pending_blob_requests = Arc::new(Mutex::new(PendingBlobRequests::new(max_pending)));
+        let powerbox = StoragePowerbox::new(storage, Arc::new(policy));
+
+        let observer = match on_remote_heads {
+            Some(f) => crate::remote_heads::JsRemoteHeadsObserver::with_callback(f),
+            None => crate::remote_heads::JsRemoteHeadsObserver::new(),
+        };
+        let sync_handler = SyncHandler::with_remote_heads_observer(
+            sedimentrees.clone(),
+            connections.clone(),
+            subscriptions.clone(),
+            powerbox.clone(),
+            pending_blob_requests.clone(),
+            depth_metric.clone(),
+            observer.clone(),
+        );
+
+        let eph_policy = ephemeral_policy.unwrap_or_else(make_open_ephemeral_policy);
+        let (ephemeral_handler, ephemeral_rx) = EphemeralHandler::new(
+            connections.clone(),
+            eph_policy,
+            EphemeralConfig::default(),
+            JsClock,
+        );
+        let ephemeral_for_wasm = ephemeral_handler.clone();
+
+        let send_counter = sync_handler.send_counter().clone();
+        let keyhive_handler = Arc::new(Mutex::new(None));
+        let handler = Arc::new(WasmComposedHandler::new(
+            sync_handler,
+            ephemeral_handler,
+            WasmKeyhiveHandler::new(keyhive_handler.clone()),
+        ));
+
+        let (core, listener_fut, manager_fut) = Subduction::new(
+            handler,
+            discovery_id,
+            signer,
+            sedimentrees,
+            connections,
+            subscriptions,
+            powerbox,
+            pending_blob_requests,
+            send_counter,
+            NonceCache::default(),
+            JsTimeout,
+            subduction_core::multiplexer::DEFAULT_IDLE_TIMEOUT,
+            depth_metric,
+            WasmSpawn,
+        );
+
+        wasm_bindgen_futures::spawn_local(async move {
+            let manager = manager_fut.fuse();
+            let listener = listener_fut.fuse();
+
+            match select(manager, listener).await {
+                Either::Left((manager_result, _pin)) => {
+                    if let Err(Aborted) = manager_result {
+                        tracing::error!("Subduction manager aborted");
+                    }
+                }
+                Either::Right((listener_result, _pin)) => {
+                    if let Err(Aborted) = listener_result {
+                        tracing::error!("Subduction listener aborted");
+                    }
+                }
+            }
+        });
+
+        // Always drain the ephemeral channel to prevent "channel full" warnings
+        // in EphemeralHandler when no JS callback is registered.
+        let observer = on_ephemeral.map(crate::ephemeral::JsEphemeralObserver::new);
+        wasm_bindgen_futures::spawn_local(async move {
+            while let Ok(event) = ephemeral_rx.recv().await {
+                if let Some(ref obs) = observer {
+                    obs.on_event(event.id, event.sender, &event.payload);
+                }
+            }
+        });
+
+        Ok(Self {
+            core,
+            js_storage,
+            ephemeral_handler: ephemeral_for_wasm,
+            keyhive_handler,
+        })
     }
 
     /// Persist a whole [`Sedimentree`](sedimentree_wasm::WasmSedimentree)
@@ -356,7 +570,7 @@ impl WasmSubduction {
     ///
     /// Returns the per-peer broadcast outcome as a
     /// [`PeerResultMap`](WasmPeerResultMap). This **awaits the broadcast**, so
-    /// an unresponsive peer can stall the call for up to `timeout_milliseconds`
+    /// an unresponsive peer can stall the call for up to `idle_timeout_milliseconds`
     /// (or the configured default when omitted); callers wanting a
     /// non-blocking durable write should use
     /// [`storeSedimentree`](Self::store_sedimentree) instead.
@@ -374,9 +588,9 @@ impl WasmSubduction {
         id: &WasmSedimentreeId,
         sedimentree: &WasmSedimentree,
         blobs: Vec<Uint8Array>,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> Result<WasmPeerResultMap, WasmWriteError> {
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
         let per_peer = self
             .core
             .add_sedimentree(
@@ -446,7 +660,7 @@ impl WasmSubduction {
     /// # Arguments
     ///
     /// * `address` - The WebSocket URL to connect to
-    /// * `timeout_milliseconds` - Request timeout in milliseconds (defaults to 30000)
+    /// * `idle_timeout_milliseconds` - Idle timeout in milliseconds: max gap between completions before giving up (defaults to 30000)
     /// * `service_name` - The service name for discovery (defaults to URL host)
     ///
     /// # Errors
@@ -484,7 +698,7 @@ impl WasmSubduction {
     ///
     /// * `base_url` - The server's HTTP base URL (e.g., `http://localhost:8080`)
     /// * `expected_peer_id` - The expected server peer ID (verified during handshake)
-    /// * `timeout_milliseconds` - Request timeout in milliseconds (default: 30000)
+    /// * `idle_timeout_milliseconds` - Idle timeout in milliseconds: max gap between completions before giving up (default: 30000)
     ///
     /// # Errors
     ///
@@ -518,7 +732,7 @@ impl WasmSubduction {
     /// # Arguments
     ///
     /// * `base_url` - The server's HTTP base URL (e.g., `http://localhost:8080`)
-    /// * `timeout_milliseconds` - Request timeout in milliseconds (default: 30000)
+    /// * `idle_timeout_milliseconds` - Idle timeout in milliseconds: max gap between completions before giving up (default: 30000)
     /// * `service_name` - The service name for discovery (defaults to `base_url`)
     ///
     /// # Errors
@@ -781,9 +995,9 @@ impl WasmSubduction {
     pub async fn fetch_blobs(
         &self,
         id: &WasmSedimentreeId,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> Result<Option<Vec<Uint8Array>>, WasmIoError> {
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
         if let Some(blobs) = self
             .core
             .fetch_blobs(id.clone().into(), timeout)
@@ -1027,7 +1241,7 @@ impl WasmSubduction {
     ///
     /// Returns the per-peer broadcast outcome as a
     /// [`PeerResultMap`](WasmPeerResultMap). This **awaits the broadcast**, so
-    /// an unresponsive peer can stall the call for up to `timeout_milliseconds`
+    /// an unresponsive peer can stall the call for up to `idle_timeout_milliseconds`
     /// (or the configured default when omitted); callers wanting a
     /// non-blocking durable write should use
     /// [`storeBuiltBatch`](Self::store_built_batch) instead.
@@ -1050,7 +1264,7 @@ impl WasmSubduction {
         id: &WasmSedimentreeId,
         commits: Vec<WasmCommitInput>,
         fragments: Vec<WasmFragmentInput>,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> Result<WasmPeerResultMap, WasmWriteError> {
         let core_id: SedimentreeId = id.clone().into();
         let core_commits = commits
@@ -1061,7 +1275,7 @@ impl WasmSubduction {
             .into_iter()
             .map(WasmFragmentInput::into_core)
             .collect();
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
 
         let per_peer = self
             .core
@@ -1110,7 +1324,7 @@ impl WasmSubduction {
     /// Like [`addBatch`](Self::add_batch) for the commits half only. Returns
     /// the per-peer broadcast outcome as a
     /// [`PeerResultMap`](WasmPeerResultMap) and **awaits the broadcast** (an
-    /// unresponsive peer can stall the call for up to `timeout_milliseconds`).
+    /// unresponsive peer can stall the call for up to `idle_timeout_milliseconds`).
     /// An empty list is a no-op and yields an empty map.
     ///
     /// # Errors
@@ -1124,14 +1338,14 @@ impl WasmSubduction {
         &self,
         id: &WasmSedimentreeId,
         commits: Vec<WasmCommitInput>,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> Result<WasmPeerResultMap, WasmWriteError> {
         let core_id: SedimentreeId = id.clone().into();
         let core_commits = commits
             .into_iter()
             .map(WasmCommitInput::into_core)
             .collect();
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
 
         let per_peer = self
             .core
@@ -1180,7 +1394,7 @@ impl WasmSubduction {
     /// Like [`addBatch`](Self::add_batch) for the fragments half only. Returns
     /// the per-peer broadcast outcome as a
     /// [`PeerResultMap`](WasmPeerResultMap) and **awaits the broadcast** (an
-    /// unresponsive peer can stall the call for up to `timeout_milliseconds`).
+    /// unresponsive peer can stall the call for up to `idle_timeout_milliseconds`).
     /// An empty list is a no-op and yields an empty map.
     ///
     /// # Errors
@@ -1194,14 +1408,14 @@ impl WasmSubduction {
         &self,
         id: &WasmSedimentreeId,
         fragments: Vec<WasmFragmentInput>,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> Result<WasmPeerResultMap, WasmWriteError> {
         let core_id: SedimentreeId = id.clone().into();
         let core_fragments = fragments
             .into_iter()
             .map(WasmFragmentInput::into_core)
             .collect();
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
 
         let per_peer = self
             .core
@@ -1240,7 +1454,7 @@ impl WasmSubduction {
     /// * `to_ask` - The peer ID to sync with
     /// * `id` - The sedimentree ID to sync
     /// * `subscribe` - Whether to subscribe for incremental updates
-    /// * `timeout_milliseconds` - Optional timeout in milliseconds
+    /// * `idle_timeout_milliseconds` - Optional idle timeout in milliseconds (max gap between completions)
     ///
     /// # Errors
     ///
@@ -1251,9 +1465,9 @@ impl WasmSubduction {
         to_ask: &WasmPeerId,
         id: &WasmSedimentreeId,
         subscribe: bool,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> Result<PeerBatchSyncResult, WasmIoError> {
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
         let (success, stats, transport_errors) = self
             .core
             .sync_with_peer(
@@ -1281,7 +1495,7 @@ impl WasmSubduction {
     ///
     /// * `id` - The sedimentree ID to sync
     /// * `subscribe` - Whether to subscribe for incremental updates
-    /// * `timeout_milliseconds` - Optional timeout in milliseconds
+    /// * `idle_timeout_milliseconds` - Optional idle timeout in milliseconds (max gap between completions)
     ///
     /// # Errors
     ///
@@ -1291,10 +1505,10 @@ impl WasmSubduction {
         &self,
         id: &WasmSedimentreeId,
         subscribe: bool,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> Result<WasmPeerResultMap, WasmIoError> {
         tracing::debug!("WasmSubduction::sync_with_all_peers");
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
         let peer_map = self
             .core
             .sync_with_all_peers(id.clone().into(), subscribe, timeout)
@@ -1309,16 +1523,16 @@ impl WasmSubduction {
     ///
     /// * `peer_id` - The peer to sync with
     /// * `subscribe` - Whether to subscribe to future updates (default: `true`)
-    /// * `timeout_milliseconds` - Per-call timeout in milliseconds
+    /// * `idle_timeout_milliseconds` - Per-call idle timeout in milliseconds
     #[wasm_bindgen(js_name = fullSyncWithPeer)]
     pub async fn full_sync_with_peer(
         &self,
         peer_id: &WasmPeerId,
         subscribe: Option<bool>,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> PeerBatchSyncResult {
         let subscribe = subscribe.unwrap_or(true);
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
         let (success, stats, conn_errs, io_errs) = self
             .core
             .full_sync_with_peer(&peer_id.clone().into(), subscribe, timeout)
@@ -1346,9 +1560,9 @@ impl WasmSubduction {
     #[wasm_bindgen(js_name = fullSyncWithAllPeers)]
     pub async fn full_sync_with_all_peers(
         &self,
-        timeout_milliseconds: Option<u64>,
+        idle_timeout_milliseconds: Option<u64>,
     ) -> PeerBatchSyncResult {
-        let timeout = timeout_milliseconds.map(Duration::from_millis);
+        let timeout = idle_timeout_milliseconds.map(Duration::from_millis);
         let (success, stats, conn_errs, io_errs) =
             self.core.full_sync_with_all_peers(timeout).await;
 

--- a/subduction_websocket/tests/ephemeral_e2e.rs
+++ b/subduction_websocket/tests/ephemeral_e2e.rs
@@ -66,7 +66,7 @@ async fn ephemeral_message_survives_websocket_transport() -> TestResult {
         .storage(MemoryStorage::default(), Arc::new(OpenPolicy))
         .spawner(TrackedTokioSpawn::new(TaskTracker::new()))
         .timer(TimeoutTokio)
-        .roundtrip_timeout(Duration::from_secs(5))
+        .idle_timeout(Duration::from_secs(5))
         .build::<Sendable, ServerConn>();
 
     tokio::spawn(async move {
@@ -149,7 +149,7 @@ async fn ephemeral_and_sync_coexist_on_same_websocket() -> TestResult {
         .storage(MemoryStorage::default(), Arc::new(OpenPolicy))
         .spawner(TrackedTokioSpawn::new(TaskTracker::new()))
         .timer(TimeoutTokio)
-        .roundtrip_timeout(Duration::from_secs(5))
+        .idle_timeout(Duration::from_secs(5))
         .build::<Sendable, ServerConn>();
 
     tokio::spawn(async move {


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [ ] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [ ] `cargo build --workspace --all-features` succeeds
- [ ] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo +nightly fmt --all -- --check` is clean
- [ ] Public API changes have doc comments
- [ ] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [ ] Required version updates for this release-blocking change have been applied
