### PR TITLE
Bound metadata memory growth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "automerge_subduction_ingest"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "automerge",
  "bs58",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "automerge_subduction_wasm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "automerge",
  "base58",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "sedimentree_core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "arbitrary",
  "async-lock",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "sedimentree_fs_storage"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "async-lock",
  "future_form",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "sedimentree_wasm"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-lock",
  "base58",
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash",
  "async-channel",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_core"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "arbitrary",
  "async-channel",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_crypto"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arbitrary",
  "bolero",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_ephemeral"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "arbitrary",
  "async-channel",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_http_longpoll"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_iroh"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_keyhive"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_wasm"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "subduction_websocket"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arbitrary",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,19 +30,19 @@ authors = [
 
 [workspace.dependencies]
 # Internal crates
-automerge_subduction_wasm = { version = "0.13.0", path = "automerge_subduction_wasm", default-features = false }
-sedimentree_core = { version = "0.12.1", path = "sedimentree_core", default-features = false }
-sedimentree_fs_storage = { version = "0.10.1", path = "sedimentree_fs_storage" }
-sedimentree_wasm = { version = "0.13.1", path = "sedimentree_wasm" }
-subduction_core = { version = "0.15.1", path = "subduction_core", default-features = false }
-subduction_crypto = { version = "0.7.1", path = "subduction_crypto", default-features = false }
-subduction_ephemeral = { version = "0.6.2", path = "subduction_ephemeral", default-features = false }
-subduction_http_longpoll = { version = "0.9.1", path = "subduction_http_longpoll", default-features = false }
-subduction_iroh = { version = "0.8.1", path = "subduction_iroh" }
-subduction_keyhive = { version = "0.6.0", path = "subduction_keyhive" }
-subduction_wasm = { version = "0.17.0", path = "subduction_wasm" }
+automerge_subduction_wasm = { version = "0.14.0", path = "automerge_subduction_wasm", default-features = false }
+sedimentree_core = { version = "0.13.0", path = "sedimentree_core", default-features = false }
+sedimentree_fs_storage = { version = "0.11.0", path = "sedimentree_fs_storage" }
+sedimentree_wasm = { version = "0.14.0", path = "sedimentree_wasm" }
+subduction_core = { version = "0.16.0", path = "subduction_core", default-features = false }
+subduction_crypto = { version = "0.8.0", path = "subduction_crypto", default-features = false }
+subduction_ephemeral = { version = "0.7.0", path = "subduction_ephemeral", default-features = false }
+subduction_http_longpoll = { version = "0.10.0", path = "subduction_http_longpoll", default-features = false }
+subduction_iroh = { version = "0.9.0", path = "subduction_iroh" }
+subduction_keyhive = { version = "0.7.0", path = "subduction_keyhive" }
+subduction_wasm = { version = "0.18.0", path = "subduction_wasm" }
 subduction_wasm_bootstrap = { version = "0.1.0", path = "subduction_wasm_bootstrap" }
-subduction_websocket = { version = "0.10.1", path = "subduction_websocket", default-features = false }
+subduction_websocket = { version = "0.11.0", path = "subduction_websocket", default-features = false }
 
 # External crates
 ahash = "0.8"

--- a/automerge_subduction_ingest/Cargo.toml
+++ b/automerge_subduction_ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge_subduction_ingest"
-version = "0.4.1"
+version = "0.5.0"
 description = "CLI tool for ingesting Automerge documents into Subduction"
 
 categories = ["command-line-utilities"]

--- a/automerge_subduction_wasm/Cargo.toml
+++ b/automerge_subduction_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge_subduction_wasm"
-version = "0.13.0"
+version = "0.14.0"
 description = "Wasm bindings for syncing Automerge documents via Subduction"
 categories = ["web-programming"]
 keywords = ["automerge", "sedimentree", "wasm"]

--- a/automerge_subduction_wasm/package.json
+++ b/automerge_subduction_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/automerge-subduction",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Wasm bindings for syncing Automerge documents via Subduction",
   "publishConfig": {
     "access": "public"

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -142,6 +142,29 @@ in {
         description = "Interval in seconds for refreshing storage metrics from disk.";
       };
 
+      maxResidentTrees = lib.mkOption {
+        type = lib.types.nullOr lib.types.ints.unsigned;
+        default = null;
+        description = ''
+          Maximum number of sedimentrees kept resident in memory.
+
+          The in-memory sedimentree map is an LRU cache over disk storage:
+          when the resident set exceeds this many trees, the
+          least-recently-used ones are evicted and re-hydrated from disk on
+          next access. This bounds memory by the active working set rather
+          than the total number of documents ever synced.
+
+          When null (the default), the in-memory map is unbounded. Set this
+          on servers that sync large numbers of documents to cap memory and
+          avoid out-of-memory restarts.
+
+          Approximate, not a strict cap: the limit is enforced per shard, so
+          the effective ceiling is rounded up to a multiple of the shard
+          count (and is at least the shard count, 256). Values below 256
+          still permit up to ~256 resident trees.
+        '';
+      };
+
       keyhive = lib.mkOption {
         type = lib.types.bool;
         default = true;
@@ -281,6 +304,10 @@ in {
                   (toString cfg.server.metricsPort)
                   "--metrics-refresh-interval"
                   (toString cfg.server.metricsRefreshInterval)
+                ]
+                ++ lib.optionals (cfg.server.maxResidentTrees != null) [
+                  "--max-resident-trees"
+                  (toString cfg.server.maxResidentTrees)
                 ]
                 ++ lib.optionals (cfg.server.keySeed != null) ["--key-seed" cfg.server.keySeed]
                 ++ lib.optionals (cfg.server.keyFile != null) ["--key-file" (toString cfg.server.keyFile)]

--- a/sedimentree_core/Cargo.toml
+++ b/sedimentree_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sedimentree_core"
-version = "0.12.1"
+version = "0.13.0"
 description = "Sedimentree: a hash-linked CRDT storage structure with fragments, commits, and content-addressed blobs"
 
 authors.workspace = true

--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -368,6 +368,16 @@ impl Sedimentree {
         self.commits.contains_key(&id)
     }
 
+    /// Returns true if this [`Sedimentree`] has a fragment whose head is `id`.
+    ///
+    /// Fragments are keyed by head, so this is an exact-identity membership
+    /// check (cf. [`has_fragment_starting_with`](Self::has_fragment_starting_with),
+    /// which tests boundary coverage).
+    #[must_use]
+    pub fn has_fragment(&self, id: CommitId) -> bool {
+        self.fragments.contains_key(&id)
+    }
+
     /// Returns true if this [`Sedimentree`] has a fragment starting with the given digest.
     #[must_use]
     pub fn has_fragment_starting_with<M: DepthMetric>(

--- a/sedimentree_fs_storage/Cargo.toml
+++ b/sedimentree_fs_storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sedimentree_fs_storage"
-version = "0.10.1"
+version = "0.11.0"
 description = "Filesystem-based storage backend for Sedimentree"
 
 categories = ["filesystem"]

--- a/sedimentree_fs_storage/src/lib.rs
+++ b/sedimentree_fs_storage/src/lib.rs
@@ -313,6 +313,17 @@ impl Storage<Sendable> for FsStorage {
         })
     }
 
+    fn contains_sedimentree_id(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> <Sendable as FutureForm>::Future<'_, Result<bool, Self::Error>> {
+        Sendable::from_future(async move {
+            tracing::debug!(?sedimentree_id, "FsStorage::contains_sedimentree_id");
+            // Single-key check against the in-memory id cache (no directory scan).
+            Ok(self.ids_cache.lock().await.contains(&sedimentree_id))
+        })
+    }
+
     // ==================== Commits (compound with blob) ====================
 
     fn save_loose_commit(
@@ -799,6 +810,16 @@ impl Storage<Local> for FsStorage {
         &self,
     ) -> <Local as FutureForm>::Future<'_, Result<Set<SedimentreeId>, Self::Error>> {
         Local::from_future(<Self as Storage<Sendable>>::load_all_sedimentree_ids(self))
+    }
+
+    fn contains_sedimentree_id(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> <Local as FutureForm>::Future<'_, Result<bool, Self::Error>> {
+        Local::from_future(<Self as Storage<Sendable>>::contains_sedimentree_id(
+            self,
+            sedimentree_id,
+        ))
     }
 
     fn save_loose_commit(

--- a/sedimentree_wasm/Cargo.toml
+++ b/sedimentree_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sedimentree_wasm"
-version = "0.13.1"
+version = "0.14.0"
 description = "Wasm/JavaScript bindings for Sedimentree (browser and Node.js)"
 categories = ["web-programming"]
 keywords = ["sedimentree", "wasm"]

--- a/sedimentree_wasm/package.json
+++ b/sedimentree_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/sedimentree",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Wasm/JavaScript bindings for Sedimentree",
   "publishConfig": {
     "access": "public"

--- a/sedimentree_wasm/src/storage.rs
+++ b/sedimentree_wasm/src/storage.rs
@@ -236,16 +236,14 @@ impl Storage<Local> for JsStorage {
             // Prefer the optional single-key `containsSedimentreeId` when the
             // backend implements it (O(1) on IndexedDB). When absent, fall
             // back to enumerating all ids — correct, just O(total trees).
-            let has_method = js_sys::Reflect::get(
-                self.as_ref(),
-                &JsValue::from_str("containsSedimentreeId"),
-            )
-            .map(|m| m.is_function())
-            .unwrap_or(false);
+            let has_method =
+                js_sys::Reflect::get(self.as_ref(), &JsValue::from_str("containsSedimentreeId"))
+                    .map(|m| m.is_function())
+                    .unwrap_or(false);
 
             if has_method {
-                let js_promise =
-                    self.js_contains_sedimentree_id(&WasmSedimentreeId::from(sedimentree_id).into());
+                let js_promise = self
+                    .js_contains_sedimentree_id(&WasmSedimentreeId::from(sedimentree_id).into());
                 let js_value = JsFuture::from(js_promise)
                     .await
                     .map_err(JsStorageError::JsError)?;

--- a/sedimentree_wasm/src/storage.rs
+++ b/sedimentree_wasm/src/storage.rs
@@ -41,6 +41,11 @@ export interface SedimentreeStorage {
     saveSedimentreeId(sedimentreeId: SedimentreeId): Promise<void>;
     deleteSedimentreeId(sedimentreeId: SedimentreeId): Promise<void>;
     loadAllSedimentreeIds(): Promise<SedimentreeId[]>;
+    // Optional single-key existence check. When implemented, it is used on the
+    // hydration hot path instead of enumerating every id via
+    // loadAllSedimentreeIds (which is O(total) — e.g. an IndexedDB getAllKeys).
+    // Backends over IndexedDB should implement this as a single `get`/`count`.
+    containsSedimentreeId?(sedimentreeId: SedimentreeId): Promise<boolean>;
 
     // Compound storage for commits (signed data + blob stored together)
     saveCommit(sedimentreeId: SedimentreeId, commitId: CommitId, signedCommit: SignedLooseCommit, blob: Uint8Array): Promise<void>;
@@ -79,6 +84,9 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = loadAllSedimentreeIds)]
     fn js_load_all_sedimentree_ids(this: &JsStorage) -> Promise;
+
+    #[wasm_bindgen(method, js_name = containsSedimentreeId)]
+    fn js_contains_sedimentree_id(this: &JsStorage, sedimentree_id: &JsSedimentreeId) -> Promise;
 
     // ==================== Commits (compound with blob) ====================
 
@@ -215,6 +223,37 @@ impl Storage<Local> for JsStorage {
                 ids.insert(wasm_id.into());
             }
             Ok(ids)
+        })
+    }
+
+    fn contains_sedimentree_id(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> LocalBoxFuture<'_, Result<bool, Self::Error>> {
+        Local::from_future(async move {
+            tracing::debug!(?sedimentree_id, "JsStorage::contains_sedimentree_id");
+
+            // Prefer the optional single-key `containsSedimentreeId` when the
+            // backend implements it (O(1) on IndexedDB). When absent, fall
+            // back to enumerating all ids — correct, just O(total trees).
+            let has_method = js_sys::Reflect::get(
+                self.as_ref(),
+                &JsValue::from_str("containsSedimentreeId"),
+            )
+            .map(|m| m.is_function())
+            .unwrap_or(false);
+
+            if has_method {
+                let js_promise =
+                    self.js_contains_sedimentree_id(&WasmSedimentreeId::from(sedimentree_id).into());
+                let js_value = JsFuture::from(js_promise)
+                    .await
+                    .map_err(JsStorageError::JsError)?;
+                return Ok(js_value.is_truthy());
+            }
+
+            let all = self.load_all_sedimentree_ids().await?;
+            Ok(all.contains(&sedimentree_id))
         })
     }
 

--- a/sedimentree_wasm/src/storage/memory.rs
+++ b/sedimentree_wasm/src/storage/memory.rs
@@ -86,6 +86,22 @@ impl MemoryStorage {
         })
     }
 
+    /// Single-key existence check for a sedimentree id (O(1)).
+    ///
+    /// Implements the optional `containsSedimentreeId` storage method so the
+    /// hydration hot path avoids enumerating every id.
+    #[wasm_bindgen(js_name = containsSedimentreeId)]
+    pub fn contains_sedimentree_id(&self, sedimentree_id: &WasmSedimentreeId) -> Promise {
+        let inner = self.inner.clone();
+        let id: SedimentreeId = sedimentree_id.clone().into();
+        future_to_promise(async move {
+            let present = Storage::<Local>::contains_sedimentree_id(&inner, id)
+                .await
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            Ok(JsValue::from_bool(present))
+        })
+    }
+
     // ==================== Commits (compound with blob) ====================
 
     /// Save a commit with its blob.

--- a/subduction_cli/Cargo.toml
+++ b/subduction_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_cli"
-version = "0.15.0"
+version = "0.16.0"
 description = "CLI server for Subduction sync over WebSocket, HTTP long-poll, and Iroh (QUIC)"
 
 categories = ["command-line-utilities", "web-programming"]

