### PR TITLE
Remove tree scan metrics

### DIFF
--- a/subduction_cli/monitoring/grafana/provisioning/dashboards/subduction.json
+++ b/subduction_cli/monitoring/grafana/provisioning/dashboards/subduction.json
@@ -526,7 +526,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 29 },
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 29 },
       "id": 11,
       "options": {
         "colorMode": "value",
@@ -549,90 +549,6 @@
         }
       ],
       "title": "Sedimentrees",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{ "color": "blue", "value": null }]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 29 },
-      "id": 12,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "subduction_storage_loose_commits_total",
-          "refId": "A"
-        }
-      ],
-      "title": "Loose Commits",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{ "color": "orange", "value": null }]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 29 },
-      "id": 13,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "subduction_storage_fragments_total",
-          "refId": "A"
-        }
-      ],
-      "title": "Fragments",
       "type": "stat"
     },
     {

--- a/subduction_core/src/metrics.rs
+++ b/subduction_core/src/metrics.rs
@@ -30,10 +30,6 @@ pub mod names {
     // Storage metrics (gauges - refreshed periodically from actual state).
     /// Current number of sedimentrees in storage.
     pub const STORAGE_SEDIMENTREES: &str = "subduction_storage_sedimentrees";
-    /// Total loose commits across all sedimentrees.
-    pub const STORAGE_LOOSE_COMMITS_TOTAL: &str = "subduction_storage_loose_commits_total";
-    /// Total fragments across all sedimentrees.
-    pub const STORAGE_FRAGMENTS_TOTAL: &str = "subduction_storage_fragments_total";
     /// Storage operation duration in seconds.
     pub const STORAGE_OPERATION_DURATION_SECONDS: &str =
         "subduction_storage_operation_duration_seconds";
@@ -127,20 +123,6 @@ pub fn set_storage_sedimentrees(count: usize) {
     metrics::gauge!(names::STORAGE_SEDIMENTREES).set(count as f64);
 }
 
-/// Set the total number of loose commits across all sedimentrees.
-#[inline]
-#[allow(clippy::cast_precision_loss)]
-pub fn set_storage_loose_commits_total(count: usize) {
-    metrics::gauge!(names::STORAGE_LOOSE_COMMITS_TOTAL).set(count as f64);
-}
-
-/// Set the total number of fragments across all sedimentrees.
-#[inline]
-#[allow(clippy::cast_precision_loss)]
-pub fn set_storage_fragments_total(count: usize) {
-    metrics::gauge!(names::STORAGE_FRAGMENTS_TOTAL).set(count as f64);
-}
-
 /// Record the duration of a storage operation.
 #[inline]
 pub fn storage_operation_duration(operation: &'static str, duration_secs: f64) {
@@ -202,14 +184,6 @@ pub fn describe_all() {
     metrics::describe_gauge!(
         names::STORAGE_SEDIMENTREES,
         "Current number of sedimentrees in persistent storage."
-    );
-    metrics::describe_gauge!(
-        names::STORAGE_LOOSE_COMMITS_TOTAL,
-        "Total loose commits across all sedimentrees in storage."
-    );
-    metrics::describe_gauge!(
-        names::STORAGE_FRAGMENTS_TOTAL,
-        "Total fragments across all sedimentrees in storage."
     );
     metrics::describe_histogram!(
         names::STORAGE_OPERATION_DURATION_SECONDS,

--- a/subduction_core/src/storage/metrics.rs
+++ b/subduction_core/src/storage/metrics.rs
@@ -70,33 +70,21 @@ impl<Store: Storage<Sendable> + Send + Sync> RefreshMetrics for MetricsStorage<S
     type Error = Store::Error;
 
     async fn refresh_metrics(&self) -> Result<(), Self::Error> {
-        let sedimentree_ids = Storage::<Sendable>::load_all_sedimentree_ids(&self.inner).await?;
-        let sedimentree_count = sedimentree_ids.len();
+        // Only the total sedimentree count is refreshed here. It is served from
+        // the backend's in-memory id set (e.g. `FsStorage`'s `ids_cache`), so
+        // this is O(1) in disk I/O regardless of tree count.
+        //
+        // We deliberately do NOT compute per-tree loose-commit / fragment
+        // totals: that required two `read_dir`s per tree, an O(trees) metadata
+        // sweep that becomes a continuous syscall storm at large tree counts
+        // (e.g. 20M `read_dir`s/minute at 10M trees on a 60s refresh).
+        let sedimentree_count =
+            Storage::<Sendable>::load_all_sedimentree_ids(&self.inner).await?.len();
 
         metrics::set_storage_sedimentrees(sedimentree_count);
 
-        let mut total_loose_commits = 0;
-        let mut total_fragments = 0;
-
-        for sedimentree_id in &sedimentree_ids {
-            // Count items per tree via identity listing.
-            // With subdirectory-based storage, this is a cheap directory scan.
-            let commit_ids =
-                Storage::<Sendable>::list_commit_ids(&self.inner, *sedimentree_id).await?;
-            let fragment_ids =
-                Storage::<Sendable>::list_fragment_ids(&self.inner, *sedimentree_id).await?;
-
-            total_loose_commits += commit_ids.len();
-            total_fragments += fragment_ids.len();
-        }
-
-        metrics::set_storage_loose_commits_total(total_loose_commits);
-        metrics::set_storage_fragments_total(total_fragments);
-
         tracing::debug!(
             sedimentrees = sedimentree_count,
-            loose_commits = total_loose_commits,
-            fragments = total_fragments,
             "Refreshed storage metrics"
         );
 

--- a/subduction_core/tests/metrics_storage.rs
+++ b/subduction_core/tests/metrics_storage.rs
@@ -21,6 +21,7 @@
 use std::collections::BTreeSet;
 
 use future_form::Sendable;
+use futures::future::BoxFuture;
 use sedimentree_core::{
     blob::{Blob, BlobMeta},
     collections::Set,
@@ -30,7 +31,11 @@ use sedimentree_core::{
 };
 use subduction_core::{
     connection::test_utils::test_signer,
-    storage::{memory::MemoryStorage, metrics::MetricsStorage, traits::Storage},
+    storage::{
+        memory::MemoryStorage,
+        metrics::{MetricsStorage, RefreshMetrics},
+        traits::Storage,
+    },
 };
 use subduction_crypto::{signed::Signed, verified_meta::VerifiedMeta};
 use testresult::TestResult;
@@ -279,5 +284,153 @@ async fn save_batch_writes_through_to_inner() -> TestResult {
         stored_fragment.is_some(),
         "save_batch should have persisted the fragment"
     );
+    Ok(())
+}
+
+// ============================================================================
+// refresh_metrics scaling guarantee
+// ============================================================================
+
+/// A storage wrapper that delegates everything to [`MemoryStorage`] except
+/// the per-tree listing calls, which `panic!`. It lets a test assert that a
+/// code path does *not* enumerate per-tree contents.
+#[derive(Clone)]
+struct ListPanicsStorage {
+    inner: MemoryStorage,
+}
+
+impl ListPanicsStorage {
+    fn new() -> Self {
+        Self {
+            inner: MemoryStorage::new(),
+        }
+    }
+}
+
+impl Storage<Sendable> for ListPanicsStorage {
+    type Error = <MemoryStorage as Storage<Sendable>>::Error;
+
+    fn save_sedimentree_id(&self, id: SedimentreeId) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::save_sedimentree_id(&self.inner, id)
+    }
+
+    fn delete_sedimentree_id(&self, id: SedimentreeId) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::delete_sedimentree_id(&self.inner, id)
+    }
+
+    fn load_all_sedimentree_ids(&self) -> BoxFuture<'_, Result<Set<SedimentreeId>, Self::Error>> {
+        Storage::<Sendable>::load_all_sedimentree_ids(&self.inner)
+    }
+
+    fn save_loose_commit(
+        &self,
+        id: SedimentreeId,
+        verified: VerifiedMeta<LooseCommit>,
+    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::save_loose_commit(&self.inner, id, verified)
+    }
+
+    // The metrics refresh must NOT call this: it would be an O(trees) per-tree
+    // directory sweep. Panicking here turns a regression that re-introduces the
+    // sweep into a hard test failure — the panic is the assertion.
+    #[allow(clippy::panic)]
+    fn list_commit_ids(&self, _id: SedimentreeId) -> BoxFuture<'_, Result<Set<CommitId>, Self::Error>> {
+        panic!("list_commit_ids must not be called by refresh_metrics");
+    }
+
+    fn load_loose_commits(
+        &self,
+        id: SedimentreeId,
+    ) -> BoxFuture<'_, Result<Vec<VerifiedMeta<LooseCommit>>, Self::Error>> {
+        Storage::<Sendable>::load_loose_commits(&self.inner, id)
+    }
+
+    fn load_loose_commit(
+        &self,
+        id: SedimentreeId,
+        commit_id: CommitId,
+    ) -> BoxFuture<'_, Result<Option<VerifiedMeta<LooseCommit>>, Self::Error>> {
+        Storage::<Sendable>::load_loose_commit(&self.inner, id, commit_id)
+    }
+
+    fn delete_loose_commit(
+        &self,
+        id: SedimentreeId,
+        commit_id: CommitId,
+    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::delete_loose_commit(&self.inner, id, commit_id)
+    }
+
+    fn delete_loose_commits(&self, id: SedimentreeId) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::delete_loose_commits(&self.inner, id)
+    }
+
+    fn save_fragment(
+        &self,
+        id: SedimentreeId,
+        verified: VerifiedMeta<Fragment>,
+    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::save_fragment(&self.inner, id, verified)
+    }
+
+    fn load_fragment(
+        &self,
+        id: SedimentreeId,
+        fragment_head: CommitId,
+    ) -> BoxFuture<'_, Result<Option<VerifiedMeta<Fragment>>, Self::Error>> {
+        Storage::<Sendable>::load_fragment(&self.inner, id, fragment_head)
+    }
+
+    #[allow(clippy::panic)]
+    fn list_fragment_ids(&self, _id: SedimentreeId) -> BoxFuture<'_, Result<Set<CommitId>, Self::Error>> {
+        panic!("list_fragment_ids must not be called by refresh_metrics");
+    }
+
+    fn load_fragments(
+        &self,
+        id: SedimentreeId,
+    ) -> BoxFuture<'_, Result<Vec<VerifiedMeta<Fragment>>, Self::Error>> {
+        Storage::<Sendable>::load_fragments(&self.inner, id)
+    }
+
+    fn delete_fragment(
+        &self,
+        id: SedimentreeId,
+        fragment_head: CommitId,
+    ) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::delete_fragment(&self.inner, id, fragment_head)
+    }
+
+    fn delete_fragments(&self, id: SedimentreeId) -> BoxFuture<'_, Result<(), Self::Error>> {
+        Storage::<Sendable>::delete_fragments(&self.inner, id)
+    }
+
+    fn save_batch(
+        &self,
+        id: SedimentreeId,
+        commits: Vec<VerifiedMeta<LooseCommit>>,
+        fragments: Vec<VerifiedMeta<Fragment>>,
+    ) -> BoxFuture<'_, Result<usize, Self::Error>> {
+        Storage::<Sendable>::save_batch(&self.inner, id, commits, fragments)
+    }
+}
+
+/// `refresh_metrics` must refresh only the tree count, which is served from
+/// the backend's in-memory id set — it must never enumerate per-tree
+/// contents. We register several trees against a storage whose per-tree
+/// listing methods panic; a successful refresh proves the O(trees) sweep is
+/// gone (and guards against it being re-introduced).
+#[tokio::test]
+async fn refresh_metrics_does_not_sweep_per_tree() -> TestResult {
+    let inner = ListPanicsStorage::new();
+    for i in 1..=5u8 {
+        Storage::<Sendable>::save_sedimentree_id(&inner, SedimentreeId::new([i; 32])).await?;
+    }
+
+    let ms = MetricsStorage::new(inner);
+
+    // If refresh_metrics still swept per tree, list_*_ids would panic here.
+    ms.refresh_metrics().await?;
+
     Ok(())
 }


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [ ] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [ ] `cargo build --workspace --all-features` succeeds
- [ ] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo +nightly fmt --all -- --check` is clean
- [ ] Public API changes have doc comments
- [ ] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [ ] Required version updates for this release-blocking change have been applied