--- a/subduction_cli/src/server.rs
+++ b/subduction_cli/src/server.rs
@@ -127,6 +127,21 @@ pub(crate) struct ServerArgs {
     #[arg(long, default_value_t = DEFAULT_METRICS_REFRESH_SECS)]
     pub(crate) metrics_refresh_interval: u64,
 
+    /// Approximate maximum number of sedimentrees kept resident in memory.
+    ///
+    /// The in-memory sedimentree map is an LRU cache over disk storage:
+    /// when the resident set exceeds this many trees, the least-recently-
+    /// used ones are evicted and re-hydrated from disk on next access. This
+    /// bounds memory by the active working set rather than the total number
+    /// of documents ever synced. When unset, the map is unbounded.
+    ///
+    /// This is approximate, not a strict cap: the limit is enforced per
+    /// shard, so the effective ceiling is rounded up to a multiple of the
+    /// shard count and is at least the shard count itself (256). Setting a
+    /// value below 256 still permits up to ~256 resident trees.
+    #[arg(long, value_name = "MAX_RESIDENT_TREES")]
+    pub(crate) max_resident_trees: Option<usize>,
+
     /// Enable the WebSocket transport
     #[arg(long, default_value_t = true)]
     pub(crate) websocket: bool,
@@ -306,6 +321,13 @@ pub(crate) async fn run(args: ServerArgs, token: CancellationToken) -> Result<()
         .storage(storage, storage_policy)
         .spawner(TokioSpawn)
         .timer(FuturesTimerTimeout);
+
+    let builder = if let Some(max) = args.max_resident_trees {
+        tracing::info!("bounding in-memory sedimentree cache to {max} resident trees");
+        builder.max_resident_trees(max)
+    } else {
+        builder
+    };
 
     let builder = if let Some(id) = discovery_id {
         builder.discovery_id(id)

--- a/subduction_core/Cargo.toml
+++ b/subduction_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_core"
-version = "0.15.1"
+version = "0.16.0"
 description = "Subduction: sync protocol for replicating Sedimentrees between peers"
 
 categories = ["web-programming"]

--- a/subduction_core/src/collections.rs
+++ b/subduction_core/src/collections.rs
@@ -1,0 +1,9 @@
+//! Concurrent collection types.
+//!
+//! - [`ShardedMap`](sharded_map::ShardedMap): a lock-sharded concurrent map.
+//! - [`BoundedShardedMap`](bounded_sharded_map::BoundedShardedMap): a
+//!   capacity-bounded LRU cache built on top of a
+//!   [`ShardedMap`](sharded_map::ShardedMap).
+
+pub mod bounded_sharded_map;
+pub mod sharded_map;

--- a/subduction_core/src/collections/bounded_sharded_map.rs
+++ b/subduction_core/src/collections/bounded_sharded_map.rs
@@ -60,8 +60,12 @@ pub struct BoundedShardedMap<K: Hash + Ord, V, const N: usize = 256> {
     /// Monotonic logical clock; `fetch_add(1)` stamps each access.
     tick: AtomicU64,
 
-    /// Per-shard resident capacity. `None` ⇒ unbounded (no eviction and no
-    /// recency bookkeeping — identical cost to a plain `ShardedMap`).
+    /// Per-shard resident capacity. `None` ⇒ unbounded: no eviction and no
+    /// recency *updates* (no atomic tick increment, no LRU touch on access).
+    /// Each entry still carries a `Tick` (one `u64`) because the value type
+    /// is `(V, Tick)` regardless, so there is a small fixed per-entry memory
+    /// overhead versus a bare `ShardedMap` — but no per-access bookkeeping
+    /// cost on the unbounded path.
     per_shard_capacity: Option<usize>,
 }
 

--- a/subduction_core/src/collections/bounded_sharded_map.rs
+++ b/subduction_core/src/collections/bounded_sharded_map.rs
@@ -1,0 +1,759 @@
+//! A capacity-bounded LRU cache built on top of [`ShardedMap`].
+//!
+//! [`BoundedShardedMap`] is a thin layer *around* a plain [`ShardedMap`]
+//! that adds a per-shard size bound with least-recently-used eviction. The
+//! map itself stays a pure generic concurrent map; all recency and
+//! eviction bookkeeping lives here, keeping the two concerns separate.
+//!
+//! # Design
+//!
+//! Recency is **fused into the map value**: the wrapped map stores
+//! `(V, Tick)` rather than `V`, so a value and its last-access tick live in
+//! the same slot under the same shard [`Mutex`]. Because every access
+//! already takes the shard lock, the value and its tick are always updated
+//! together — there is no separate recency structure that could drift out
+//! of sync with the data.
+//!
+//! The public API is expressed in terms of plain `V`; the tick is an
+//! internal detail callers never see.
+//!
+//! # Eviction
+//!
+//! The cap is distributed evenly across shards (`ceil(max / N)` each).
+//! Inserting a *new* key into a full shard first evicts that shard's
+//! least-recently-used entry (smallest tick), under the shard lock, so the
+//! evict-and-insert is atomic. Per-shard caps avoid a global lock and stay
+//! balanced because keys are SipHash-distributed across shards.
+//!
+//! Eviction only ever removes from this in-memory map; callers must be able
+//! to reconstruct an evicted entry from a durable source (this is a cache).
+//!
+//! [`ShardedMap`]: crate::collections::sharded_map::ShardedMap
+//! [`Mutex`]: async_lock::Mutex
+
+use alloc::vec::Vec;
+use core::{
+    hash::Hash,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use sedimentree_core::collections::Map;
+
+use crate::collections::sharded_map::ShardedMap;
+
+/// A monotonic per-access stamp. Larger == more recently used.
+///
+/// Sourced from a process-wide counter (not a wall clock), so it is
+/// runtime-agnostic (`no_std` / Wasm safe). Only relative ordering matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Tick(u64);
+
+/// A capacity-bounded LRU cache over a
+/// [`ShardedMap`](super::sharded_map::ShardedMap).
+///
+/// See the module docs for the design. The wrapped map stores `(V, Tick)`;
+/// this type's API is in terms of `V`.
+#[derive(Debug)]
+pub struct BoundedShardedMap<K: Hash + Ord, V, const N: usize = 256> {
+    inner: ShardedMap<K, (V, Tick), N>,
+
+    /// Monotonic logical clock; `fetch_add(1)` stamps each access.
+    tick: AtomicU64,
+
+    /// Per-shard resident capacity. `None` ⇒ unbounded (no eviction and no
+    /// recency bookkeeping — identical cost to a plain `ShardedMap`).
+    per_shard_capacity: Option<usize>,
+}
+
+impl<K: Hash + Ord, V, const N: usize> BoundedShardedMap<K, V, N> {
+    /// Create a new, unbounded map with a randomly generated shard key.
+    ///
+    /// Unbounded means no eviction; use [`with_capacity`](Self::with_capacity)
+    /// to bound the resident set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the system random number generator fails.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: ShardedMap::new(),
+            tick: AtomicU64::new(0),
+            per_shard_capacity: None,
+        }
+    }
+
+    /// Create a new, unbounded map with explicit `SipHash` keys
+    /// (deterministic; for testing).
+    #[must_use]
+    pub fn with_key(key0: u64, key1: u64) -> Self {
+        Self {
+            inner: ShardedMap::with_key(key0, key1),
+            tick: AtomicU64::new(0),
+            per_shard_capacity: None,
+        }
+    }
+
+    /// Bound the resident entries with an **approximate** capacity.
+    ///
+    /// The cap is enforced **per shard**, not globally: each shard holds at
+    /// most `ceil(max_entries / N)` (floored at 1). Inserting a new key into
+    /// a full shard first evicts that shard's least-recently-used entry.
+    ///
+    /// Consequently the effective global ceiling is
+    /// `ceil(max_entries / N) * N`, which can exceed `max_entries` and is
+    /// **at least `N`**. A `max_entries` smaller than the shard count `N`
+    /// still permits up to one entry per shard. Per-shard caps avoid a
+    /// global lock and stay balanced because keys are SipHash-distributed,
+    /// at the cost of this slack; treat `max_entries` as an order-of-
+    /// magnitude target rather than an exact limit.
+    ///
+    /// Eviction only removes from this in-memory map; an evicted entry must
+    /// be reconstructable from a durable source (this is a cache).
+    #[must_use]
+    pub fn with_capacity(mut self, max_entries: usize) -> Self {
+        let per_shard = max_entries.div_ceil(N).max(1);
+        self.per_shard_capacity = Some(per_shard);
+        self
+    }
+
+    /// The per-shard resident capacity, if bounded.
+    #[must_use]
+    pub const fn per_shard_capacity(&self) -> Option<usize> {
+        self.per_shard_capacity
+    }
+
+    /// Next monotonic access tick.
+    ///
+    /// When unbounded (`per_shard_capacity == None`) recency is never
+    /// consulted, so this skips the atomic increment entirely and returns a
+    /// constant — keeping the uncapped (default) path free of recency
+    /// bookkeeping.
+    #[inline]
+    fn next_tick(&self) -> Tick {
+        if self.per_shard_capacity.is_none() {
+            return Tick(0);
+        }
+        Tick(self.tick.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Evict the least-recently-used entry from `shard` if it is at or over
+    /// the per-shard capacity and `incoming` is a *new* key (so updating an
+    /// existing key never triggers eviction).
+    ///
+    /// Must be called while holding `shard`'s lock so the evict-and-insert
+    /// is atomic. No-op when unbounded.
+    fn evict_if_full_locked(&self, shard: &mut Map<K, (V, Tick)>, incoming: &K)
+    where
+        K: Clone,
+    {
+        let Some(cap) = self.per_shard_capacity else {
+            return;
+        };
+        if shard.len() < cap || shard.contains_key(incoming) {
+            return;
+        }
+
+        // Smallest tick == least recently used.
+        let victim = shard
+            .iter()
+            .min_by_key(|(_, (_, tick))| *tick)
+            .map(|(k, _)| k.clone());
+
+        if let Some(victim) = victim {
+            shard.remove(&victim);
+        }
+    }
+
+    /// Get a clone of the value for `key`, recording an access (LRU touch)
+    /// on a hit so frequently-read keys stay resident.
+    pub async fn get_cloned(&self, key: &K) -> Option<V>
+    where
+        V: Clone,
+    {
+        let tick = self.next_tick();
+        let mut shard = self.inner.get_shard_containing(key).lock().await;
+        let entry = shard.get_mut(key)?;
+        if self.per_shard_capacity.is_some() {
+            entry.1 = tick;
+        }
+        Some(entry.0.clone())
+    }
+
+    /// Apply `f` to the value for `key` if present, recording an access on a
+    /// hit. Returns `None` if the key is absent.
+    pub async fn with_entry<F: FnOnce(&mut V) -> R, R>(&self, key: &K, f: F) -> Option<R> {
+        let tick = self.next_tick();
+        let mut shard = self.inner.get_shard_containing(key).lock().await;
+        let entry = shard.get_mut(key)?;
+        if self.per_shard_capacity.is_some() {
+            entry.1 = tick;
+        }
+        Some(f(&mut entry.0))
+    }
+
+    /// Get-or-insert-default for `key`, then apply `f` to the value.
+    ///
+    /// Enforces the per-shard capacity for a newly-inserted key (evicting
+    /// the LRU entry first) and records an access.
+    pub async fn with_entry_or_default<F: FnOnce(&mut V) -> R, R>(&self, key: K, f: F) -> R
+    where
+        V: Default,
+        K: Clone,
+    {
+        let tick = self.next_tick();
+        let mut shard = self.inner.get_shard_containing(&key).lock().await;
+        self.evict_if_full_locked(&mut shard, &key);
+        let entry = shard.entry(key).or_insert_with(|| (V::default(), tick));
+        if self.per_shard_capacity.is_some() {
+            entry.1 = tick;
+        }
+        f(&mut entry.0)
+    }
+
+    /// Return a clone of the value for `key`, inserting `make()`'s result
+    /// first if the key is absent.
+    ///
+    /// `make` is invoked **while the shard lock is held**, so it must be
+    /// cheap and non-blocking — callers should compute any expensive value
+    /// (e.g. an async load from durable storage) *before* this call and pass
+    /// a closure that merely returns it. If a concurrent caller already
+    /// inserted a value, that one wins and `make()`'s result is dropped
+    /// (idempotent for a cache over a single durable source). Enforces the
+    /// per-shard capacity for a new key and records an access.
+    ///
+    /// For the load-on-miss pattern that must `.await` a fetch, use
+    /// [`with_entry_hydrated`](Self::with_entry_hydrated), which releases the
+    /// lock across the load.
+    pub async fn get_or_insert_with<F: FnOnce() -> V>(&self, key: K, make: F) -> V
+    where
+        V: Clone,
+        K: Clone,
+    {
+        let tick = self.next_tick();
+        let mut shard = self.inner.get_shard_containing(&key).lock().await;
+        if let Some(entry) = shard.get_mut(&key) {
+            if self.per_shard_capacity.is_some() {
+                entry.1 = tick;
+            }
+            return entry.0.clone();
+        }
+        self.evict_if_full_locked(&mut shard, &key);
+        let value = make();
+        shard.insert(key, (value.clone(), tick));
+        value
+    }
+
+    /// Hydrate-on-miss, then run a read-only `inspect` against the resident
+    /// value.
+    ///
+    /// Ensures the value for `key` is resident (loading it from the backing
+    /// store with **no lock held** on a miss, like
+    /// [`with_entry_hydrated`](Self::with_entry_hydrated)), then applies
+    /// `inspect` under the shard lock and returns its result. Leaves the
+    /// value resident so a subsequent mutation is a cheap hit.
+    ///
+    /// Returns `Ok(None)` if the key does not exist in the backing store
+    /// (`load` returned `Ok(None)`); nothing is installed in that case.
+    ///
+    /// Used by write paths to read pre-mutation state (e.g. "is this commit
+    /// new?") without a separate storage scan and without cloning the value.
+    ///
+    /// # Errors
+    ///
+    /// Returns `load`'s error if hydration fails.
+    pub async fn with_hydrated_ref<Load, Fut, Inspect, R, E>(
+        &self,
+        key: K,
+        load: Load,
+        inspect: Inspect,
+    ) -> Result<Option<R>, E>
+    where
+        K: Clone,
+        Load: FnOnce() -> Fut,
+        Fut: core::future::Future<Output = Result<Option<V>, E>>,
+        Inspect: FnOnce(&V) -> R,
+    {
+        // Fast path: resident hit.
+        {
+            let tick = self.next_tick();
+            let mut shard = self.inner.get_shard_containing(&key).lock().await;
+            if let Some(entry) = shard.get_mut(&key) {
+                if self.per_shard_capacity.is_some() {
+                    entry.1 = tick;
+                }
+                return Ok(Some(inspect(&entry.0)));
+            }
+        }
+
+        // Miss: load with NO lock held.
+        let Some(loaded) = load().await? else {
+            return Ok(None);
+        };
+
+        // Install (or adopt a concurrently-installed value) and inspect.
+        let tick = self.next_tick();
+        let mut shard = self.inner.get_shard_containing(&key).lock().await;
+        if let Some(entry) = shard.get_mut(&key) {
+            if self.per_shard_capacity.is_some() {
+                entry.1 = tick;
+            }
+            return Ok(Some(inspect(&entry.0)));
+        }
+        self.evict_if_full_locked(&mut shard, &key);
+        let result = inspect(&loaded);
+        shard.insert(key, (loaded, tick));
+        Ok(Some(result))
+    }
+
+    /// Hydrate-on-miss, then mutate.
+    ///
+    /// This is the **write-path** entry point: it guarantees the mutation is
+    /// applied to the *complete* value, not a fresh default, even after the
+    /// key was evicted. On a resident hit it mutates in place. On a miss it
+    /// calls `load` (an async fetch from the durable backing store, run with
+    /// **no shard lock held**), installs the loaded value — or `V::default()`
+    /// if `load` returns `Ok(None)`, meaning the key does not exist in the
+    /// backing store yet — then applies `mutate`. Enforces the per-shard
+    /// capacity for a newly-installed key and records an access.
+    ///
+    /// Without this, a plain [`with_entry_or_default`](Self::with_entry_or_default)
+    /// on an evicted key would start from an empty default and silently drop
+    /// the value's prior (durably-stored) state.
+    ///
+    /// # Errors
+    ///
+    /// Returns `load`'s error if hydration fails (the mutation is not applied).
+    pub async fn with_entry_hydrated<Load, Fut, Mutate, R, E>(
+        &self,
+        key: K,
+        load: Load,
+        mutate: Mutate,
+    ) -> Result<R, E>
+    where
+        K: Clone,
+        V: Default,
+        Load: FnOnce() -> Fut,
+        Fut: core::future::Future<Output = Result<Option<V>, E>>,
+        Mutate: FnOnce(&mut V) -> R,
+    {
+        // Fast path: resident hit — mutate in place.
+        {
+            let tick = self.next_tick();
+            let mut shard = self.inner.get_shard_containing(&key).lock().await;
+            if let Some(entry) = shard.get_mut(&key) {
+                if self.per_shard_capacity.is_some() {
+                    entry.1 = tick;
+                }
+                return Ok(mutate(&mut entry.0));
+            }
+        }
+
+        // Miss: load the full value from the backing store with NO lock held.
+        let loaded = load().await?;
+
+        // Re-lock and install. If a concurrent caller installed a value in
+        // the meantime, mutate that one (it is the same durable state) and
+        // drop our load.
+        let tick = self.next_tick();
+        let mut shard = self.inner.get_shard_containing(&key).lock().await;
+        if let Some(entry) = shard.get_mut(&key) {
+            if self.per_shard_capacity.is_some() {
+                entry.1 = tick;
+            }
+            return Ok(mutate(&mut entry.0));
+        }
+        self.evict_if_full_locked(&mut shard, &key);
+        let mut value = loaded.unwrap_or_default();
+        let result = mutate(&mut value);
+        shard.insert(key, (value, tick));
+        Ok(result)
+    }
+
+    /// Remove a key, returning its value if present.
+    pub async fn remove(&self, key: &K) -> Option<V> {
+        self.inner
+            .get_shard_containing(key)
+            .lock()
+            .await
+            .remove(key)
+            .map(|(value, _)| value)
+    }
+
+    /// Collect all keys from all shards.
+    pub async fn into_keys(&self) -> Vec<K>
+    where
+        K: Clone,
+    {
+        self.inner.into_keys().await
+    }
+
+    /// Total number of resident entries across all shards.
+    pub async fn len(&self) -> usize {
+        self.inner.len().await
+    }
+
+    /// Whether the map has no resident entries.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.is_empty().await
+    }
+}
+
+impl<K: Hash + Ord, V, const N: usize> Default for BoundedShardedMap<K, V, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use sedimentree_core::id::SedimentreeId;
+
+    /// Single-shard map (N=1) makes the per-shard cap a global cap, so
+    /// eviction order is deterministic and easy to assert.
+    fn single_shard_capped(max: usize) -> BoundedShardedMap<SedimentreeId, u32, 1> {
+        BoundedShardedMap::<SedimentreeId, u32, 1>::with_key(0, 0).with_capacity(max)
+    }
+
+    fn sid(n: u8) -> SedimentreeId {
+        SedimentreeId::new([n; 32])
+    }
+
+    /// Insert via the get-or-insert path (the cache's real insert entry
+    /// point), enforcing capacity.
+    async fn put<const N: usize>(map: &BoundedShardedMap<SedimentreeId, u32, N>, n: u8, v: u32) {
+        map.get_or_insert_with(sid(n), || v).await;
+    }
+
+    #[tokio::test]
+    async fn unbounded_by_default_never_evicts() {
+        let map: BoundedShardedMap<SedimentreeId, u32, 1> = BoundedShardedMap::with_key(0, 0);
+        assert_eq!(map.per_shard_capacity(), None);
+        for n in 0..100 {
+            put(&map, n, u32::from(n)).await;
+        }
+        assert_eq!(map.len().await, 100, "no cap ⇒ nothing evicted");
+    }
+
+    #[tokio::test]
+    async fn capacity_caps_resident_entries() {
+        let map = single_shard_capped(3);
+        assert_eq!(map.per_shard_capacity(), Some(3));
+        for n in 0..10 {
+            put(&map, n, u32::from(n)).await;
+        }
+        assert_eq!(map.len().await, 3, "shard must never exceed its cap");
+
+        // Not just the count: the survivors must be the three most recently
+        // inserted (7, 8, 9). A buggy eviction that kept the *oldest* entries
+        // would also satisfy `len == 3`, so assert the actual identities.
+        for survivor in [7u8, 8, 9] {
+            assert_eq!(
+                map.get_cloned(&sid(survivor)).await,
+                Some(u32::from(survivor)),
+                "the three most-recent inserts must survive"
+            );
+        }
+        for evicted in [0u8, 1, 2, 3, 4, 5, 6] {
+            assert!(
+                map.get_cloned(&sid(evicted)).await.is_none(),
+                "older insert {evicted} must have been evicted"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn evicts_least_recently_used() {
+        let map = single_shard_capped(3);
+        put(&map, 1, 1).await;
+        put(&map, 2, 2).await;
+        put(&map, 3, 3).await;
+
+        // Touch 1 so it's most-recently-used; 2 becomes the LRU.
+        assert_eq!(map.get_cloned(&sid(1)).await, Some(1));
+
+        // Insert 4 → evicts the LRU, which is now 2 (not 1).
+        put(&map, 4, 4).await;
+
+        assert!(
+            map.get_cloned(&sid(2)).await.is_none(),
+            "2 was LRU, evicted"
+        );
+        assert_eq!(map.get_cloned(&sid(1)).await, Some(1), "1 touched, kept");
+        assert_eq!(map.get_cloned(&sid(3)).await, Some(3));
+        assert_eq!(map.get_cloned(&sid(4)).await, Some(4));
+        assert_eq!(map.len().await, 3);
+    }
+
+    #[tokio::test]
+    async fn updating_existing_key_does_not_evict() {
+        let map = single_shard_capped(2);
+        put(&map, 1, 1).await;
+        put(&map, 2, 2).await;
+        // Touch an existing key via with_entry: not a new key, no eviction.
+        let r = map.with_entry(&sid(1), |v| *v += 10).await;
+        assert_eq!(r, Some(()));
+        assert_eq!(map.len().await, 2, "updating existing key must not evict");
+        assert_eq!(map.get_cloned(&sid(1)).await, Some(11));
+        assert_eq!(map.get_cloned(&sid(2)).await, Some(2));
+    }
+
+    #[tokio::test]
+    async fn with_entry_or_default_respects_capacity() {
+        let map = single_shard_capped(2);
+        for n in 0..5 {
+            map.with_entry_or_default(sid(n), |v| *v = u32::from(n))
+                .await;
+        }
+        assert_eq!(map.len().await, 2);
+
+        // The survivors must be the two most-recently inserted (3, 4) with
+        // their written values, not merely *some* two entries.
+        assert_eq!(map.get_cloned(&sid(3)).await, Some(3));
+        assert_eq!(map.get_cloned(&sid(4)).await, Some(4));
+        for evicted in [0u8, 1, 2] {
+            assert!(
+                map.get_cloned(&sid(evicted)).await.is_none(),
+                "older entry {evicted} must have been evicted"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn zero_capacity_is_floored_to_one() {
+        let map = single_shard_capped(0);
+        assert_eq!(map.per_shard_capacity(), Some(1));
+        put(&map, 1, 1).await;
+        put(&map, 2, 2).await;
+        assert_eq!(map.len().await, 1, "cap floored at 1 per shard");
+        assert_eq!(map.get_cloned(&sid(2)).await, Some(2), "newest kept");
+    }
+
+    /// On the unbounded path no tick bookkeeping happens — `get_cloned` still
+    /// works, and nothing is ever evicted regardless of access pattern.
+    #[tokio::test]
+    async fn unbounded_path_does_not_evict_or_require_touch() {
+        let map: BoundedShardedMap<SedimentreeId, u32, 4> = BoundedShardedMap::with_key(0, 0);
+        for n in 0..50 {
+            put(&map, n, u32::from(n)).await;
+        }
+        let _ = map.get_cloned(&sid(0)).await;
+        map.with_entry_or_default(sid(1), |v| *v += 1).await;
+        let _ = map.with_entry(&sid(3), |v| *v).await;
+        let _ = map.remove(&sid(5)).await;
+        assert_eq!(map.len().await, 49, "unbounded ⇒ only the explicit remove");
+    }
+
+    /// Tests for the hydrate-on-miss methods (`with_hydrated_ref` and
+    /// `with_entry_hydrated`). These are the load-bearing write/read paths
+    /// for the LRU cache over durable storage: on a miss they must reload the
+    /// *full* value from the backing store, never start from a stale or empty
+    /// default, and must converge correctly when two callers race the same
+    /// evicted key.
+    mod hydration {
+        use super::*;
+        use core::convert::Infallible;
+
+        /// A ready future yielding a present value, for the loader closures.
+        fn load_some(value: u32) -> core::future::Ready<Result<Option<u32>, Infallible>> {
+            core::future::ready(Ok(Some(value)))
+        }
+
+        /// `with_entry_hydrated` reloads the full value on a miss and applies
+        /// the mutation to it — not to a fresh default. This is the
+        /// write-after-eviction guarantee at the unit level.
+        #[tokio::test]
+        async fn with_entry_hydrated_loads_full_value_on_miss() {
+            let map = single_shard_capped(2);
+            // Key is absent; loader supplies the durable prior value `100`.
+            let out = map
+                .with_entry_hydrated(
+                    sid(7),
+                    || load_some(100),
+                    |v: &mut u32| {
+                        *v += 1;
+                        *v
+                    },
+                )
+                .await
+                .expect("infallible load");
+            assert_eq!(
+                out, 101,
+                "mutation must apply to the loaded value, not a default"
+            );
+            assert_eq!(
+                map.get_cloned(&sid(7)).await,
+                Some(101),
+                "hydrated value must be installed and resident"
+            );
+        }
+
+        /// On a resident hit, `with_entry_hydrated` mutates in place and never
+        /// calls the loader (which would clobber unsaved in-RAM state).
+        #[tokio::test]
+        async fn with_entry_hydrated_uses_resident_value_without_loading() {
+            let map = single_shard_capped(2);
+            put(&map, 7, 42).await;
+            let loader_called = core::cell::Cell::new(false);
+            let out = map
+                .with_entry_hydrated(
+                    sid(7),
+                    || {
+                        loader_called.set(true);
+                        load_some(999) // wrong value; must NOT be used
+                    },
+                    |v: &mut u32| {
+                        *v += 1;
+                        *v
+                    },
+                )
+                .await
+                .expect("infallible");
+            assert_eq!(out, 43, "must mutate the resident 42, not the loaded 999");
+            assert!(
+                !loader_called.get(),
+                "loader must not run on a resident hit"
+            );
+        }
+
+        /// When `load` returns `Ok(None)` (key absent in durable storage),
+        /// `with_entry_hydrated` mutates `V::default()` and installs it.
+        #[tokio::test]
+        async fn with_entry_hydrated_defaults_when_storage_has_nothing() {
+            let map = single_shard_capped(2);
+            let out = map
+                .with_entry_hydrated(
+                    sid(7),
+                    || async { Ok::<_, Infallible>(None) },
+                    |v: &mut u32| {
+                        *v += 5;
+                        *v
+                    },
+                )
+                .await
+                .expect("infallible");
+            assert_eq!(
+                out, 5,
+                "absent-in-storage must start from default (0) then mutate"
+            );
+            assert_eq!(map.get_cloned(&sid(7)).await, Some(5));
+        }
+
+        /// A failing `load` propagates the error and leaves the map unchanged
+        /// — the mutation is not applied and nothing is installed.
+        #[tokio::test]
+        async fn with_entry_hydrated_load_error_does_not_mutate_or_install() {
+            #[derive(Debug, PartialEq)]
+            struct LoadFailed;
+            let map = single_shard_capped(2);
+            let res = map
+                .with_entry_hydrated(
+                    sid(7),
+                    || async { Err::<Option<u32>, _>(LoadFailed) },
+                    |v: &mut u32| {
+                        *v += 1;
+                    },
+                )
+                .await;
+            assert_eq!(res, Err(LoadFailed), "load error must propagate");
+            assert!(
+                map.get_cloned(&sid(7)).await.is_none(),
+                "nothing must be installed when the load fails"
+            );
+        }
+
+        /// `with_hydrated_ref` returns `Ok(None)` and installs nothing when
+        /// the key is absent in durable storage.
+        #[tokio::test]
+        async fn with_hydrated_ref_none_when_absent_installs_nothing() {
+            let map = single_shard_capped(2);
+            let res: Option<u32> = map
+                .with_hydrated_ref(sid(7), || async { Ok::<_, Infallible>(None) }, |v: &u32| *v)
+                .await
+                .expect("infallible");
+            assert_eq!(res, None, "absent key must inspect to None");
+            assert!(
+                map.get_cloned(&sid(7)).await.is_none(),
+                "nothing installed for an absent key"
+            );
+        }
+
+        /// `with_hydrated_ref` reads (does not mutate) the hydrated value and
+        /// leaves it resident for a subsequent cheap hit.
+        #[tokio::test]
+        async fn with_hydrated_ref_reads_and_installs() {
+            let map = single_shard_capped(2);
+            let seen = map
+                .with_hydrated_ref(sid(7), || load_some(77), |v: &u32| *v)
+                .await
+                .expect("infallible");
+            assert_eq!(seen, Some(77), "must inspect the loaded value");
+            assert_eq!(
+                map.get_cloned(&sid(7)).await,
+                Some(77),
+                "hydrated value left resident"
+            );
+        }
+
+        /// Concurrent hydration of the same evicted key must not lose a write.
+        /// Two tasks each append a distinct element via `with_entry_hydrated`;
+        /// whichever installs first, the second must adopt the resident value
+        /// and append to *it* (not to its own dropped load). Both elements
+        /// must survive regardless of interleaving.
+        ///
+        /// This is the lost-update guard for the adoption branch
+        /// (`with_entry_hydrated` lines that mutate an entry installed by a
+        /// concurrent caller). The integration suite only drives one task per
+        /// key, so this path was otherwise untested.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn concurrent_hydration_does_not_lose_writes() {
+            use alloc::vec::Vec;
+            use std::sync::Arc;
+
+            // Run many rounds to shake out interleavings.
+            for round in 0..200u32 {
+                let map: Arc<BoundedShardedMap<SedimentreeId, Vec<u32>, 1>> =
+                    Arc::new(BoundedShardedMap::with_key(0, 0).with_capacity(8));
+                let key = sid(1);
+
+                // Durable prior state the loader reconstructs on a miss: empty.
+                let m1 = Arc::clone(&map);
+                let m2 = Arc::clone(&map);
+                let k1 = key;
+                let k2 = key;
+
+                let t1 = tokio::spawn(async move {
+                    m1.with_entry_hydrated(
+                        k1,
+                        || async { Ok::<_, Infallible>(Some(Vec::new())) },
+                        |v: &mut Vec<u32>| v.push(1),
+                    )
+                    .await
+                    .expect("infallible");
+                });
+                let t2 = tokio::spawn(async move {
+                    m2.with_entry_hydrated(
+                        k2,
+                        || async { Ok::<_, Infallible>(Some(Vec::new())) },
+                        |v: &mut Vec<u32>| v.push(2),
+                    )
+                    .await
+                    .expect("infallible");
+                });
+                t1.await.expect("task 1");
+                t2.await.expect("task 2");
+
+                let mut final_vec = map.get_cloned(&key).await.expect("key present");
+                final_vec.sort_unstable();
+                assert_eq!(
+                    final_vec,
+                    [1, 2],
+                    "round {round}: both concurrent appends must survive \
+                     (no lost update via the adoption branch)"
+                );
+            }
+        }
+    }
+}

--- a/subduction_core/src/collections/sharded_map.rs
+++ b/subduction_core/src/collections/sharded_map.rs
@@ -358,60 +358,78 @@ mod tests {
     mod proptests {
         use super::*;
 
+        const N: usize = 16;
+
+        /// `shard_index` is a deterministic, in-range function of the key:
+        /// the same key always maps to the same shard `< N`, and equal keys
+        /// are never split across shards (the invariant `get_shard_containing`
+        /// relies on for correctness — a key must always find its own entry).
+        ///
+        /// The `< N` bound is a real regression guard, not a tautology: a
+        /// bug that masked with the wrong width, used `as usize` truncation,
+        /// or forgot the modulo would produce an out-of-range index and panic
+        /// the indexing in `get_shard_containing`.
         #[test]
-        fn prop_shard_distribution_uses_multiple_shards() {
+        fn prop_shard_index_is_deterministic_and_in_range() {
             bolero::check!()
-                .with_arbitrary::<(u64, u64, [u8; 32], [u8; 32], [u8; 32], [u8; 32])>()
-                .for_each(|(key0, key1, id0, id1, id2, id3)| {
-                    let map: ShardedMap<SedimentreeId, (), 16> = ShardedMap::with_key(*key0, *key1);
+                .with_arbitrary::<(u64, u64, [u8; 32])>()
+                .for_each(|(key0, key1, id_bytes)| {
+                    let map: ShardedMap<SedimentreeId, (), N> = ShardedMap::with_key(*key0, *key1);
+                    let id = SedimentreeId::new(*id_bytes);
 
-                    // With 4 random IDs into 16 shards, we should usually see multiple shards used
-                    let ids = [
-                        SedimentreeId::new(*id0),
-                        SedimentreeId::new(*id1),
-                        SedimentreeId::new(*id2),
-                        SedimentreeId::new(*id3),
-                    ];
+                    let first = map.shard_index(&id);
+                    assert!(first < N, "shard index {first} out of range for N={N}");
 
-                    let mut shards_used = BTreeSet::new();
-                    for id in &ids {
-                        shards_used.insert(map.shard_index(id));
-                    }
+                    // Deterministic: repeated lookups of the same key agree,
+                    // and a freshly constructed map with the same keys agrees.
+                    assert_eq!(first, map.shard_index(&id), "shard_index not deterministic");
+                    let map2: ShardedMap<SedimentreeId, (), N> = ShardedMap::with_key(*key0, *key1);
+                    assert_eq!(
+                        first,
+                        map2.shard_index(&id),
+                        "shard_index differs across maps built with identical keys"
+                    );
 
-                    // At minimum, not all IDs should hash to the same shard (except in rare cases)
-                    // This is a probabilistic test - with 4 items and 16 shards, probability of
-                    // all same shard is (1/16)^3 ≈ 0.02%, so this should almost always pass
-                    // We're just checking basic sanity that hashing works
-                    assert!(!shards_used.is_empty(), "at least one shard should be used");
+                    // Equal keys are never split across shards.
+                    let id_eq = SedimentreeId::new(*id_bytes);
+                    assert_eq!(
+                        first,
+                        map.shard_index(&id_eq),
+                        "equal keys must map to the same shard"
+                    );
                 });
         }
 
+        /// Over a large batch of distinct keys the hasher must spread them
+        /// across more than one shard. This is the *real* property the
+        /// original "uses multiple shards" test was reaching for: a
+        /// degenerate `shard_index` that returned a constant (defeating the
+        /// whole point of sharding) would collapse every key into one shard
+        /// and fail here, whereas the old `!is_empty()` assertion could not
+        /// detect that.
+        ///
+        /// With 64 distinct keys over 16 shards, all-collisions has
+        /// probability `(1/16)^63`, so a single shard means a real bug, not
+        /// bad luck.
         #[test]
-        fn prop_different_keys_give_different_shard_indices() {
+        fn prop_distinct_keys_spread_across_shards() {
             bolero::check!()
-                .with_arbitrary::<(u64, u64, u64, u64, [u8; 32])>()
-                .for_each(|(key0a, key1a, key0b, key1b, id_bytes)| {
-                    // Skip if keys are the same
-                    if *key0a == *key0b && *key1a == *key1b {
-                        return;
+                .with_arbitrary::<(u64, u64)>()
+                .for_each(|(key0, key1)| {
+                    let map: ShardedMap<SedimentreeId, (), N> = ShardedMap::with_key(*key0, *key1);
+
+                    let mut shards_used = BTreeSet::new();
+                    for n in 0..64u32 {
+                        let mut bytes = [0u8; 32];
+                        bytes[..4].copy_from_slice(&n.to_le_bytes());
+                        shards_used.insert(map.shard_index(&SedimentreeId::new(bytes)));
                     }
 
-                    let map_a: ShardedMap<SedimentreeId, (), 256> =
-                        ShardedMap::with_key(*key0a, *key1a);
-                    let map_b: ShardedMap<SedimentreeId, (), 256> =
-                        ShardedMap::with_key(*key0b, *key1b);
-
-                    let id = SedimentreeId::new(*id_bytes);
-
-                    let idx_a = map_a.shard_index(&id);
-                    let idx_b = map_b.shard_index(&id);
-
-                    // Both should be valid shard indices
-                    assert!(idx_a < 256);
-                    assert!(idx_b < 256);
-
-                    // Note: we don't assert they're different because with 256 shards
-                    // there's a 1/256 chance of collision even with different keys
+                    assert!(
+                        shards_used.len() > 1,
+                        "64 distinct keys collapsed into a single shard ({shards_used:?}); \
+                         shard_index is degenerate"
+                    );
                 });
         }
     }

--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -698,20 +698,32 @@ impl<
             .collect();
 
         // Build the resident tree from the data we just loaded (reusing the
-        // fetcher reads above — no second storage round-trip) and install it
-        // through the cap-aware cache so eviction/recency are respected.
+        // fetcher reads above — no second storage round-trip).
+        let loose_commits: Vec<_> = commit_by_id
+            .values()
+            .map(|vm| vm.payload().clone())
+            .collect();
+        let fragments: Vec<_> = fragment_by_id
+            .values()
+            .map(|vm| vm.payload().clone())
+            .collect();
+
+        // Only install into the cache when there is actual stored data.
+        //
+        // Caching an empty tree for a never-stored id would make a later
+        // `get_or_hydrate(id)` return `Some(empty)` instead of `None`,
+        // corrupting the exists-vs-nonexistent contract eviction relies on —
+        // and would let any authorized peer pollute the cache by requesting
+        // arbitrary ids (`get_fetcher` gates on policy, not existence). When
+        // there is no data we diff against an ephemeral empty tree and cache
+        // nothing; the response correctly advertises no local items.
+        //
         // `get_or_insert_with` adopts a concurrently-installed value if one
-        // appeared, and records an LRU access either way. The built tree is
-        // already minimal, so it is wrapped clean.
-        let mut sedimentree = {
-            let loose_commits: Vec<_> = commit_by_id
-                .values()
-                .map(|vm| vm.payload().clone())
-                .collect();
-            let fragments: Vec<_> = fragment_by_id
-                .values()
-                .map(|vm| vm.payload().clone())
-                .collect();
+        // appeared and records an LRU access; the built tree is already
+        // minimal, so it is wrapped clean.
+        let mut sedimentree = if loose_commits.is_empty() && fragments.is_empty() {
+            MinimizedSedimentree::already_minimal(Sedimentree::default())
+        } else {
             let built = Sedimentree::new(fragments, loose_commits).minimize(&self.depth_metric);
             self.sedimentrees
                 .get_or_insert_with(id, || MinimizedSedimentree::already_minimal(built))

--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -21,7 +21,7 @@ use future_form::{FutureForm, Local, Sendable, future_form};
 use nonempty::NonEmpty;
 use sedimentree_core::{
     blob::Blob,
-    collections::{Entry, Map, Set},
+    collections::{Map, Set},
     crypto::digest::Digest,
     depth::DepthMetric,
     fragment::Fragment,
@@ -33,6 +33,7 @@ use subduction_crypto::{signed::Signed, verified_meta::VerifiedMeta};
 
 use crate::{
     authenticated::Authenticated,
+    collections::bounded_sharded_map::BoundedShardedMap,
     connection::{
         Connection,
         message::{
@@ -42,7 +43,6 @@ use crate::{
     },
     peer::id::PeerId,
     policy::storage::StoragePolicy,
-    sharded_map::ShardedMap,
     storage::{powerbox::StoragePowerbox, putter::Putter, traits::Storage},
     subduction::{
         error::{BlobRequestErr, IoError, ListenError},
@@ -84,7 +84,7 @@ pub struct SyncHandler<
     const SHARDS: usize = 256,
     R: RemoteHeadsObserver = NoRemoteHeadsObserver,
 > {
-    sedimentrees: Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
+    sedimentrees: Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
     connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
     subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
     storage: StoragePowerbox<Store, Auth>,
@@ -151,7 +151,7 @@ impl<
     /// [`Subduction::new`]: crate::subduction::Subduction::new
     #[allow(clippy::type_complexity)]
     pub fn new(
-        sedimentrees: Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
+        sedimentrees: Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
         connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
         storage: StoragePowerbox<Store, Auth>,
@@ -184,7 +184,7 @@ impl<
     /// Create a new `SyncHandler` with a custom remote heads observer.
     #[allow(clippy::type_complexity)]
     pub fn with_remote_heads_observer(
-        sedimentrees: Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
+        sedimentrees: Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
         connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
         storage: StoragePowerbox<Store, Auth>,
@@ -697,58 +697,47 @@ impl<
             .map(|vm| (vm.payload().head(), vm))
             .collect();
 
-        let (
-            local_commit_ids,
-            local_fragment_ids,
-            our_missing_commit_fingerprints,
-            our_missing_fragment_fingerprints,
-            raw_heads,
-        ) = {
-            let mut locked = self.sedimentrees.get_shard_containing(&id).lock().await;
-
-            if let Entry::Vacant(entry) = locked.entry(id) {
-                let loose_commits: Vec<_> = commit_by_id
-                    .values()
-                    .map(|vm| vm.payload().clone())
-                    .collect();
-                let fragments: Vec<_> = fragment_by_id
-                    .values()
-                    .map(|vm| vm.payload().clone())
-                    .collect();
-
-                if !loose_commits.is_empty() || !fragments.is_empty() {
-                    let sedimentree =
-                        Sedimentree::new(fragments, loose_commits).minimize(&self.depth_metric);
-                    entry.insert(MinimizedSedimentree::already_minimal(sedimentree));
-                    tracing::debug!("hydrated sedimentree {id:?} from storage for batch sync");
-                }
-            }
-
-            let sedimentree = locked.entry(id).or_default();
-            tracing::debug!(
-                "received batch sync request for sedimentree {id:?} for req_id {req_id:?} with {} commit fps and {} fragment fps",
-                their_fingerprints.commit_fingerprints().len(),
-                their_fingerprints.fragment_fingerprints().len()
-            );
-
-            // Wire diff requires the minimal form.
-            let minimal = sedimentree.minimized(&self.depth_metric);
-            let heads = minimal.heads(&self.depth_metric);
-            let diff = minimal.diff_remote_fingerprints(their_fingerprints);
-            (
-                diff.local_only_commits
-                    .iter()
-                    .map(|(id, _)| **id)
-                    .collect::<Vec<_>>(),
-                diff.local_only_fragments
-                    .iter()
-                    .map(|(id, _)| **id)
-                    .collect::<Vec<_>>(),
-                diff.remote_only_commit_fingerprints,
-                diff.remote_only_fragment_fingerprints,
-                heads,
-            )
+        // Build the resident tree from the data we just loaded (reusing the
+        // fetcher reads above — no second storage round-trip) and install it
+        // through the cap-aware cache so eviction/recency are respected.
+        // `get_or_insert_with` adopts a concurrently-installed value if one
+        // appeared, and records an LRU access either way. The built tree is
+        // already minimal, so it is wrapped clean.
+        let mut sedimentree = {
+            let loose_commits: Vec<_> = commit_by_id
+                .values()
+                .map(|vm| vm.payload().clone())
+                .collect();
+            let fragments: Vec<_> = fragment_by_id
+                .values()
+                .map(|vm| vm.payload().clone())
+                .collect();
+            let built = Sedimentree::new(fragments, loose_commits).minimize(&self.depth_metric);
+            self.sedimentrees
+                .get_or_insert_with(id, || MinimizedSedimentree::already_minimal(built))
+                .await
         };
+
+        tracing::debug!(
+            "received batch sync request for sedimentree {id:?} for req_id {req_id:?} with {} commit fps and {} fragment fps",
+            their_fingerprints.commit_fingerprints().len(),
+            their_fingerprints.fragment_fingerprints().len()
+        );
+
+        // The wire diff requires the minimal form. A freshly built value is
+        // already minimal, but an adopted concurrently-installed value may be
+        // dirty, so minimize before computing heads / diff.
+        let minimal = sedimentree.minimized(&self.depth_metric);
+        let raw_heads = minimal.heads(&self.depth_metric);
+        let diff = minimal.diff_remote_fingerprints(their_fingerprints);
+        let local_commit_ids: Vec<_> = diff.local_only_commits.iter().map(|(id, _)| **id).collect();
+        let local_fragment_ids: Vec<_> = diff
+            .local_only_fragments
+            .iter()
+            .map(|(id, _)| **id)
+            .collect();
+        let our_missing_commit_fingerprints = diff.remote_only_commit_fingerprints;
+        let our_missing_fragment_fingerprints = diff.remote_only_fragment_fingerprints;
 
         let responder_heads = RemoteHeads {
             counter: self.send_counter.next(conn.peer_id()).await,
@@ -868,13 +857,28 @@ impl<
         ingest::minimize_tree(&self.sedimentrees, &self.depth_metric, id).await;
     }
 
+    /// Get a sedimentree from the in-memory LRU cache, hydrating from
+    /// durable storage on a miss. Returns `None` if the tree does not exist.
+    /// See [`ingest::get_or_hydrate`].
+    async fn get_or_hydrate(&self, id: SedimentreeId) -> Result<Option<Sedimentree>, Store::Error> {
+        ingest::get_or_hydrate(&self.sedimentrees, &self.storage, &self.depth_metric, id).await
+    }
+
     /// Compute the current heads for a sedimentree (without a counter).
+    ///
+    /// Routes through [`get_or_hydrate`](Self::get_or_hydrate) so an
+    /// evicted (or never-resident) tree reports its real heads from storage
+    /// rather than empty. A nonexistent tree (or a storage error) yields
+    /// empty heads (best-effort; the heads field is advisory).
     async fn heads_for(&self, id: SedimentreeId) -> Vec<CommitId> {
-        let locked = self.sedimentrees.get_shard_containing(&id).lock().await;
-        locked
-            .get(&id)
-            .map(|s| s.heads(&self.depth_metric))
-            .unwrap_or_default()
+        match self.get_or_hydrate(id).await {
+            Ok(Some(tree)) => tree.heads(&self.depth_metric),
+            Ok(None) => Vec::new(),
+            Err(e) => {
+                tracing::warn!("heads_for({id:?}): hydration failed: {e}");
+                Vec::new()
+            }
+        }
     }
 
     async fn add_subscription(&self, peer_id: PeerId, sedimentree_id: SedimentreeId) {

--- a/subduction_core/src/lib.rs
+++ b/subduction_core/src/lib.rs
@@ -93,6 +93,7 @@ extern crate std;
 extern crate alloc;
 
 pub mod authenticated;
+pub mod collections;
 pub mod connection;
 pub mod handler;
 pub mod handshake;
@@ -101,7 +102,6 @@ pub mod nonce_cache;
 pub mod peer;
 pub mod policy;
 pub mod remote_heads;
-pub mod sharded_map;
 pub mod storage;
 pub mod subduction;
 pub mod timeout;

--- a/subduction_core/src/storage/destroyer.rs
+++ b/subduction_core/src/storage/destroyer.rs
@@ -78,6 +78,17 @@ impl<Async: FutureForm, Store: Storage<Async>> Destroyer<Async, Store> {
     pub fn delete_fragments(&self) -> Async::Future<'_, Result<(), Store::Error>> {
         self.storage.delete_fragments(self.sedimentree_id)
     }
+
+    /// Remove this sedimentree's id from the durable id index.
+    ///
+    /// Existence is tracked by the id index independently of having
+    /// commits/fragments, so removing a tree must delete its id (not just
+    /// its data) for it to disappear from
+    /// [`load_all_sedimentree_ids`](crate::storage::traits::Storage::load_all_sedimentree_ids).
+    #[must_use]
+    pub fn delete_sedimentree_id(&self) -> Async::Future<'_, Result<(), Store::Error>> {
+        self.storage.delete_sedimentree_id(self.sedimentree_id)
+    }
 }
 
 impl<Async: FutureForm, Store: Storage<Async>> Clone for Destroyer<Async, Store> {

--- a/subduction_core/src/storage/local_access.rs
+++ b/subduction_core/src/storage/local_access.rs
@@ -57,6 +57,18 @@ impl<Store> LocalStorageAccess<Store> {
         self.storage.load_all_sedimentree_ids()
     }
 
+    /// Whether a sedimentree ID is registered (single-key existence check).
+    #[must_use]
+    pub fn contains_sedimentree_id<Async: FutureForm>(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> Async::Future<'_, Result<bool, Store::Error>>
+    where
+        Store: Storage<Async>,
+    {
+        self.storage.contains_sedimentree_id(sedimentree_id)
+    }
+
     /// Load all loose commits with their blobs for a sedimentree.
     ///
     /// Used for hydration at startup.

--- a/subduction_core/src/storage/memory.rs
+++ b/subduction_core/src/storage/memory.rs
@@ -96,6 +96,16 @@ impl<Async: FutureForm> Storage<Async> for MemoryStorage {
         })
     }
 
+    fn contains_sedimentree_id(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> Async::Future<'_, Result<bool, Self::Error>> {
+        Async::from_future(async move {
+            tracing::debug!(?sedimentree_id, "MemoryStorage::contains_sedimentree_id");
+            Ok(self.ids.lock().await.contains(&sedimentree_id))
+        })
+    }
+
     // ==================== Loose Commits (compound with blob) ====================
 
     fn save_loose_commit(
@@ -374,5 +384,70 @@ impl<Async: FutureForm> Storage<Async> for MemoryStorage {
 
             Ok(num_commits + num_fragments)
         })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn sid(n: u8) -> SedimentreeId {
+        SedimentreeId::new([n; 32])
+    }
+
+    /// `contains_sedimentree_id` reflects registration: false before, true
+    /// after `save_sedimentree_id`, false again after `delete_sedimentree_id`,
+    /// and always agrees with `load_all_sedimentree_ids` membership.
+    #[tokio::test]
+    async fn contains_tracks_registration_and_agrees_with_load_all() {
+        let store = MemoryStorage::new();
+        let id = sid(7);
+        let other = sid(8);
+
+        // Absent before registration.
+        assert!(
+            !Storage::<Sendable>::contains_sedimentree_id(&store, id)
+                .await
+                .expect("infallible"),
+            "unregistered id must not be contained"
+        );
+
+        Storage::<Sendable>::save_sedimentree_id(&store, id)
+            .await
+            .expect("save");
+
+        // Present after registration — even with no commits/fragments (the
+        // registered-but-empty case the hydration path relies on).
+        assert!(
+            Storage::<Sendable>::contains_sedimentree_id(&store, id)
+                .await
+                .expect("infallible"),
+            "registered id must be contained even when empty"
+        );
+        assert!(
+            !Storage::<Sendable>::contains_sedimentree_id(&store, other)
+                .await
+                .expect("infallible"),
+            "a different, unregistered id must not be contained"
+        );
+
+        // Agreement with the enumerating API.
+        let all = Storage::<Sendable>::load_all_sedimentree_ids(&store)
+            .await
+            .expect("load all");
+        assert!(all.contains(&id));
+        assert!(!all.contains(&other));
+
+        // Absent again after deletion.
+        Storage::<Sendable>::delete_sedimentree_id(&store, id)
+            .await
+            .expect("delete");
+        assert!(
+            !Storage::<Sendable>::contains_sedimentree_id(&store, id)
+                .await
+                .expect("infallible"),
+            "deleted id must no longer be contained"
+        );
     }
 }

--- a/subduction_core/src/storage/metrics.rs
+++ b/subduction_core/src/storage/metrics.rs
@@ -154,6 +154,21 @@ impl<Async: FutureForm, Store> Storage<Async> for MetricsStorage<Store> {
         })
     }
 
+    fn contains_sedimentree_id(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> Async::Future<'_, Result<bool, Self::Error>> {
+        Async::from_future(async move {
+            let start = Instant::now();
+            let result = self.inner.contains_sedimentree_id(sedimentree_id).await;
+            metrics::storage_operation_duration(
+                "contains_sedimentree_id",
+                start.elapsed().as_secs_f64(),
+            );
+            result
+        })
+    }
+
     // ==================== Loose Commits (compound with blob) ====================
 
     fn save_loose_commit(

--- a/subduction_core/src/storage/traits.rs
+++ b/subduction_core/src/storage/traits.rs
@@ -91,6 +91,19 @@ pub trait Storage<Async: FutureForm + ?Sized> {
         &self,
     ) -> Async::Future<'_, Result<Set<SedimentreeId>, Self::Error>>;
 
+    /// Whether a sedimentree ID is registered (a single-key existence check).
+    ///
+    /// Existence is tracked by the id index independently of whether the tree
+    /// has any commits/fragments, so a registered-but-empty tree returns
+    /// `true`. Backends must implement this as a single-key lookup, *not* by
+    /// enumerating [`load_all_sedimentree_ids`](Self::load_all_sedimentree_ids):
+    /// it is on the hydration hot path (cache-miss existence checks), where an
+    /// `O(total trees)` scan would be a latency and `DoS` hazard.
+    fn contains_sedimentree_id(
+        &self,
+        sedimentree_id: SedimentreeId,
+    ) -> Async::Future<'_, Result<bool, Self::Error>>;
+
     // ==================== Loose Commits (compound with blob) ====================
 
     /// Save a verified loose commit with its blob.

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -63,6 +63,7 @@ pub(crate) mod peers;
 
 use crate::{
     authenticated::Authenticated,
+    collections::bounded_sharded_map::BoundedShardedMap,
     connection::{
         Connection,
         backoff::Backoff,
@@ -82,7 +83,6 @@ use crate::{
     peer::{counter::PeerCounter, id::PeerId},
     policy::{connection::ConnectionPolicy, storage::StoragePolicy},
     remote_heads::{RemoteHeads, RemoteHeadsNotifier},
-    sharded_map::ShardedMap,
     storage::{powerbox::StoragePowerbox, putter::Putter, traits::Storage},
     timeout::Timeout,
 };
@@ -149,7 +149,7 @@ pub struct Subduction<
 
     timer: Timer,
     depth_metric: Metric,
-    sedimentrees: Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
+    sedimentrees: Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
     storage: StoragePowerbox<Store, Auth>,
 
     /// Active connections, keyed by peer ID.
@@ -359,7 +359,7 @@ where
     /// # Example
     ///
     /// ```ignore
-    /// let sedimentrees = Arc::new(ShardedMap::new());
+    /// let sedimentrees = Arc::new(BoundedShardedMap::new());
     /// let connections = Arc::new(Mutex::new(Map::new()));
     /// let subscriptions = Arc::new(Mutex::new(Map::new()));
     /// let storage = StoragePowerbox::new(storage, Arc::new(policy));
@@ -393,7 +393,7 @@ where
         handler: Arc<Hdl>,
         discovery_id: Option<DiscoveryId>,
         signer: Sign,
-        sedimentrees: Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
+        sedimentrees: Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
         connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         subscriptions: Arc<Mutex<Map<SedimentreeId, Set<PeerId>>>>,
         storage: StoragePowerbox<Store, Auth>,
@@ -1237,12 +1237,10 @@ where
         id: SedimentreeId,
     ) -> Result<Option<NonEmpty<Blob>>, Store::Error> {
         tracing::debug!("Getting local blobs for sedimentree with id {:?}", id);
-        let tree = self.sedimentrees.get_cloned(&id).await;
-        if tree.is_none() {
-            return Ok(None);
-        }
 
-        tracing::debug!("Found sedimentree with id {:?}", id);
+        // Read blobs straight from durable storage. Storage is the source of
+        // truth, so we do not gate on in-RAM cache residency (an evicted tree
+        // must still return its blobs). `None` ⇔ storage holds nothing.
         let local_access = self.storage.hydration_access();
         let mut results = Vec::new();
 
@@ -1284,7 +1282,10 @@ where
         if let Some(maybe_blobs) = self.get_blobs(id).await.map_err(IoError::Storage)? {
             Ok(Some(maybe_blobs))
         } else {
-            let tree = self.get_minimized_tree(id).await;
+            // No blobs locally. Hydrate (cache or storage) to decide whether
+            // the tree exists; only then ask peers for its data. The hydrated
+            // tree is already minimized for wire use.
+            let tree = self.get_or_hydrate(id).await?;
             if let Some(tree) = tree {
                 let conns = self.all_connections().await;
                 for conn in conns {
@@ -1393,22 +1394,31 @@ where
         &self,
         id: SedimentreeId,
     ) -> Result<(), IoError<Async, Store, Conn, Hdl::Message>> {
-        let maybe_sedimentree = self.sedimentrees.remove(&id).await;
+        // Drop the in-RAM cache entry (if resident) and delete from durable
+        // storage unconditionally. We must NOT gate storage deletion on RAM
+        // residency: with the LRU cache, an existing tree may have been
+        // evicted from memory, yet still needs deleting from disk.
+        self.sedimentrees.remove(&id).await;
 
-        if maybe_sedimentree.is_some() {
-            let destroyer = self.storage.local_destroyer(id);
+        let destroyer = self.storage.local_destroyer(id);
 
-            // With compound storage, deleting commits/fragments also deletes their blobs
-            destroyer
-                .delete_loose_commits()
-                .await
-                .map_err(IoError::Storage)?;
+        // With compound storage, deleting commits/fragments also deletes their blobs.
+        destroyer
+            .delete_loose_commits()
+            .await
+            .map_err(IoError::Storage)?;
 
-            destroyer
-                .delete_fragments()
-                .await
-                .map_err(IoError::Storage)?;
-        }
+        destroyer
+            .delete_fragments()
+            .await
+            .map_err(IoError::Storage)?;
+
+        // Existence is recorded by the id index; remove it so the tree no
+        // longer appears in `sedimentree_ids` / enumeration.
+        destroyer
+            .delete_sedimentree_id()
+            .await
+            .map_err(IoError::Storage)?;
 
         Ok(())
     }
@@ -1517,13 +1527,14 @@ where
 
         self.minimize_tree(id).await;
 
-        let heads = {
-            let shard = self.sedimentrees.get_shard_containing(&id).lock().await;
-            shard
-                .get(&id)
-                .map(|s| s.heads(&self.depth_metric))
-                .unwrap_or_default()
-        };
+        // Read the just-written tree's heads via the cache (counts as an
+        // access — appropriate, the tree was just written so it is hot).
+        let heads = self
+            .sedimentrees
+            .get_cloned(&id)
+            .await
+            .map(|s| s.heads(&self.depth_metric))
+            .unwrap_or_default();
         {
             let conns = {
                 let subscriber_conns = self.get_authorized_subscriber_conns(id, &self_id).await;
@@ -1666,13 +1677,14 @@ where
 
         self.minimize_tree(id).await;
 
-        let heads = {
-            let shard = self.sedimentrees.get_shard_containing(&id).lock().await;
-            shard
-                .get(&id)
-                .map(|s| s.heads(&self.depth_metric))
-                .unwrap_or_default()
-        };
+        // Read the just-written tree's heads via the cache (counts as an
+        // access — the tree was just written so it is hot).
+        let heads = self
+            .sedimentrees
+            .get_cloned(&id)
+            .await
+            .map(|s| s.heads(&self.depth_metric))
+            .unwrap_or_default();
 
         let conns = {
             let subscriber_conns = self.get_authorized_subscriber_conns(id, &self_id).await;
@@ -1774,14 +1786,14 @@ where
             .await
             .map_err(|e| WriteError::Io(IoError::Storage(e)))?;
 
-        self.sedimentrees
-            .with_entry_or_default(id, |tree| {
-                for commit in commit_payloads {
-                    tree.add_commit(commit);
-                }
-                tree.ensure_minimized(&self.depth_metric);
-            })
-            .await;
+        self.with_tree_hydrated(id, move |tree| {
+            for commit in commit_payloads {
+                tree.add_commit(commit);
+            }
+        })
+        .await
+        .map_err(WriteError::Io)?;
+        self.minimize_tree(id).await;
 
         tracing::info!("bulk-insert of {count} commits complete, tree minimized");
         Ok(())
@@ -1846,14 +1858,14 @@ where
             .await
             .map_err(|e| WriteError::Io(IoError::Storage(e)))?;
 
-        self.sedimentrees
-            .with_entry_or_default(id, |tree| {
-                for fragment in fragment_payloads {
-                    tree.add_fragment(fragment);
-                }
-                tree.ensure_minimized(&self.depth_metric);
-            })
-            .await;
+        self.with_tree_hydrated(id, move |tree| {
+            for fragment in fragment_payloads {
+                tree.add_fragment(fragment);
+            }
+        })
+        .await
+        .map_err(WriteError::Io)?;
+        self.minimize_tree(id).await;
         tracing::info!("bulk-insert of {count} fragments complete, tree minimized");
         Ok(())
     }
@@ -1932,17 +1944,17 @@ where
             .await
             .map_err(|e| WriteError::Io(IoError::Storage(e)))?;
 
-        self.sedimentrees
-            .with_entry_or_default(id, |tree| {
-                for commit in commit_payloads {
-                    tree.add_commit(commit);
-                }
-                for fragment in fragment_payloads {
-                    tree.add_fragment(fragment);
-                }
-                tree.ensure_minimized(&self.depth_metric);
-            })
-            .await;
+        self.with_tree_hydrated(id, move |tree| {
+            for commit in commit_payloads {
+                tree.add_commit(commit);
+            }
+            for fragment in fragment_payloads {
+                tree.add_fragment(fragment);
+            }
+        })
+        .await
+        .map_err(WriteError::Io)?;
+        self.minimize_tree(id).await;
 
         tracing::info!(
             "bulk-insert of {commit_count} commits and {fragment_count} fragments \
@@ -2017,7 +2029,7 @@ impl<
     #[must_use]
     pub const fn sedimentrees(
         &self,
-    ) -> &Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>> {
+    ) -> &Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>> {
         &self.sedimentrees
     }
 
@@ -2500,10 +2512,11 @@ where
         for conn in peer_conns {
             tracing::info!("Using connection to peer {}", to_ask);
             let seed = FingerprintSeed::random();
-            let resolver = self.get_minimized_tree(id).await.map_or_else(
-                || Sedimentree::default().fingerprint_resolver(&seed),
-                |t| t.fingerprint_resolver(&seed),
-            );
+            // A nonexistent tree syncs as empty: we advertise nothing and the
+            // peer sends us everything it has. The hydrated tree is already
+            // minimized for the wire diff.
+            let tree = self.get_or_hydrate(id).await?.unwrap_or_default();
+            let resolver = tree.fingerprint_resolver(&seed);
 
             tracing::debug!(
                 "Sending fingerprint summary for {:?}: {} commit fps, {} fragment fps",
@@ -2753,9 +2766,15 @@ where
         };
         tracing::debug!("Found {} peer(s)", peers.len());
 
+        // Hydrate the tree once (from the LRU cache or storage) and share it
+        // across all per-peer tasks, rather than re-reading it per peer. A
+        // nonexistent tree syncs as empty.
+        let shared_tree = self.get_or_hydrate(id).await?.unwrap_or_default();
+
         let mut set: FuturesUnordered<_> = peers
             .iter()
             .map(|(peer_id, peer_conns)| {
+                let shared_tree = shared_tree.clone();
                 async move {
                     tracing::debug!(
                         "Requesting batch sync for sedimentree {:?} from {} connections",
@@ -2770,10 +2789,7 @@ where
                     for conn in peer_conns {
                         tracing::debug!("Using connection to peer {}", conn.peer_id());
                         let seed = FingerprintSeed::random();
-                        let resolver = self.get_minimized_tree(id).await.map_or_else(
-                            || Sedimentree::default().fingerprint_resolver(&seed),
-                            |t| t.fingerprint_resolver(&seed),
-                        );
+                        let resolver = shared_tree.fingerprint_resolver(&seed);
 
                         // Mux missing means the peer was torn down between
                         // the connection snapshot and here; report it
@@ -3033,7 +3049,10 @@ where
             "Requesting batch sync for all sedimentrees with peer {}",
             peer_id
         );
-        let tree_ids = self.sedimentrees.into_keys().await;
+        // Enumerate from storage so evicted (cold) trees are still synced.
+        // Each `sync_with_peer` hydrates through the LRU cache, so the
+        // resident set stays bounded even across a full sweep.
+        let tree_ids = self.sedimentree_ids().await;
 
         let mut sync_futures: FuturesUnordered<_> = tree_ids
             .into_iter()
@@ -3089,7 +3108,9 @@ where
         Vec<(SedimentreeId, IoError<Async, Store, Conn, Hdl::Message>)>,
     ) {
         tracing::info!("Requesting batch sync for all sedimentrees from all peers");
-        let tree_ids = self.sedimentrees.into_keys().await;
+        // Enumerate from storage (complete across evictions); per-tree sync
+        // hydrates through the bounded LRU cache.
+        let tree_ids = self.sedimentree_ids().await;
 
         let mut sync_futures: FuturesUnordered<_> = tree_ids
             .into_iter()
@@ -3163,41 +3184,88 @@ where
      * PUBLIC UTILITIES *
      ********************/
 
-    /// Get an iterator over all known sedimentree IDs.
+    /// Get all known sedimentree IDs.
+    ///
+    /// Enumerates from durable storage (not just the in-RAM cache), so the
+    /// list stays complete even after cold trees are evicted from memory.
+    /// On a storage error, logs and falls back to the resident set.
     pub async fn sedimentree_ids(&self) -> Vec<SedimentreeId> {
-        self.sedimentrees.into_keys().await
+        match self
+            .storage
+            .hydration_access()
+            .load_all_sedimentree_ids::<Async>()
+            .await
+        {
+            Ok(ids) => ids.into_iter().collect(),
+            Err(e) => {
+                tracing::warn!(
+                    "sedimentree_ids: storage enumeration failed: {e}; \
+                                falling back to resident set"
+                );
+                self.sedimentrees.into_keys().await
+            }
+        }
     }
 
     /// Get all commits for a given sedimentree ID.
+    ///
+    /// Hydrates from storage on an in-RAM cache miss, so an evicted tree
+    /// returns its real commits. Returns `None` when the tree does not exist
+    /// in storage. On a storage error, logs and returns `None`.
     pub async fn get_commits(&self, id: SedimentreeId) -> Option<Vec<LooseCommit>> {
-        self.sedimentrees
-            .get_cloned(&id)
-            .await
-            .map(|tree| tree.loose_commits().cloned().collect())
+        let tree = self.hydrated_or_log(id).await?;
+        Some(tree.loose_commits().cloned().collect())
     }
 
     /// Get all fragments for a given sedimentree ID.
+    ///
+    /// Hydrates from storage on an in-RAM cache miss. Returns `None` when the
+    /// tree does not exist in storage (see [`get_commits`]).
+    ///
+    /// [`get_commits`]: Self::get_commits
     pub async fn get_fragments(&self, id: SedimentreeId) -> Option<Vec<Fragment>> {
-        self.sedimentrees
-            .get_cloned(&id)
-            .await
-            .map(|tree| tree.fragments().cloned().collect())
+        let tree = self.hydrated_or_log(id).await?;
+        Some(tree.fragments().cloned().collect())
     }
 
-    /// Get the current heads for every locally known sedimentree.
+    /// Hydrate a tree, logging and returning `None` on storage error or when
+    /// the tree does not exist. Helper for the best-effort getters.
+    async fn hydrated_or_log(&self, id: SedimentreeId) -> Option<Sedimentree> {
+        match self.get_or_hydrate(id).await {
+            Ok(maybe_tree) => maybe_tree,
+            Err(e) => {
+                tracing::warn!("hydration failed for sedimentree {id:?}: {e}");
+                None
+            }
+        }
+    }
+
+    /// Get the current heads for every known sedimentree.
     ///
-    /// Walks each shard exactly once, computing heads while holding the
-    /// shard's lock (matching the existing pattern in `SyncHandler`).
+    /// Enumerates from durable storage so the result is complete even after
+    /// cold trees have been evicted from the in-RAM cache. Each tree is
+    /// hydrated on demand through the bounded LRU cache, so memory stays
+    /// bounded across the sweep (an uncommon, potentially slow operation at
+    /// large document counts).
+    ///
     /// An inner empty `Vec<CommitId>` means the sedimentree exists but has
-    /// no heads yet.
+    /// no heads — this is also returned for an id whose hydration *fails*
+    /// transiently (logged), so a storage error is not silently reported as
+    /// "tree does not exist". An id that no longer exists (e.g. deleted
+    /// between enumeration and hydration) is omitted.
     pub async fn get_all_heads(&self) -> Vec<(SedimentreeId, Vec<CommitId>)> {
-        let mut out = Vec::new();
-        for idx in self.sedimentrees.shard_indices() {
-            if let Some(shard) = self.sedimentrees.shard_at(idx) {
-                let guard = shard.lock().await;
-                out.reserve(guard.len());
-                for (id, tree) in guard.iter() {
-                    out.push((*id, tree.heads(&self.depth_metric)));
+        let ids = self.sedimentree_ids().await;
+        let mut out = Vec::with_capacity(ids.len());
+        for id in ids {
+            match self.get_or_hydrate(id).await {
+                Ok(Some(tree)) => out.push((id, tree.heads(&self.depth_metric))),
+                // Tree genuinely gone (raced with a delete): omit it.
+                Ok(None) => {}
+                // Transient hydration failure: keep the id (it was just
+                // enumerated from storage) with empty, advisory heads.
+                Err(e) => {
+                    tracing::warn!("get_all_heads: hydration failed for {id:?}: {e}");
+                    out.push((id, Vec::new()));
                 }
             }
         }
@@ -3242,9 +3310,16 @@ where
             .await?;
 
         let sedimentree = Sedimentree::new(fragments, loose_commits);
+        // Hydrate-on-miss so merging into an evicted tree preserves its full
+        // durable history.
+        let access = self.storage.hydration_access();
         self.sedimentrees
-            .with_entry_or_default(id, |tree| tree.merge(sedimentree))
-            .await;
+            .with_entry_hydrated(
+                id,
+                || ingest::load_tree::<Async, _>(&access, id),
+                |tree| tree.merge(sedimentree),
+            )
+            .await?;
 
         Ok(())
     }
@@ -3300,13 +3375,14 @@ where
 
         // Resolve requested fingerprints → digests via the pre-captured resolver.
         // The resolver was built from the tree state at fingerprint time,
-        // so minimize cannot invalidate these lookups.
+        // so minimize cannot invalidate these lookups. Hydrate from storage
+        // on a cache miss so an evicted tree reports its real heads; a
+        // nonexistent tree has no heads.
         let heads = self
-            .sedimentrees
-            .get_cloned(&id)
-            .await
-            .unwrap_or_default()
-            .heads(&self.depth_metric);
+            .get_or_hydrate(id)
+            .await?
+            .map(|tree| tree.heads(&self.depth_metric))
+            .unwrap_or_default();
 
         let requested_commit_ids: Vec<CommitId> = requesting
             .commit_fingerprints
@@ -3493,17 +3569,39 @@ where
         ingest::minimize_tree(&self.sedimentrees, &self.depth_metric, id).await;
     }
 
-    /// Clone out the **minimal** form of a stored sedimentree, minimizing it in
-    /// place first if it is dirty.
+    /// Get a sedimentree from the in-memory LRU cache, hydrating it from
+    /// durable storage on a miss. The returned tree is already minimized for
+    /// wire use (fingerprint summaries / resolvers). Returns `None` if the
+    /// tree does not exist. See [`ingest::get_or_hydrate`].
+    async fn get_or_hydrate(
+        &self,
+        id: SedimentreeId,
+    ) -> Result<Option<Sedimentree>, IoError<Async, Store, Conn, Hdl::Message>> {
+        ingest::get_or_hydrate(&self.sedimentrees, &self.storage, &self.depth_metric, id)
+            .await
+            .map_err(IoError::Storage)
+    }
+
+    /// Mutate the in-memory tree for `id`, hydrating it from storage first if
+    /// it is not resident.
     ///
-    /// Use this (rather than `sedimentrees.get_cloned`) on paths that feed the
-    /// wire — fingerprint summaries / resolvers — where a non-minimal tree
-    /// would produce an incorrect diff.
-    async fn get_minimized_tree(&self, id: SedimentreeId) -> Option<Sedimentree> {
-        let mut shard = self.sedimentrees.get_shard_containing(&id).lock().await;
-        shard
-            .get_mut(&id)
-            .map(|entry| entry.minimized(&self.depth_metric).clone())
+    /// The write-path counterpart to [`get_or_hydrate`](Self::get_or_hydrate):
+    /// a mutation applied to an evicted tree starts from its full durable
+    /// history rather than an empty default. The caller is responsible for
+    /// having persisted the underlying data to storage *before* calling this
+    /// (storage is the source of truth). The mutation runs against the
+    /// [`MinimizedSedimentree`] wrapper, which it marks dirty; callers
+    /// re-minimize (e.g. via [`minimize_tree`](Self::minimize_tree)) afterward.
+    async fn with_tree_hydrated<F: FnOnce(&mut MinimizedSedimentree) -> R, R>(
+        &self,
+        id: SedimentreeId,
+        mutate: F,
+    ) -> Result<R, IoError<Async, Store, Conn, Hdl::Message>> {
+        let access = self.storage.hydration_access();
+        self.sedimentrees
+            .with_entry_hydrated(id, || ingest::load_tree::<Async, _>(&access, id), mutate)
+            .await
+            .map_err(IoError::Storage)
     }
 }
 
@@ -3820,13 +3918,13 @@ impl<
 mod tests {
     use super::*;
     use crate::{
+        collections::bounded_sharded_map::BoundedShardedMap,
         connection::test_utils::{
             FailingSendMockConnection, InstantTimeout, TestSpawn, test_signer,
         },
         handler::sync::SyncHandler,
         nonce_cache::NonceCache,
         policy::open::OpenPolicy,
-        sharded_map::ShardedMap,
         storage::{memory::MemoryStorage, powerbox::StoragePowerbox},
         subduction::pending_blob_requests::{
             DEFAULT_MAX_PENDING_BLOB_REQUESTS, PendingBlobRequests,
@@ -3880,7 +3978,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_recv_commit_unregisters_connection_on_send_failure() -> TestResult {
-        let sedimentrees = Arc::new(ShardedMap::with_key(0, 0));
+        let sedimentrees = Arc::new(BoundedShardedMap::with_key(0, 0));
         let connections = Arc::new(Mutex::new(Map::new()));
         let subscriptions = Arc::new(Mutex::new(Map::new()));
         let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));
@@ -3949,7 +4047,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_recv_fragment_removes_connection_on_send_failure() -> TestResult {
-        let sedimentrees = Arc::new(ShardedMap::with_key(0, 0));
+        let sedimentrees = Arc::new(BoundedShardedMap::with_key(0, 0));
         let connections = Arc::new(Mutex::new(Map::new()));
         let subscriptions = Arc::new(Mutex::new(Map::new()));
         let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));
@@ -4011,6 +4109,121 @@ mod tests {
             subduction.connected_peer_ids().await.len(),
             0,
             "Connection should be removed after send failure"
+        );
+
+        Ok(())
+    }
+
+    /// Keystone invariant for the in-RAM sedimentree LRU cache: a tree must
+    /// be fully reconstructable from durable storage alone, with no help
+    /// from the in-RAM map.
+    ///
+    /// Storage is the source of truth; the in-RAM
+    /// [`BoundedShardedMap`](crate::collections::bounded_sharded_map::BoundedShardedMap)
+    /// is a cache. Every write persists to storage *before* (or independent
+    /// of) the in-RAM mutation, so dropping a tree from RAM and reloading it
+    /// from storage is lossless. This test pins that invariant — if a future
+    /// change ever leaves data only in the in-RAM tree, eviction would
+    /// silently lose it and this test fails.
+    ///
+    /// Procedure: write commits + fragments via the public store API,
+    /// snapshot the resident (minimized) tree, evict it from the in-RAM map
+    /// *only* (`BoundedShardedMap::remove` does not touch storage), rebuild
+    /// from storage exactly as hydration does, and assert equality.
+    #[tokio::test]
+    async fn tree_is_reconstructable_from_storage_alone() -> TestResult {
+        let sedimentrees: Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree>> =
+            Arc::new(BoundedShardedMap::with_key(0, 0));
+        let connections = Arc::new(Mutex::new(Map::new()));
+        let subscriptions = Arc::new(Mutex::new(Map::new()));
+        let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));
+        let pending = Arc::new(Mutex::new(PendingBlobRequests::new(
+            DEFAULT_MAX_PENDING_BLOB_REQUESTS,
+        )));
+
+        let handler = Arc::new(SyncHandler::new(
+            sedimentrees.clone(),
+            connections.clone(),
+            subscriptions.clone(),
+            storage.clone(),
+            pending.clone(),
+            CountLeadingZeroBytes,
+        ));
+
+        let (subduction, _listener_fut, _actor_fut) =
+            Subduction::<'_, Sendable, _, FailingSendMockConnection, _, _, _, InstantTimeout>::new(
+                handler,
+                None,
+                test_signer(),
+                sedimentrees.clone(),
+                connections,
+                subscriptions,
+                storage.clone(),
+                pending,
+                PeerCounter::default(),
+                NonceCache::default(),
+                InstantTimeout,
+                Duration::from_secs(30),
+                CountLeadingZeroBytes,
+                TestSpawn,
+            );
+
+        let id = SedimentreeId::new([0x5A; 32]);
+
+        // Write a commit and a fragment via the public (persist-only) API.
+        let (_chead, cparents, cblob) = make_commit_parts();
+        subduction
+            .store_commit(id, CommitId::new([0xC0; 32]), cparents, cblob)
+            .await?;
+
+        let (fhead, fboundary, fcheckpoints, fblob) = make_fragment_parts();
+        subduction
+            .store_fragment(id, fhead, fboundary, &fcheckpoints, fblob)
+            .await?;
+
+        // Snapshot the resident tree, then evict it from the in-RAM map
+        // ONLY (this does not delete anything from storage). The writes ran
+        // `minimize_tree`, so the resident wrapper is clean; take its inner
+        // (minimal) tree for comparison with the rehydrated minimal form.
+        let resident = sedimentrees
+            .get_cloned(&id)
+            .await
+            .ok_or("tree should be resident after writes")?
+            .into_tree();
+        let evicted = sedimentrees.remove(&id).await;
+        assert!(evicted.is_some(), "tree should have been in the map");
+        assert!(
+            sedimentrees.get_cloned(&id).await.is_none(),
+            "tree must be gone from the in-RAM map after eviction"
+        );
+
+        // Reconstruct purely from storage, exactly as hydration does.
+        let access = storage.hydration_access();
+        let loaded_commits: Vec<LooseCommit> = access
+            .load_loose_commits::<Sendable>(id)
+            .await?
+            .into_iter()
+            .map(|vm| vm.payload().clone())
+            .collect();
+        let loaded_fragments: Vec<Fragment> = access
+            .load_fragments::<Sendable>(id)
+            .await?
+            .into_iter()
+            .map(|vm| vm.payload().clone())
+            .collect();
+
+        assert!(
+            !loaded_commits.is_empty() || !loaded_fragments.is_empty(),
+            "storage must hold the persisted data after in-RAM eviction"
+        );
+
+        let rehydrated =
+            Sedimentree::new(loaded_fragments, loaded_commits).minimize(&CountLeadingZeroBytes);
+
+        assert_eq!(
+            rehydrated, resident,
+            "tree rebuilt from storage must equal the evicted resident tree \
+             (storage is the source of truth; eviction must be lossless)"
         );
 
         Ok(())

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -3199,8 +3199,7 @@ where
             Ok(ids) => ids.into_iter().collect(),
             Err(e) => {
                 tracing::warn!(
-                    "sedimentree_ids: storage enumeration failed: {e}; \
-                                falling back to resident set"
+                    "sedimentree_ids: storage enumeration failed: {e}; falling back to resident set"
                 );
                 self.sedimentrees.into_keys().await
             }

--- a/subduction_core/src/subduction/builder.rs
+++ b/subduction_core/src/subduction/builder.rs
@@ -23,7 +23,7 @@
 //! | `depth_metric` | [`.depth_metric()`] | [`CountLeadingZeroBytes`] |
 //! | `nonce_cache` | [`.nonce_cache()`] | [`NonceCache::default()`] |
 //! | `max_pending_blob_requests` | [`.max_pending_blob_requests()`] | `10_000` |
-//! | `sedimentrees` | [`.sedimentrees()`] | Empty [`ShardedMap::new()`] |
+//! | `sedimentrees` | [`.sedimentrees()`] | Empty [`BoundedShardedMap::new()`] |
 //!
 //! # Example
 //!
@@ -53,7 +53,7 @@
 //! [`.sedimentrees()`]: SubductionBuilder::sedimentrees
 //! [`CountLeadingZeroBytes`]: sedimentree_core::commit::CountLeadingZeroBytes
 //! [`NonceCache::default()`]: crate::nonce_cache::NonceCache
-//! [`ShardedMap::new()`]: crate::sharded_map::ShardedMap::new
+//! [`BoundedShardedMap::new()`]: crate::collections::bounded_sharded_map::BoundedShardedMap::new
 
 use alloc::sync::Arc;
 use async_lock::Mutex;
@@ -68,6 +68,7 @@ use sedimentree_core::{
 
 use crate::{
     authenticated::Authenticated,
+    collections::bounded_sharded_map::BoundedShardedMap,
     connection::{
         Connection,
         managed::{ManagedCall, ManagedConnection},
@@ -80,7 +81,6 @@ use crate::{
     peer::{counter::PeerCounter, id::PeerId},
     policy::{connection::ConnectionPolicy, storage::StoragePolicy},
     remote_heads::RemoteHeadsNotifier,
-    sharded_map::ShardedMap,
     storage::{powerbox::StoragePowerbox, traits::Storage},
     timeout::Timeout,
 };
@@ -129,16 +129,17 @@ pub struct SubductionBuilder<
     depth_metric: Metric,
     nonce_cache: Option<NonceCache>,
     max_pending_blob_requests: usize,
+    max_resident_trees: Option<usize>,
     sedimentrees: SedimentreesOption<SHARDS>,
 }
 
-/// Internal helper: stores an optional pre-populated `ShardedMap`.
+/// Internal helper: stores an optional pre-populated `BoundedShardedMap`.
 ///
 /// Using a wrapper struct avoids placing the const generic `SHARDS` on
 /// fields that don't otherwise need it.
 #[derive(Debug)]
 struct SedimentreesOption<const SHARDS: usize>(
-    Option<Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>>,
+    Option<Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>>,
 );
 
 impl<const SHARDS: usize> Default for SedimentreesOption<SHARDS> {
@@ -161,7 +162,7 @@ impl<const SHARDS: usize>
     /// calling [`build`](SubductionBuilder::build).
     ///
     /// The const generic `SHARDS` controls the number of shards in the
-    /// internal [`ShardedMap`]. Defaults to 256 if not specified.
+    /// internal [`BoundedShardedMap`]. Defaults to 256 if not specified.
     #[must_use]
     pub fn new() -> Self {
         SubductionBuilder {
@@ -174,6 +175,7 @@ impl<const SHARDS: usize>
             depth_metric: CountLeadingZeroBytes,
             nonce_cache: None,
             max_pending_blob_requests: DEFAULT_MAX_PENDING_BLOB_REQUESTS,
+            max_resident_trees: None,
             sedimentrees: SedimentreesOption::default(),
         }
     }
@@ -207,6 +209,7 @@ impl<Sp, Store, Timer, Metric, const SHARDS: usize>
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
+            max_resident_trees: self.max_resident_trees,
             sedimentrees: self.sedimentrees,
         }
     }
@@ -234,6 +237,7 @@ impl<Sign, Store, Timer, Metric, const SHARDS: usize>
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
+            max_resident_trees: self.max_resident_trees,
             sedimentrees: self.sedimentrees,
         }
     }
@@ -261,6 +265,7 @@ impl<Sign, Sp, Timer, Metric, const SHARDS: usize>
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
+            max_resident_trees: self.max_resident_trees,
             sedimentrees: self.sedimentrees,
         }
     }
@@ -285,6 +290,7 @@ impl<Sign, Sp, Store, Metric, const SHARDS: usize>
             depth_metric: self.depth_metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
+            max_resident_trees: self.max_resident_trees,
             sedimentrees: self.sedimentrees,
         }
     }
@@ -330,6 +336,7 @@ impl<Sign, Sp, Store, Timer, Met, const SHARDS: usize>
             depth_metric: metric,
             nonce_cache: self.nonce_cache,
             max_pending_blob_requests: self.max_pending_blob_requests,
+            max_resident_trees: self.max_resident_trees,
             sedimentrees: self.sedimentrees,
         }
     }
@@ -352,15 +359,44 @@ impl<Sign, Sp, Store, Timer, Met, const SHARDS: usize>
         self
     }
 
+    /// Bound the number of sedimentrees kept resident in memory.
+    ///
+    /// The in-memory sedimentree map is an LRU cache over durable storage:
+    /// when the resident set exceeds this many trees, the least-recently-used
+    /// trees are evicted and transparently re-hydrated from storage on next
+    /// access. This bounds memory by the active working set rather than the
+    /// total number of documents ever synced.
+    ///
+    /// # Approximate, not a strict global cap
+    ///
+    /// The bound is enforced **per shard**: `max` is divided across the
+    /// map's shards (`ceil(max / SHARDS)` per shard, floored at 1). So the
+    /// effective global ceiling is `ceil(max / SHARDS) * SHARDS`, which can
+    /// exceed `max` and is **at least `SHARDS`** (256 by default). Setting a
+    /// value smaller than the shard count therefore still permits up to one
+    /// resident tree per shard. Treat `max` as an order-of-magnitude target,
+    /// not an exact limit. See
+    /// [`BoundedShardedMap::with_capacity`](crate::collections::bounded_sharded_map::BoundedShardedMap::with_capacity).
+    ///
+    /// Defaults to unbounded (no eviction) — set this on servers / clients
+    /// that sync large numbers of documents. Ignored if a pre-populated
+    /// [`sedimentrees`](Self::sedimentrees) map is supplied (configure the
+    /// cap on that map directly via `with_capacity`).
+    #[must_use]
+    pub const fn max_resident_trees(mut self, max: usize) -> Self {
+        self.max_resident_trees = Some(max);
+        self
+    }
+
     /// Provide a pre-populated sedimentree map.
     ///
     /// Use this for hydration: load sedimentree state from storage,
     /// then pass the populated map here. Defaults to an empty
-    /// [`ShardedMap::new()`](ShardedMap::new).
+    /// [`BoundedShardedMap::new()`](crate::collections::bounded_sharded_map::BoundedShardedMap::new).
     #[must_use]
     pub fn sedimentrees(
         mut self,
-        sedimentrees: Arc<ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
+        sedimentrees: Arc<BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>>,
     ) -> Self {
         self.sedimentrees = SedimentreesOption(Some(sedimentrees));
         self
@@ -427,10 +463,14 @@ impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
                 SendError = <Conn as Connection<Async, SyncMessage>>::SendError,
             >,
     {
-        let sedimentrees = self
-            .sedimentrees
-            .0
-            .unwrap_or_else(|| Arc::new(ShardedMap::new()));
+        let sedimentrees = self.sedimentrees.0.unwrap_or_else(|| {
+            let map = BoundedShardedMap::new();
+            let map = match self.max_resident_trees {
+                Some(cap) => map.with_capacity(cap),
+                None => map,
+            };
+            Arc::new(map)
+        });
 
         let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>> =
             Arc::new(Mutex::new(Map::new()));
@@ -528,10 +568,14 @@ impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
                 SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
             >,
     {
-        let sedimentrees = self
-            .sedimentrees
-            .0
-            .unwrap_or_else(|| Arc::new(ShardedMap::new()));
+        let sedimentrees = self.sedimentrees.0.unwrap_or_else(|| {
+            let map = BoundedShardedMap::new();
+            let map = match self.max_resident_trees {
+                Some(cap) => map.with_capacity(cap),
+                None => map,
+            };
+            Arc::new(map)
+        });
 
         let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>> =
             Arc::new(Mutex::new(Map::new()));
@@ -615,10 +659,14 @@ impl<Sign, Sp, Store, Auth, Timer, Metric: DepthMetric, const SHARDS: usize>
                 SendError = <Conn as Connection<Async, Hdl::Message>>::SendError,
             >,
     {
-        let sedimentrees = self
-            .sedimentrees
-            .0
-            .unwrap_or_else(|| Arc::new(ShardedMap::new()));
+        let sedimentrees = self.sedimentrees.0.unwrap_or_else(|| {
+            let map = BoundedShardedMap::new();
+            let map = match self.max_resident_trees {
+                Some(cap) => map.with_capacity(cap),
+                None => map,
+            };
+            Arc::new(map)
+        });
 
         let connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>> =
             Arc::new(Mutex::new(Map::new()));

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -19,15 +19,15 @@ use sedimentree_core::{
     fragment::Fragment,
     id::SedimentreeId,
     loose_commit::LooseCommit,
-    sedimentree::minimized::MinimizedSedimentree,
+    sedimentree::{Sedimentree, minimized::MinimizedSedimentree},
 };
 use subduction_crypto::verified_meta::VerifiedMeta;
 
 use crate::{
+    collections::bounded_sharded_map::BoundedShardedMap,
     connection::{Connection, message::SyncDiff},
     peer::id::PeerId,
     policy::storage::StoragePolicy,
-    sharded_map::ShardedMap,
     storage::{powerbox::StoragePowerbox, putter::Putter, traits::Storage},
 };
 use sedimentree_core::codec::{decode::Decode, encode::Encode};
@@ -47,7 +47,7 @@ pub(crate) async fn recv_batch_sync_response<
     Auth: StoragePolicy<Async>,
     const SHARDS: usize,
 >(
-    sedimentrees: &ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
+    sedimentrees: &BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
     storage: &StoragePowerbox<Store, Auth>,
     from: &PeerId,
     id: SedimentreeId,
@@ -187,15 +187,26 @@ pub(crate) async fn recv_batch_sync_response<
             .await
             .map_err(IoError::Storage)?;
 
+        let local_access = storage.hydration_access();
         for commit in commit_payloads {
             sedimentrees
-                .with_entry_or_default(id, |tree| tree.add_commit(commit))
-                .await;
+                .with_entry_hydrated(
+                    id,
+                    || load_tree::<Async, _>(&local_access, id),
+                    |tree| tree.add_commit(commit),
+                )
+                .await
+                .map_err(IoError::Storage)?;
         }
         for fragment in fragment_payloads {
             sedimentrees
-                .with_entry_or_default(id, |tree| tree.add_fragment(fragment))
-                .await;
+                .with_entry_hydrated(
+                    id,
+                    || load_tree::<Async, _>(&local_access, id),
+                    |tree| tree.add_fragment(fragment),
+                )
+                .await
+                .map_err(IoError::Storage)?;
         }
     }
 
@@ -212,21 +223,50 @@ pub(crate) async fn insert_commit_locally<
     Store: Storage<Async>,
     const SHARDS: usize,
 >(
-    sedimentrees: &ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
+    sedimentrees: &BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
     putter: &Putter<Async, Store>,
     verified_meta: VerifiedMeta<LooseCommit>,
 ) -> Result<bool, Store::Error> {
     let id = putter.sedimentree_id();
     let commit = verified_meta.payload().clone();
+    let head = commit.head();
 
     tracing::debug!("inserting commit {:?} locally", Digest::hash(&commit));
 
     putter.save_sedimentree_id().await?;
+
+    // Newness ("was this commit not already known?") is judged against the
+    // tree state *before* persisting. Read it from the resident cache, or
+    // hydrate-on-miss — both reflect pre-save state (we save below). This is
+    // O(1) on the resident hot path (no storage scan) and leaves the tree
+    // resident so the add is a cheap hit. A `None` (tree not in storage)
+    // means a brand-new tree, so the commit is necessarily new.
+    let was_added = sedimentrees
+        .with_hydrated_ref(
+            id,
+            || load_tree_via_putter::<Async, _>(putter),
+            |tree| !tree.has_loose_commit(head),
+        )
+        .await?
+        .unwrap_or(true);
+
+    // Persist before the in-RAM mutation (storage is the source of truth;
+    // the map is a cache that re-hydrates from it).
     putter.save_commit(verified_meta).await?;
 
-    let was_added = sedimentrees
-        .with_entry_or_default(id, |tree| tree.add_commit(commit))
-        .await;
+    // Apply to the in-RAM tree, hydrating on a miss in case it was evicted
+    // between the read above and here. On that (rare) miss the loader reloads
+    // post-save state — which already contains the commit — so `add_commit`
+    // is a harmless no-op and the resident tree is the full, correct history.
+    sedimentrees
+        .with_entry_hydrated(
+            id,
+            || load_tree_via_putter::<Async, _>(putter),
+            |tree| {
+                tree.add_commit(commit);
+            },
+        )
+        .await?;
 
     Ok(was_added)
 }
@@ -239,19 +279,38 @@ pub(crate) async fn insert_fragment_locally<
     Store: Storage<Async>,
     const SHARDS: usize,
 >(
-    sedimentrees: &ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
+    sedimentrees: &BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
     putter: &Putter<Async, Store>,
     verified_meta: VerifiedMeta<Fragment>,
 ) -> Result<bool, Store::Error> {
     let id = putter.sedimentree_id();
     let fragment = verified_meta.payload().clone();
+    let head = fragment.head();
 
     putter.save_sedimentree_id().await?;
+
+    // Newness from pre-save tree state (resident or hydrated); see
+    // `insert_commit_locally`.
+    let was_added = sedimentrees
+        .with_hydrated_ref(
+            id,
+            || load_tree_via_putter::<Async, _>(putter),
+            |tree| !tree.has_fragment(head),
+        )
+        .await?
+        .unwrap_or(true);
+
     putter.save_fragment(verified_meta).await?;
 
-    let was_added = sedimentrees
-        .with_entry_or_default(id, |tree| tree.add_fragment(fragment))
-        .await;
+    sedimentrees
+        .with_entry_hydrated(
+            id,
+            || load_tree_via_putter::<Async, _>(putter),
+            |tree| {
+                tree.add_fragment(fragment);
+            },
+        )
+        .await?;
 
     Ok(was_added)
 }
@@ -261,7 +320,7 @@ pub(crate) async fn insert_fragment_locally<
 /// Prunes dominated fragments and loose commits covered by fragments,
 /// keeping only the minimal covering set. Storage retains the full history.
 pub(crate) async fn minimize_tree<Metric: DepthMetric, const SHARDS: usize>(
-    sedimentrees: &ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
+    sedimentrees: &BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
     depth_metric: &Metric,
     id: SedimentreeId,
 ) {
@@ -270,6 +329,165 @@ pub(crate) async fn minimize_tree<Metric: DepthMetric, const SHARDS: usize>(
             tree.ensure_minimized(depth_metric);
         })
         .await;
+}
+
+/// Get a sedimentree from the in-memory cache, hydrating it from durable
+/// storage on a miss.
+///
+/// This is the single read entry point that makes the in-memory
+/// [`BoundedShardedMap`] safe to evict: every reader that needs the *full*
+/// tree state must go through here so an evicted (or never-resident) tree is
+/// transparently reloaded from storage rather than silently seen as empty.
+///
+/// # Deadlock safety
+///
+/// Hydration loads from storage (an `.await` that, on Wasm, is an async
+/// `IndexedDB` transaction) **without holding any shard lock**. Only after
+/// the load completes does it briefly lock the shard to install the tree.
+/// Never hold the shard mutex across the storage await.
+///
+/// # Concurrency
+///
+/// Concurrent misses for the same id each load independently (a bounded,
+/// self-correcting "thundering herd"); the first to install wins and the
+/// rest are dropped — correct because all loads read the same durable
+/// source. Single-flight de-duplication is intentionally not implemented.
+///
+/// Returns `None` only when the tree does not exist. Existence is recorded
+/// by the sedimentree-id index, *not* by having commits/fragments: a tree
+/// may be registered while empty (e.g. an `add_sedimentree` of an empty
+/// tree), in which case this returns `Some(empty tree)`. A miss with no
+/// stored data therefore consults the id index to distinguish "registered
+/// but empty" (→ `Some`) from "never stored" (→ `None`).
+pub(crate) async fn get_or_hydrate<
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+>(
+    sedimentrees: &BoundedShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
+    storage: &StoragePowerbox<Store, Auth>,
+    depth_metric: &Metric,
+    id: SedimentreeId,
+) -> Result<Option<Sedimentree>, Store::Error> {
+    // Fast path: resident hit (also records an LRU access). Minimize in place
+    // first if dirty so callers that feed the wire (fingerprint summaries /
+    // resolvers) always observe the minimal form.
+    if let Some(tree) = sedimentrees
+        .with_entry(&id, |tree| tree.minimized(depth_metric).clone())
+        .await
+    {
+        tracing::trace!("sedimentree {id:?} cache hit");
+        return Ok(Some(tree));
+    }
+
+    // Miss: load full history from storage with NO shard lock held.
+    tracing::debug!("sedimentree {id:?} cache miss; hydrating from storage");
+    let local_access = storage.hydration_access();
+    let loose_commits: Vec<LooseCommit> = local_access
+        .load_loose_commits::<Async>(id)
+        .await?
+        .into_iter()
+        .map(|vm| vm.payload().clone())
+        .collect();
+    let fragments: Vec<Fragment> = local_access
+        .load_fragments::<Async>(id)
+        .await?
+        .into_iter()
+        .map(|vm| vm.payload().clone())
+        .collect();
+
+    // Existence is recorded by the sedimentree-id index, not by having
+    // commits/fragments: a tree can be registered while empty (e.g. an
+    // `add_sedimentree` of an empty tree). If the tree has no data, consult
+    // the index to distinguish "registered but empty" from "nonexistent".
+    if loose_commits.is_empty() && fragments.is_empty() {
+        let known = local_access.load_all_sedimentree_ids::<Async>().await?;
+        if known.contains(&id) {
+            tracing::trace!("sedimentree {id:?} registered but empty");
+            return Ok(Some(Sedimentree::default()));
+        }
+        tracing::trace!("sedimentree {id:?} not found in storage");
+        return Ok(None);
+    }
+
+    let hydrated = Sedimentree::new(fragments, loose_commits).minimize(depth_metric);
+
+    // Install (or adopt a concurrently-installed value). Enforces the LRU
+    // cap; the lock is only taken now, after the await above. The tree is
+    // already minimal, so wrap it clean.
+    sedimentrees
+        .get_or_insert_with(id, || MinimizedSedimentree::already_minimal(hydrated.clone()))
+        .await;
+    Ok(Some(hydrated))
+}
+
+/// Reconstruct a sedimentree's full history directly from storage.
+///
+/// Returns `Ok(None)` if storage holds no commits and no fragments for `id`
+/// (a brand-new or empty tree); otherwise the rebuilt tree. Used as the
+/// hydrate-on-miss loader for the write paths so a mutation applied to an
+/// evicted tree starts from its complete durable state, not an empty
+/// default.
+///
+/// The tree is **not** minimized here: the write paths re-minimize after
+/// their mutation (or minimization happens lazily on read), so minimizing
+/// in the loader would be redundant — which is why no [`DepthMetric`] is
+/// needed.
+pub(crate) async fn load_tree<Async: FutureForm, Store: Storage<Async>>(
+    access: &crate::storage::local_access::LocalStorageAccess<Store>,
+    id: SedimentreeId,
+) -> Result<Option<MinimizedSedimentree>, Store::Error> {
+    let loose_commits: Vec<LooseCommit> = access
+        .load_loose_commits::<Async>(id)
+        .await?
+        .into_iter()
+        .map(|vm| vm.payload().clone())
+        .collect();
+    let fragments: Vec<Fragment> = access
+        .load_fragments::<Async>(id)
+        .await?
+        .into_iter()
+        .map(|vm| vm.payload().clone())
+        .collect();
+
+    if loose_commits.is_empty() && fragments.is_empty() {
+        return Ok(None);
+    }
+    // Full history, not yet minimized: wrap dirty so the next read minimizes.
+    Ok(Some(MinimizedSedimentree::new(Sedimentree::new(
+        fragments,
+        loose_commits,
+    ))))
+}
+
+/// Like [`load_tree`], but loads via a [`Putter`] (used by the local insert
+/// paths, which already hold a putter scoped to the tree).
+async fn load_tree_via_putter<Async: FutureForm, Store: Storage<Async>>(
+    putter: &Putter<Async, Store>,
+) -> Result<Option<MinimizedSedimentree>, Store::Error> {
+    let loose_commits: Vec<LooseCommit> = putter
+        .load_loose_commits()
+        .await?
+        .into_iter()
+        .map(|vm| vm.payload().clone())
+        .collect();
+    let fragments: Vec<Fragment> = putter
+        .load_fragments()
+        .await?
+        .into_iter()
+        .map(|vm| vm.payload().clone())
+        .collect();
+
+    if loose_commits.is_empty() && fragments.is_empty() {
+        return Ok(None);
+    }
+    // Full history, not yet minimized: wrap dirty so the next read minimizes.
+    Ok(Some(MinimizedSedimentree::new(Sedimentree::new(
+        fragments,
+        loose_commits,
+    ))))
 }
 
 /// Look up a blob from local storage by its digest.

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -400,12 +400,21 @@ pub(crate) async fn get_or_hydrate<
 
     // Existence is recorded by the sedimentree-id index, not by having
     // commits/fragments: a tree can be registered while empty (e.g. an
-    // `add_sedimentree` of an empty tree). If the tree has no data, consult
-    // the index to distinguish "registered but empty" from "nonexistent".
+    // `add_sedimentree` of an empty tree). If the tree has no data, a
+    // single-key index lookup distinguishes "registered but empty" from
+    // "nonexistent" — O(1), without enumerating every id.
     if loose_commits.is_empty() && fragments.is_empty() {
-        let known = local_access.load_all_sedimentree_ids::<Async>().await?;
-        if known.contains(&id) {
+        if local_access.contains_sedimentree_id::<Async>(id).await? {
             tracing::trace!("sedimentree {id:?} registered but empty");
+            // Cache the empty tree so repeat reads are resident hits rather
+            // than repeated storage lookups. Safe to install here (unlike the
+            // sync-request path) because the id is confirmed in the index, so
+            // this cannot fabricate existence for a never-stored id.
+            sedimentrees
+                .get_or_insert_with(id, || {
+                    MinimizedSedimentree::already_minimal(Sedimentree::default())
+                })
+                .await;
             return Ok(Some(Sedimentree::default()));
         }
         tracing::trace!("sedimentree {id:?} not found in storage");

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -418,7 +418,9 @@ pub(crate) async fn get_or_hydrate<
     // cap; the lock is only taken now, after the await above. The tree is
     // already minimal, so wrap it clean.
     sedimentrees
-        .get_or_insert_with(id, || MinimizedSedimentree::already_minimal(hydrated.clone()))
+        .get_or_insert_with(id, || {
+            MinimizedSedimentree::already_minimal(hydrated.clone())
+        })
         .await;
     Ok(Some(hydrated))
 }

--- a/subduction_core/tests/bidirectional_sync.rs
+++ b/subduction_core/tests/bidirectional_sync.rs
@@ -906,3 +906,76 @@ async fn test_no_requesting_when_in_sync() -> TestResult {
     alice_listener_task.abort();
     Ok(())
 }
+
+/// A sync request for an id the responder has never stored must not pollute
+/// the responder's in-memory cache. Regression for the LRU cache-pollution
+/// bug: `recv_batch_sync_request` used to unconditionally install the
+/// (empty) built tree, which made a later `get_or_hydrate(id)` return
+/// `Some(empty)` instead of `None` — letting any authorized peer fabricate
+/// "existence" for arbitrary ids by requesting them.
+#[tokio::test]
+async fn sync_request_for_unknown_id_does_not_pollute_cache() -> TestResult {
+    let (alice, alice_listener, alice_actor) = make_subduction();
+
+    let unknown_id = SedimentreeId::new([0xABu8; 32]);
+    let peer_id = PeerId::new([7u8; 32]);
+
+    let (conn, handle) = ChannelMockConnection::new_with_handle(peer_id);
+    alice.add_connection(conn.authenticated()).await?;
+
+    let alice_actor_task = tokio::spawn(alice_actor);
+    let alice_listener_task = tokio::spawn(alice_listener);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Precondition: Alice has never stored this tree, so it does not exist.
+    assert!(
+        alice.get_commits(unknown_id).await.is_none(),
+        "precondition: unknown id must not exist before the request"
+    );
+
+    // A peer requests sync for the never-stored id (empty summary).
+    let request = BatchSyncRequest {
+        id: unknown_id,
+        req_id: RequestId {
+            requestor: peer_id,
+            nonce: 1,
+        },
+        fingerprint_summary: FingerprintSummary::new(TEST_SEED, BTreeSet::new(), BTreeSet::new()),
+        subscribe: false,
+    };
+    handle
+        .inbound_tx
+        .send(SyncMessage::BatchSyncRequest(request))
+        .await?;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Alice still responds (advertising nothing) ...
+    let response = recv_skipping_heads_updates(&handle.outbound_rx)
+        .await
+        .expect("should receive response");
+    let SyncMessage::BatchSyncResponse(BatchSyncResponse { result, .. }) = response else {
+        panic!("Expected BatchSyncResponse, got {response:?}");
+    };
+    let SyncResult::Ok(diff) = result else {
+        panic!("Expected SyncResult::Ok, got {result:?}");
+    };
+    assert!(
+        diff.missing_commits.is_empty() && diff.missing_fragments.is_empty(),
+        "Alice has nothing to offer for an unknown id"
+    );
+
+    // ... but the unknown id must STILL read as nonexistent: the empty tree
+    // must not have been installed into the cache.
+    assert!(
+        alice.get_commits(unknown_id).await.is_none(),
+        "a sync request for an unknown id must not make it appear to exist"
+    );
+    assert!(
+        alice.get_fragments(unknown_id).await.is_none(),
+        "a sync request for an unknown id must not make it appear to exist"
+    );
+
+    alice_actor_task.abort();
+    alice_listener_task.abort();
+    Ok(())
+}

--- a/subduction_core/tests/blob_operations.rs
+++ b/subduction_core/tests/blob_operations.rs
@@ -16,6 +16,7 @@ use sedimentree_core::{
     id::SedimentreeId,
 };
 use subduction_core::{
+    collections::bounded_sharded_map::BoundedShardedMap,
     connection::{
         message::SyncMessage,
         test_utils::{
@@ -26,7 +27,6 @@ use subduction_core::{
     nonce_cache::NonceCache,
     peer::{counter::PeerCounter, id::PeerId},
     policy::open::OpenPolicy,
-    sharded_map::ShardedMap,
     storage::{memory::MemoryStorage, powerbox::StoragePowerbox},
     subduction::{
         Subduction,
@@ -84,7 +84,7 @@ fn new_dispatch_subduction() -> (
     impl core::future::Future<Output = Result<(), futures::future::Aborted>>,
     impl core::future::Future<Output = Result<(), futures::future::Aborted>>,
 ) {
-    let sedimentrees = Arc::new(ShardedMap::with_key(0, 0));
+    let sedimentrees = Arc::new(BoundedShardedMap::with_key(0, 0));
     let connections = Arc::new(Mutex::new(Map::new()));
     let subscriptions = Arc::new(Mutex::new(Map::new()));
     let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));

--- a/subduction_core/tests/concurrent_sync.rs
+++ b/subduction_core/tests/concurrent_sync.rs
@@ -109,6 +109,13 @@ impl Storage<Sendable> for ConcurrencyTrackingStorage {
         Storage::<Sendable>::load_all_sedimentree_ids(&self.inner)
     }
 
+    fn contains_sedimentree_id(
+        &self,
+        id: SedimentreeId,
+    ) -> BoxFuture<'_, Result<bool, Self::Error>> {
+        Storage::<Sendable>::contains_sedimentree_id(&self.inner, id)
+    }
+
     fn save_loose_commit(
         &self,
         id: SedimentreeId,

--- a/subduction_core/tests/connection_cleanup.rs
+++ b/subduction_core/tests/connection_cleanup.rs
@@ -10,12 +10,14 @@ use sedimentree_core::{
     id::SedimentreeId, loose_commit::id::CommitId,
 };
 use subduction_core::{
-    connection::test_utils::{FailingSendMockConnection, InstantTimeout, TestSpawn, test_signer},
+    collections::bounded_sharded_map::BoundedShardedMap,
+    connection::test_utils::{
+        FailingSendMockConnection, InstantTimeout, TestSpawn, test_signer,
+    },
     handler::sync::SyncHandler,
     nonce_cache::NonceCache,
     peer::{counter::PeerCounter, id::PeerId},
     policy::open::OpenPolicy,
-    sharded_map::ShardedMap,
     storage::{memory::MemoryStorage, powerbox::StoragePowerbox},
     subduction::{
         Subduction,
@@ -42,7 +44,7 @@ fn make_fragment_parts() -> (CommitId, BTreeSet<CommitId>, Vec<CommitId>, Blob) 
 
 #[tokio::test]
 async fn test_add_commit_unregisters_connection_on_send_failure() -> TestResult {
-    let sedimentrees = Arc::new(ShardedMap::with_key(0, 0));
+    let sedimentrees = Arc::new(BoundedShardedMap::with_key(0, 0));
     let connections = Arc::new(Mutex::new(Map::new()));
     let subscriptions = Arc::new(Mutex::new(Map::new()));
     let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));
@@ -101,7 +103,7 @@ async fn test_add_commit_unregisters_connection_on_send_failure() -> TestResult 
 
 #[tokio::test]
 async fn test_add_fragment_unregisters_connection_on_send_failure() -> TestResult {
-    let sedimentrees = Arc::new(ShardedMap::with_key(0, 0));
+    let sedimentrees = Arc::new(BoundedShardedMap::with_key(0, 0));
     let connections = Arc::new(Mutex::new(Map::new()));
     let subscriptions = Arc::new(Mutex::new(Map::new()));
     let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));
@@ -166,7 +168,7 @@ async fn test_add_fragment_unregisters_connection_on_send_failure() -> TestResul
 
 #[tokio::test]
 async fn test_request_blobs_unregisters_connection_on_send_failure() -> TestResult {
-    let sedimentrees = Arc::new(ShardedMap::with_key(0, 0));
+    let sedimentrees = Arc::new(BoundedShardedMap::with_key(0, 0));
     let connections = Arc::new(Mutex::new(Map::new()));
     let subscriptions = Arc::new(Mutex::new(Map::new()));
     let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));
@@ -225,7 +227,7 @@ async fn test_request_blobs_unregisters_connection_on_send_failure() -> TestResu
 
 #[tokio::test]
 async fn test_multiple_connections_only_failing_ones_removed() -> TestResult {
-    let sedimentrees = Arc::new(ShardedMap::with_key(0, 0));
+    let sedimentrees = Arc::new(BoundedShardedMap::with_key(0, 0));
     let connections = Arc::new(Mutex::new(Map::new()));
     let subscriptions = Arc::new(Mutex::new(Map::new()));
     let storage = StoragePowerbox::new(MemoryStorage::new(), Arc::new(OpenPolicy));

--- a/subduction_core/tests/connection_cleanup.rs
+++ b/subduction_core/tests/connection_cleanup.rs
@@ -11,9 +11,7 @@ use sedimentree_core::{
 };
 use subduction_core::{
     collections::bounded_sharded_map::BoundedShardedMap,
-    connection::test_utils::{
-        FailingSendMockConnection, InstantTimeout, TestSpawn, test_signer,
-    },
+    connection::test_utils::{FailingSendMockConnection, InstantTimeout, TestSpawn, test_signer},
     handler::sync::SyncHandler,
     nonce_cache::NonceCache,
     peer::{counter::PeerCounter, id::PeerId},

--- a/subduction_core/tests/lru_eviction.rs
+++ b/subduction_core/tests/lru_eviction.rs
@@ -1,0 +1,297 @@
+//! The in-memory sedimentree map is a bounded LRU cache over durable
+//! storage. These tests prove that *eviction is transparent*: once a cold
+//! tree has been pushed out of memory, the public read paths must still
+//! return its real contents by re-hydrating from storage — never an empty
+//! tree, and never a "not found".
+//!
+//! This is the correctness guarantee the OOM fix depends on: bounding the
+//! resident set must not change observable behaviour.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::Blob, commit::CountLeadingZeroBytes, id::SedimentreeId, loose_commit::id::CommitId,
+};
+use subduction_core::{
+    connection::test_utils::{MockConnection, TokioSpawn, TokioTimeout},
+    handler::sync::SyncHandler,
+    policy::open::OpenPolicy,
+    storage::memory::MemoryStorage,
+    subduction::{Subduction, builder::SubductionBuilder},
+};
+use subduction_crypto::signer::memory::MemorySigner;
+use testresult::TestResult;
+
+type Conn = MockConnection;
+type TestSyncHandler =
+    SyncHandler<Sendable, MemoryStorage, Conn, OpenPolicy, CountLeadingZeroBytes>;
+type TestSubduction = Arc<
+    Subduction<
+        'static,
+        Sendable,
+        MemoryStorage,
+        Conn,
+        TestSyncHandler,
+        OpenPolicy,
+        MemorySigner,
+        TokioTimeout,
+    >,
+>;
+
+/// Build a node whose in-memory sedimentree cache is capped at `cap`
+/// resident trees.
+fn capped_node(cap: usize) -> TestSubduction {
+    let (sd, _h, listener, manager) = SubductionBuilder::new()
+        .signer(MemorySigner::from_bytes(&[7u8; 32]))
+        .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(TokioTimeout)
+        .max_resident_trees(cap)
+        .build::<Sendable, Conn>();
+    tokio::spawn(listener);
+    tokio::spawn(manager);
+    sd
+}
+
+/// Distinct sedimentree id derived from a 32-bit seed (the first four
+/// bytes), giving plenty of distinct trees to overflow the cache.
+fn sid(n: u32) -> SedimentreeId {
+    let mut bytes = [0u8; 32];
+    bytes[0..4].copy_from_slice(&n.to_le_bytes());
+    SedimentreeId::new(bytes)
+}
+
+/// Distinct commit head derived from a 32-bit seed.
+fn commit_id(n: u32) -> CommitId {
+    let mut bytes = [0u8; 32];
+    bytes[0..4].copy_from_slice(&n.to_le_bytes());
+    bytes[4] = 0x01; // keep distinct from any sedimentree-id byte pattern
+    CommitId::new(bytes)
+}
+
+fn blob(seed: u32) -> Blob {
+    let base = seed.to_le_bytes()[0];
+    Blob::new((0..48).map(|i| base.wrapping_add(i)).collect::<Vec<u8>>())
+}
+
+/// Store a single commit in tree `id`, returning its head.
+async fn store_one_commit(
+    sd: &TestSubduction,
+    id: SedimentreeId,
+    head_seed: u32,
+) -> TestResult<CommitId> {
+    let head_id = commit_id(head_seed);
+    sd.store_commit(id, head_id, BTreeSet::new(), blob(head_seed))
+        .await?;
+    Ok(head_id)
+}
+
+/// Total number of sedimentrees currently resident in the in-memory cache.
+async fn resident_count(sd: &TestSubduction) -> usize {
+    sd.sedimentrees().len().await
+}
+
+/// Number of trees to store. The builder uses the default 256 shards;
+/// `with_capacity(cap)` with `cap < 256` floors at 1 tree per shard, so the
+/// resident set can never exceed 256. Storing comfortably more than that
+/// guarantees the cache overflows and trees are genuinely evicted —
+/// regardless of how the `SipHash` distributes them across shards. (600 keeps
+/// the margin while bounding test runtime.)
+const STORE_COUNT: u32 = 600;
+const SHARD_COUNT: usize = 256; // SubductionBuilder default
+
+/// After far more trees than the cache can hold are stored, a previously
+/// stored tree is evicted from memory yet must still return its real
+/// commits, fragments and heads via the public getters (re-hydration).
+///
+/// This test *asserts* eviction actually happened (resident count is
+/// bounded well below the number stored, and the target tree is verifiably
+/// non-resident) before exercising the rehydrate path — so a regression
+/// that broke eviction would fail here rather than silently pass.
+#[tokio::test]
+async fn reads_after_eviction_rehydrate_from_storage() -> TestResult {
+    let sd = capped_node(4); // 4 / 256 shards → ≤ 1 per shard → ≤ 256 resident
+
+    // Tree A: store a distinctive commit first, so it is the oldest and a
+    // prime eviction candidate once the cache fills.
+    let a = sid(0xA000_0000);
+    let a_head = store_one_commit(&sd, a, 0x1111_1111).await?;
+
+    // Confirm it reads back while resident.
+    let commits = sd.get_commits(a).await.expect("A exists");
+    assert_eq!(commits.len(), 1);
+    assert_eq!(commits[0].head(), a_head);
+
+    // Flood with far more trees than can be resident.
+    for n in 0..STORE_COUNT {
+        store_one_commit(&sd, sid(n), n.wrapping_add(1)).await?;
+    }
+
+    // Assert eviction really happened: the resident set is capped at one
+    // tree per shard, so it is far below the number stored.
+    let resident = resident_count(&sd).await;
+    assert!(
+        resident <= SHARD_COUNT,
+        "resident set ({resident}) must not exceed the per-shard cap ceiling ({SHARD_COUNT})"
+    );
+    assert!(
+        resident < STORE_COUNT as usize,
+        "resident set ({resident}) must be far below the {STORE_COUNT} stored trees"
+    );
+
+    // And specifically: A is no longer resident (it was the oldest). If it
+    // somehow is, evict it explicitly so the read below provably takes the
+    // rehydrate path; assert at least that the cache is genuinely bounded.
+    if sd.sedimentrees().get_cloned(&a).await.is_some() {
+        // Extremely unlikely (A is oldest and the cache is full), but make
+        // the rehydrate path deterministic regardless of hash distribution.
+        sd.sedimentrees().remove(&a).await;
+    }
+    assert!(
+        sd.sedimentrees().get_cloned(&a).await.is_none(),
+        "A must be non-resident before the rehydrating read"
+    );
+
+    // The getter must STILL return A's real contents, transparently
+    // re-hydrating from storage.
+    let commits = sd
+        .get_commits(a)
+        .await
+        .expect("A must still be readable after eviction (re-hydrate)");
+    assert_eq!(commits.len(), 1, "evicted tree must rehydrate its commit");
+    assert_eq!(
+        commits[0].head(),
+        a_head,
+        "rehydrated commit must be the original, not empty/default"
+    );
+
+    // Fragments getter: A has none, but the tree EXISTS, so this must be
+    // Some(empty), not None.
+    let frags = sd.get_fragments(a).await;
+    assert!(
+        frags.is_some(),
+        "existing tree must not read as nonexistent"
+    );
+
+    Ok(())
+}
+
+/// `sedimentree_ids` must list every stored tree, including ones evicted
+/// from the in-memory cache (it enumerates from durable storage).
+#[tokio::test]
+async fn sedimentree_ids_complete_across_eviction() -> TestResult {
+    let sd = capped_node(4);
+
+    let mut stored = BTreeSet::new();
+    for n in 0..STORE_COUNT {
+        let id = sid(n);
+        store_one_commit(&sd, id, n.wrapping_add(100)).await?;
+        stored.insert(id);
+    }
+
+    // Confirm the cache genuinely evicted (resident ≪ stored), so the
+    // completeness assertion below is meaningful rather than vacuous.
+    let resident = resident_count(&sd).await;
+    assert!(
+        resident < stored.len(),
+        "cache must have evicted: resident ({resident}) < stored ({})",
+        stored.len()
+    );
+
+    // Enumeration must still report ALL stored trees, not just resident ones.
+    let listed: BTreeSet<SedimentreeId> = sd.sedimentree_ids().await.into_iter().collect();
+    assert_eq!(
+        listed, stored,
+        "sedimentree_ids must enumerate ALL stored trees from storage, \
+         not just the resident set"
+    );
+
+    Ok(())
+}
+
+/// Writing to a tree *after it has been evicted* must preserve its prior
+/// history: the write path has to hydrate the full tree from storage before
+/// adding, not start from an empty default. Otherwise the resident tree
+/// becomes a partial view (only the latest commit) and `add_commit` would
+/// broadcast wrong heads.
+///
+/// This is the regression test for the write-path partial-tree bug.
+#[tokio::test]
+async fn write_after_eviction_preserves_prior_history() -> TestResult {
+    let sd = capped_node(4); // ≤ 256 resident
+
+    // Store commit #1 into tree A.
+    let a = sid(0xA111_0000);
+    let h1 = store_one_commit(&sd, a, 0x1111_0001).await?;
+
+    // Flood to evict A.
+    for n in 0..STORE_COUNT {
+        store_one_commit(&sd, sid(n), n.wrapping_add(1)).await?;
+    }
+    // Deterministically ensure A is not resident before the second write.
+    sd.sedimentrees().remove(&a).await;
+    assert!(
+        sd.sedimentrees().get_cloned(&a).await.is_none(),
+        "A must be evicted before the second write"
+    );
+
+    // Store commit #2 into the SAME tree A while it is evicted.
+    let h2 = store_one_commit(&sd, a, 0x1111_0002).await?;
+
+    // Both commits must be present: the write hydrated A's full history
+    // (h1) before adding h2, rather than starting from an empty tree.
+    let commits = sd
+        .get_commits(a)
+        .await
+        .expect("A must exist after the second write");
+    let heads: BTreeSet<CommitId> = commits
+        .iter()
+        .map(sedimentree_core::loose_commit::LooseCommit::head)
+        .collect();
+    assert!(
+        heads.contains(&h1),
+        "the pre-eviction commit must survive a write-after-eviction \
+         (got heads {heads:?})"
+    );
+    assert!(
+        heads.contains(&h2),
+        "the newly-written commit must be present"
+    );
+    assert_eq!(heads.len(), 2, "exactly the two stored commits, no loss");
+
+    Ok(())
+}
+
+/// A nonexistent tree still reads as `None` (the getters distinguish
+/// "evicted but exists" from "never stored").
+///
+/// The stored tree acts as a positive control: without it, a regression
+/// that returned `None` for *every* id (including stored ones) would still
+/// pass the `is_none` assertions and falsely look correct.
+#[tokio::test]
+async fn nonexistent_tree_reads_as_none() -> TestResult {
+    let sd = capped_node(4);
+    let stored = sid(1);
+    let head = store_one_commit(&sd, stored, 1).await?;
+
+    // Positive control: a stored id must read as `Some` with its real commit.
+    let commits = sd
+        .get_commits(stored)
+        .await
+        .expect("stored tree must read as Some");
+    assert_eq!(commits.len(), 1);
+    assert_eq!(commits[0].head(), head);
+    assert!(
+        sd.get_fragments(stored).await.is_some(),
+        "stored tree must read as Some(empty), not None"
+    );
+
+    // Negative: a never-stored id reads as `None` on both getters.
+    assert!(sd.get_commits(sid(0xDEAD_BEEF)).await.is_none());
+    assert!(sd.get_fragments(sid(0xDEAD_BEEF)).await.is_none());
+
+    Ok(())
+}

--- a/subduction_crypto/Cargo.toml
+++ b/subduction_crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_crypto"
-version = "0.7.1"
+version = "0.8.0"
 description = "Cryptographic types for Subduction: signed payloads, verification witnesses"
 
 authors.workspace = true

--- a/subduction_ephemeral/Cargo.toml
+++ b/subduction_ephemeral/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_ephemeral"
-version = "0.6.2"
+version = "0.7.0"
 description = "Ephemeral (non-persisted) messaging for Subduction"
 
 categories = ["web-programming"]

--- a/subduction_http_longpoll/Cargo.toml
+++ b/subduction_http_longpoll/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_http_longpoll"
-version = "0.9.1"
+version = "0.10.0"
 description = "HTTP long-poll transport layer for the Subduction sync protocol"
 
 categories = ["web-programming"]

--- a/subduction_iroh/Cargo.toml
+++ b/subduction_iroh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_iroh"
-version = "0.8.1"
+version = "0.9.0"
 description = "Iroh (QUIC) transport layer for the Subduction sync protocol"
 
 categories = ["network-programming"]

--- a/subduction_keyhive/Cargo.toml
+++ b/subduction_keyhive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_keyhive"
-version = "0.6.0"
+version = "0.7.0"
 description = "Keyhive protocol"
 
 categories = ["web-programming"]

--- a/subduction_wasm/Cargo.toml
+++ b/subduction_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_wasm"
-version = "0.17.0"
+version = "0.18.0"
 description = "Wasm/JavaScript bindings for Subduction (browser and Node.js)"
 categories = ["web-programming"]
 keywords = ["subduction", "websocket"]

--- a/subduction_wasm/e2e/ephemeral.spec.ts
+++ b/subduction_wasm/e2e/ephemeral.spec.ts
@@ -165,13 +165,14 @@ async function setupPeer(
       window.syncer = new Subduction(
         signer,
         new MemoryStorage(),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        callback
+        null, // service_name
+        null, // hash_metric_override
+        null, // max_pending_blob_requests
+        null, // max_resident_trees
+        null, // policy
+        null, // ephemeral_policy
+        null, // on_remote_heads
+        callback // on_ephemeral
       );
 
       const url = new URL(wsUrl);

--- a/subduction_wasm/e2e/subduction.spec.ts
+++ b/subduction_wasm/e2e/subduction.spec.ts
@@ -25,7 +25,7 @@ test.describe("Subduction", () => {
       expect(result.hasStorage).toBe(true);
     });
 
-    test("should hydrate Subduction from existing storage", async ({ page }) => {
+    test("a second node over the same storage sees persisted trees", async ({ page }) => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
@@ -34,7 +34,7 @@ test.describe("Subduction", () => {
         const syncer1 = new Subduction(signer, storage);
         const ids1 = await syncer1.sedimentreeIds();
 
-        const syncer2 = await Subduction.hydrate(signer, storage);
+        const syncer2 = new Subduction(signer, storage);
         const ids2 = await syncer2.sedimentreeIds();
 
         return {
@@ -758,8 +758,8 @@ test.describe("Subduction", () => {
     });
   });
 
-  test.describe("Hydration", () => {
-    test("should persist and retrieve commits across hydrate", async ({ page }) => {
+  test.describe("Cross-instance persistence", () => {
+    test("persists and retrieves commits across a new instance", async ({ page }) => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
@@ -775,8 +775,8 @@ test.describe("Subduction", () => {
         const commitCountBefore = commitsBefore ? commitsBefore.length : 0;
         const blobMetaSizeBefore = commitsBefore ? Number(commitsBefore[0].blobMeta.sizeBytes) : 0;
 
-        // Hydrate a new instance from the same storage
-        const syncer2 = await Subduction.hydrate(signer, storage);
+        // A new instance over the same storage hydrates on demand.
+        const syncer2 = new Subduction(signer, storage);
         const idsAfter = await syncer2.sedimentreeIds();
         const commitsAfter = await syncer2.getCommits(sedId);
         const commitCountAfter = commitsAfter ? commitsAfter.length : 0;
@@ -800,7 +800,7 @@ test.describe("Subduction", () => {
       expect(result.blobMetaSizeAfter).toBe(3);
     });
 
-    test("should hydrate multiple sedimentrees correctly", async ({ page }) => {
+    test("a new instance reads multiple persisted sedimentrees correctly", async ({ page }) => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } =
           window.subduction;
@@ -827,8 +827,8 @@ test.describe("Subduction", () => {
         // Verify initial state
         const idsBefore = await syncer1.sedimentreeIds();
 
-        // Hydrate a new instance from the same storage
-        const syncer2 = await Subduction.hydrate(signer, storage);
+        // A new instance over the same storage hydrates on demand.
+        const syncer2 = new Subduction(signer, storage);
         const idsAfter = await syncer2.sedimentreeIds();
 
         // Verify all 3 sedimentrees loaded with correct commit counts

--- a/subduction_wasm/package.json
+++ b/subduction_wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automerge/subduction",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Wasm/JavaScript bindings for Subduction (browser and Node.js)",
   "publishConfig": {
     "access": "public"

--- a/subduction_wasm/playwright.config.ts
+++ b/subduction_wasm/playwright.config.ts
@@ -17,8 +17,14 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* Retry once on CI (a single retry absorbs genuine flakes without letting a
+   * systemic failure multiply the runtime). */
+  retries: process.env.CI ? 1 : 0,
+  /* Fail fast on CI: a mass failure (e.g. a broken constructor causing every
+   * test to time out) should abort quickly rather than burning ~30 min running
+   * every test to its timeout and retrying. A handful of genuine flakes stays
+   * under this bound. */
+  maxFailures: process.env.CI ? 5 : undefined,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -9,7 +9,7 @@ use alloc::{
 };
 use async_lock::Mutex;
 use core::{fmt::Debug, time::Duration};
-use sedimentree_core::collections::{Map, Set};
+use sedimentree_core::collections::Map;
 
 use from_js_ref::FromJsRef;
 use future_form::Local;
@@ -26,7 +26,6 @@ use sedimentree_core::{
     depth::{Depth, DepthMetric},
     id::SedimentreeId,
     loose_commit::id::CommitId,
-    sedimentree::{Sedimentree, minimized::MinimizedSedimentree},
 };
 use subduction_core::{
     collections::bounded_sharded_map::BoundedShardedMap,
@@ -38,7 +37,6 @@ use subduction_core::{
     storage::powerbox::StoragePowerbox,
     subduction::{
         Subduction,
-        error::HydrationError,
         pending_blob_requests::{DEFAULT_MAX_PENDING_BLOB_REQUESTS, PendingBlobRequests},
     },
     timestamp::TimestampSeconds,
@@ -59,7 +57,7 @@ use crate::{
     batch_input::{WasmCommitInput, WasmFragmentInput},
     error::{
         WasmAddConnectionError, WasmConnectError, WasmDisconnectionError, WasmHandshakeError,
-        WasmHydrationError, WasmIoError, WasmLongPollConnectError, WasmWriteError,
+        WasmIoError, WasmLongPollConnectError, WasmWriteError,
     },
     fragment::WasmFragmentRequested,
     peer_id::WasmPeerId,
@@ -311,221 +309,6 @@ impl WasmSubduction {
             ephemeral_handler: ephemeral_for_wasm,
             keyhive_handler,
         }
-    }
-
-    /// Hydrate a [`Subduction`] instance from external storage.
-    ///
-    /// Loads all sedimentree data from storage and reconstructs the in-memory
-    /// state before initializing the sync engine.
-    ///
-    /// # Arguments
-    ///
-    /// * `signer` - The cryptographic signer for this node's identity
-    /// * `storage` - Storage backend for persisting data
-    /// * `service_name` - Optional service identifier for discovery mode (e.g., `sync.example.com`).
-    ///   When set, clients can connect without knowing the server's peer ID.
-    /// * `hash_metric_override` - Optional custom depth metric function
-    /// * `max_pending_blob_requests` - Optional maximum number of pending blob requests (default: 10,000)
-    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
-    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
-    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
-    ///   cap is per-shard-approximate, with an effective floor of
-    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default.
-    /// * `policy` - Optional connection/storage authorization policy.
-    ///   Defaults to allow-all.
-    /// * `ephemeral_policy` - Optional ephemeral message authorization policy.
-    ///   Defaults to allow-all.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `hash_metric_override` is `Some` but the underlying JS value
-    /// cannot be cast to a `Function`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`WasmHydrationError`] if hydration fails.
-    #[wasm_bindgen]
-    #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
-    pub async fn hydrate(
-        signer: JsSigner,
-        storage: JsStorage,
-        service_name: Option<String>,
-        hash_metric_override: Option<JsToDepth>,
-        max_pending_blob_requests: Option<usize>,
-        max_resident_trees: Option<usize>,
-        policy: Option<JsPolicy>,
-        ephemeral_policy: Option<JsEphemeralPolicy>,
-        on_remote_heads: Option<js_sys::Function>,
-        on_ephemeral: Option<js_sys::Function>,
-    ) -> Result<Self, WasmHydrationError> {
-        use subduction_core::storage::traits::Storage as _;
-
-        tracing::debug!("hydrating new Subduction node");
-        let js_storage = <JsStorage as AsRef<JsValue>>::as_ref(&storage).clone();
-        #[allow(clippy::expect_used)]
-        let raw_fn: Option<js_sys::Function> = hash_metric_override.map(|h| {
-            JsValue::from(h)
-                .dyn_into()
-                .expect("hash_metric_override is not a Function")
-        });
-        let discovery_id = service_name.map(|name| DiscoveryId::new(name.as_bytes()));
-        let depth_metric = WasmHashMetric(raw_fn);
-        let max_pending = max_pending_blob_requests.unwrap_or(DEFAULT_MAX_PENDING_BLOB_REQUESTS);
-        // `None` or an explicit `0` falls back to the default cap.
-        let max_resident = match max_resident_trees {
-            Some(n) if n > 0 => n,
-            _ => WASM_DEFAULT_MAX_RESIDENT_TREES,
-        };
-
-        // Load sedimentree IDs from raw storage before wrapping in powerbox
-        let ids: Set<SedimentreeId> = storage
-            .load_all_sedimentree_ids()
-            .await
-            .map_err(HydrationError::LoadAllIdsError)?;
-
-        // Hydrate sedimentrees from storage.
-        //
-        // Each sedimentree is loaded concurrently — commits and fragments
-        // for each ID are independent and can overlap their IndexedDB reads.
-        // Within each sedimentree, commits and fragments are loaded in
-        // parallel via `try_join`.
-        let sedimentrees = Arc::new(BoundedShardedMap::new().with_capacity(max_resident));
-        let loaded: Vec<_> = futures::future::try_join_all(ids.iter().map(|&id| {
-            let storage = &storage;
-            async move {
-                let (commits, fragments) = futures::future::try_join(
-                    async {
-                        storage
-                            .load_loose_commits(id)
-                            .await
-                            .map_err(HydrationError::LoadLooseCommitsError)
-                    },
-                    async {
-                        storage
-                            .load_fragments(id)
-                            .await
-                            .map_err(HydrationError::LoadFragmentsError)
-                    },
-                )
-                .await?;
-
-                let loose_commits: Vec<_> =
-                    commits.into_iter().map(|v| v.payload().clone()).collect();
-                let fragments: Vec<_> =
-                    fragments.into_iter().map(|v| v.payload().clone()).collect();
-
-                Ok::<_, HydrationError<Local, JsStorage>>((
-                    id,
-                    Sedimentree::new(fragments, loose_commits),
-                ))
-            }
-        }))
-        .await?;
-
-        // Merge + minimize sequentially (BoundedShardedMap access is per entry).
-        for (id, sedimentree) in loaded {
-            sedimentrees
-                .with_entry_or_default(id, |tree: &mut MinimizedSedimentree| {
-                    tree.merge(sedimentree);
-                })
-                .await;
-            sedimentrees
-                .with_entry(&id, |tree| {
-                    tree.ensure_minimized(&depth_metric);
-                })
-                .await;
-        }
-
-        let policy = policy.unwrap_or_else(make_open_policy);
-
-        let connections = Arc::new(Mutex::new(Map::new()));
-        let subscriptions = Arc::new(Mutex::new(Map::new()));
-        let pending_blob_requests = Arc::new(Mutex::new(PendingBlobRequests::new(max_pending)));
-        let powerbox = StoragePowerbox::new(storage, Arc::new(policy));
-
-        let observer = match on_remote_heads {
-            Some(f) => crate::remote_heads::JsRemoteHeadsObserver::with_callback(f),
-            None => crate::remote_heads::JsRemoteHeadsObserver::new(),
-        };
-        let sync_handler = SyncHandler::with_remote_heads_observer(
-            sedimentrees.clone(),
-            connections.clone(),
-            subscriptions.clone(),
-            powerbox.clone(),
-            pending_blob_requests.clone(),
-            depth_metric.clone(),
-            observer.clone(),
-        );
-
-        let eph_policy = ephemeral_policy.unwrap_or_else(make_open_ephemeral_policy);
-        let (ephemeral_handler, ephemeral_rx) = EphemeralHandler::new(
-            connections.clone(),
-            eph_policy,
-            EphemeralConfig::default(),
-            JsClock,
-        );
-        let ephemeral_for_wasm = ephemeral_handler.clone();
-
-        let send_counter = sync_handler.send_counter().clone();
-        let keyhive_handler = Arc::new(Mutex::new(None));
-        let handler = Arc::new(WasmComposedHandler::new(
-            sync_handler,
-            ephemeral_handler,
-            WasmKeyhiveHandler::new(keyhive_handler.clone()),
-        ));
-
-        let (core, listener_fut, manager_fut) = Subduction::new(
-            handler,
-            discovery_id,
-            signer,
-            sedimentrees,
-            connections,
-            subscriptions,
-            powerbox,
-            pending_blob_requests,
-            send_counter,
-            NonceCache::default(),
-            JsTimeout,
-            Duration::from_secs(30),
-            depth_metric,
-            WasmSpawn,
-        );
-
-        wasm_bindgen_futures::spawn_local(async move {
-            let manager = manager_fut.fuse();
-            let listener = listener_fut.fuse();
-
-            match select(manager, listener).await {
-                Either::Left((manager_result, _pin)) => {
-                    if let Err(Aborted) = manager_result {
-                        tracing::error!("Subduction manager aborted");
-                    }
-                }
-                Either::Right((listener_result, _pin)) => {
-                    if let Err(Aborted) = listener_result {
-                        tracing::error!("Subduction listener aborted");
-                    }
-                }
-            }
-        });
-
-        // Always drain the ephemeral channel to prevent "channel full" warnings
-        // in EphemeralHandler when no JS callback is registered.
-        let observer = on_ephemeral.map(crate::ephemeral::JsEphemeralObserver::new);
-        wasm_bindgen_futures::spawn_local(async move {
-            while let Ok(event) = ephemeral_rx.recv().await {
-                if let Some(ref obs) = observer {
-                    obs.on_event(event.id, event.sender, &event.payload);
-                }
-            }
-        });
-
-        Ok(Self {
-            core,
-            js_storage,
-            ephemeral_handler: ephemeral_for_wasm,
-            keyhive_handler,
-        })
     }
 
     /// Persist a whole [`Sedimentree`](sedimentree_wasm::WasmSedimentree)

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -172,18 +172,18 @@ impl WasmSubduction {
     ///   When set, clients can connect without knowing the server's peer ID.
     /// * `hash_metric_override` - Optional custom depth metric function
     /// * `max_pending_blob_requests` - Optional maximum number of pending blob requests (default: 10,000)
+    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
+    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
+    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
+    ///   cap is per-shard-approximate, with an effective floor of
+    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default. Grouped with
+    ///   `max_pending_blob_requests` as the capacity/tuning knobs.
     /// * `policy` - Optional connection/storage authorization policy.
     ///   Defaults to allow-all.
     /// * `ephemeral_policy` - Optional ephemeral message authorization policy.
     ///   Defaults to allow-all.
     /// * `on_remote_heads` - Optional callback fired when a peer's heads change.
     /// * `on_ephemeral` - Optional callback fired on inbound ephemeral messages.
-    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
-    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
-    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
-    ///   cap is per-shard-approximate, with an effective floor of
-    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default. This is the
-    ///   last positional argument so existing call sites stay valid.
     ///
     /// # Panics
     ///
@@ -198,11 +198,11 @@ impl WasmSubduction {
         service_name: Option<String>,
         hash_metric_override: Option<JsToDepth>,
         max_pending_blob_requests: Option<usize>,
+        max_resident_trees: Option<usize>,
         policy: Option<JsPolicy>,
         ephemeral_policy: Option<JsEphemeralPolicy>,
         on_remote_heads: Option<js_sys::Function>,
         on_ephemeral: Option<js_sys::Function>,
-        max_resident_trees: Option<usize>,
     ) -> Self {
         tracing::debug!("new Subduction node");
         let js_storage = <JsStorage as AsRef<JsValue>>::as_ref(&storage).clone();

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -29,12 +29,12 @@ use sedimentree_core::{
     sedimentree::{Sedimentree, minimized::MinimizedSedimentree},
 };
 use subduction_core::{
+    collections::bounded_sharded_map::BoundedShardedMap,
     connection::manager::Spawn,
     handler::sync::SyncHandler,
     handshake::audience::DiscoveryId,
     nonce_cache::NonceCache,
     peer::id::PeerId,
-    sharded_map::ShardedMap,
     storage::powerbox::StoragePowerbox,
     subduction::{
         Subduction,
@@ -90,6 +90,16 @@ use futures::{
 
 /// Number of shards for the sedimentree map in Wasm (smaller for client-side).
 pub(crate) const WASM_SHARD_COUNT: usize = 4;
+
+/// Default cap on the number of sedimentrees kept resident in memory in the
+/// browser.
+///
+/// The in-memory sedimentree map is an LRU cache over `IndexedDB`: cold trees
+/// are evicted and re-hydrated on demand. A browser tab has a far tighter
+/// memory budget (and a hard wasm32 address-space ceiling) than a server,
+/// so the default resident set is small. At a few tens of KiB of metadata
+/// per tree this is on the order of ~90 MiB resident.
+pub(crate) const WASM_DEFAULT_MAX_RESIDENT_TREES: usize = 1_024;
 
 /// A spawner that uses wasm-bindgen-futures to spawn local tasks.
 #[derive(Debug, Clone, Copy, Default)]
@@ -164,6 +174,11 @@ impl WasmSubduction {
     ///   When set, clients can connect without knowing the server's peer ID.
     /// * `hash_metric_override` - Optional custom depth metric function
     /// * `max_pending_blob_requests` - Optional maximum number of pending blob requests (default: 10,000)
+    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
+    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
+    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
+    ///   cap is per-shard-approximate, with an effective floor of
+    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default.
     /// * `policy` - Optional connection/storage authorization policy.
     ///   Defaults to allow-all.
     /// * `ephemeral_policy` - Optional ephemeral message authorization policy.
@@ -182,6 +197,7 @@ impl WasmSubduction {
         service_name: Option<String>,
         hash_metric_override: Option<JsToDepth>,
         max_pending_blob_requests: Option<usize>,
+        max_resident_trees: Option<usize>,
         policy: Option<JsPolicy>,
         ephemeral_policy: Option<JsEphemeralPolicy>,
         on_remote_heads: Option<js_sys::Function>,
@@ -198,12 +214,17 @@ impl WasmSubduction {
         let discovery_id = service_name.map(|name| DiscoveryId::new(name.as_bytes()));
         let depth_metric = WasmHashMetric(raw_fn);
         let max_pending = max_pending_blob_requests.unwrap_or(DEFAULT_MAX_PENDING_BLOB_REQUESTS);
+        // `None` or an explicit `0` falls back to the default cap.
+        let max_resident = match max_resident_trees {
+            Some(n) if n > 0 => n,
+            _ => WASM_DEFAULT_MAX_RESIDENT_TREES,
+        };
 
         let policy = policy.unwrap_or_else(make_open_policy);
 
         let connections = Arc::new(Mutex::new(Map::new()));
         let subscriptions = Arc::new(Mutex::new(Map::new()));
-        let sedimentrees = Arc::new(ShardedMap::new());
+        let sedimentrees = Arc::new(BoundedShardedMap::new().with_capacity(max_resident));
         let pending_blob_requests = Arc::new(Mutex::new(PendingBlobRequests::new(max_pending)));
         let powerbox = StoragePowerbox::new(storage, Arc::new(policy));
 
@@ -305,6 +326,11 @@ impl WasmSubduction {
     ///   When set, clients can connect without knowing the server's peer ID.
     /// * `hash_metric_override` - Optional custom depth metric function
     /// * `max_pending_blob_requests` - Optional maximum number of pending blob requests (default: 10,000)
+    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
+    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
+    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
+    ///   cap is per-shard-approximate, with an effective floor of
+    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default.
     /// * `policy` - Optional connection/storage authorization policy.
     ///   Defaults to allow-all.
     /// * `ephemeral_policy` - Optional ephemeral message authorization policy.
@@ -326,6 +352,7 @@ impl WasmSubduction {
         service_name: Option<String>,
         hash_metric_override: Option<JsToDepth>,
         max_pending_blob_requests: Option<usize>,
+        max_resident_trees: Option<usize>,
         policy: Option<JsPolicy>,
         ephemeral_policy: Option<JsEphemeralPolicy>,
         on_remote_heads: Option<js_sys::Function>,
@@ -344,6 +371,11 @@ impl WasmSubduction {
         let discovery_id = service_name.map(|name| DiscoveryId::new(name.as_bytes()));
         let depth_metric = WasmHashMetric(raw_fn);
         let max_pending = max_pending_blob_requests.unwrap_or(DEFAULT_MAX_PENDING_BLOB_REQUESTS);
+        // `None` or an explicit `0` falls back to the default cap.
+        let max_resident = match max_resident_trees {
+            Some(n) if n > 0 => n,
+            _ => WASM_DEFAULT_MAX_RESIDENT_TREES,
+        };
 
         // Load sedimentree IDs from raw storage before wrapping in powerbox
         let ids: Set<SedimentreeId> = storage
@@ -357,7 +389,7 @@ impl WasmSubduction {
         // for each ID are independent and can overlap their IndexedDB reads.
         // Within each sedimentree, commits and fragments are loaded in
         // parallel via `try_join`.
-        let sedimentrees = Arc::new(ShardedMap::new());
+        let sedimentrees = Arc::new(BoundedShardedMap::new().with_capacity(max_resident));
         let loaded: Vec<_> = futures::future::try_join_all(ids.iter().map(|&id| {
             let storage = &storage;
             async move {
@@ -390,7 +422,7 @@ impl WasmSubduction {
         }))
         .await?;
 
-        // Merge + minimize sequentially (ShardedMap access is &mut per entry).
+        // Merge + minimize sequentially (BoundedShardedMap access is per entry).
         for (id, sedimentree) in loaded {
             sedimentrees
                 .with_entry_or_default(id, |tree: &mut MinimizedSedimentree| {

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -172,15 +172,18 @@ impl WasmSubduction {
     ///   When set, clients can connect without knowing the server's peer ID.
     /// * `hash_metric_override` - Optional custom depth metric function
     /// * `max_pending_blob_requests` - Optional maximum number of pending blob requests (default: 10,000)
-    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
-    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
-    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
-    ///   cap is per-shard-approximate, with an effective floor of
-    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default.
     /// * `policy` - Optional connection/storage authorization policy.
     ///   Defaults to allow-all.
     /// * `ephemeral_policy` - Optional ephemeral message authorization policy.
     ///   Defaults to allow-all.
+    /// * `on_remote_heads` - Optional callback fired when a peer's heads change.
+    /// * `on_ephemeral` - Optional callback fired on inbound ephemeral messages.
+    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
+    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
+    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
+    ///   cap is per-shard-approximate, with an effective floor of
+    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default. This is the
+    ///   last positional argument so existing call sites stay valid.
     ///
     /// # Panics
     ///
@@ -195,11 +198,11 @@ impl WasmSubduction {
         service_name: Option<String>,
         hash_metric_override: Option<JsToDepth>,
         max_pending_blob_requests: Option<usize>,
-        max_resident_trees: Option<usize>,
         policy: Option<JsPolicy>,
         ephemeral_policy: Option<JsEphemeralPolicy>,
         on_remote_heads: Option<js_sys::Function>,
         on_ephemeral: Option<js_sys::Function>,
+        max_resident_trees: Option<usize>,
     ) -> Self {
         tracing::debug!("new Subduction node");
         let js_storage = <JsStorage as AsRef<JsValue>>::as_ref(&storage).clone();

--- a/subduction_websocket/Cargo.toml
+++ b/subduction_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subduction_websocket"
-version = "0.10.1"
+version = "0.11.0"
 description = "WebSocket transport layer for the Subduction sync protocol"
 
 categories = ["web-programming"]


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

- The LRU cache that we keep pushing off because "we'll hit that scale eventually" is here
- Seeing some OOMs on the server, this is the most obvious area of unbounded growth

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
