### PR TITLE
Split trees FS storage

### DIFF
--- a/scripts/migrate-trees-sharding.sh
+++ b/scripts/migrate-trees-sharding.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Migrate an FsStorage data directory from the legacy flat tree layout to the
+# sharded layout introduced for scale:
+#
+#   legacy:   trees/{64-hex-id}/...
+#   sharded:  trees/{first-4-hex}/{remaining-60-hex}/...
+#
+# The first two bytes of the (cryptographically distributed) SedimentreeId form
+# a hex bucket (0000..ffff); the remaining 30 bytes form the leaf directory.
+# The full id is never stored redundantly — it is reconstructed by concatenating
+# bucket + leaf, which is exactly what `FsStorage::load_tree_ids` does.
+#
+# Properties:
+#   - OFFLINE:    the subduction service MUST be stopped first. The script
+#                 aborts if it detects a running subduction unit.
+#   - IDEMPOTENT: already-sharded buckets (4-hex top-level dirs) are skipped.
+#   - RESUMABLE:  each tree is moved with a single atomic rename; re-running
+#                 after an interruption picks up where it left off.
+#
+# Usage:
+#   scripts/migrate-trees-sharding.sh <data-dir> [--dry-run] [--force]
+#
+# Arguments:
+#   <data-dir>   FsStorage root (the directory that contains `trees/`),
+#                e.g. /var/lib/subduction
+#
+# Options:
+#   --dry-run    Print what would be moved without changing anything.
+#   --force      Skip the running-service safety check (use with care).
+
+usage() {
+  sed -n '3,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+data_dir=""
+dry_run=false
+force=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    --dry-run) dry_run=true ;;
+    --force)   force=true ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage 1
+      ;;
+    *)
+      if [ -n "$data_dir" ]; then
+        echo "error: unexpected extra argument: $1" >&2
+        usage 1
+      fi
+      data_dir="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$data_dir" ]; then
+  echo "error: missing <data-dir>" >&2
+  usage 1
+fi
+
+trees_dir="$data_dir/trees"
+
+if [ ! -d "$trees_dir" ]; then
+  echo "error: no trees/ directory under '$data_dir' (looked for '$trees_dir')" >&2
+  exit 1
+fi
+
+# ── Safety: refuse to run against a live server ─────────────────────────────
+# Moving directories out from under a running server risks lost writes. Detect
+# an active subduction systemd unit unless --force is given.
+if [ "$force" = false ]; then
+  if command -v systemctl >/dev/null 2>&1 \
+     && systemctl is-active --quiet subduction 2>/dev/null; then
+    echo "error: the 'subduction' service appears to be running." >&2
+    echo "       Stop it first (e.g. 'sudo systemctl stop subduction'), or pass --force." >&2
+    exit 1
+  fi
+fi
+
+# A legacy tree dir name is the full 64-char hex id; a sharded bucket dir name
+# is the 4-char hex prefix. We classify each top-level entry by name length.
+is_hex() {
+  case "$1" in
+    *[!0-9a-fA-F]*) return 1 ;;
+    "") return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+migrated=0
+skipped=0
+
+for entry in "$trees_dir"/*; do
+  # Handle an empty trees/ (the glob stays literal when nothing matches).
+  [ -e "$entry" ] || continue
+  [ -d "$entry" ] || continue
+
+  name="$(basename "$entry")"
+
+  # Already-sharded bucket: 4 hex chars. Leave it in place (idempotent).
+  if [ "${#name}" -eq 4 ] && is_hex "$name"; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  # Legacy tree: 64 hex chars. Move into trees/{prefix}/{rest}.
+  if [ "${#name}" -eq 64 ] && is_hex "$name"; then
+    prefix="${name:0:4}"
+    rest="${name:4}"
+    bucket="$trees_dir/$prefix"
+    dest="$bucket/$rest"
+
+    if [ -e "$dest" ]; then
+      # Destination already present (e.g. a partial earlier run). Content is
+      # addressed by id, so an existing dest is the same tree; skip.
+      echo "skip (already at destination): $name"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [ "$dry_run" = true ]; then
+      echo "would move: trees/$name -> trees/$prefix/$rest"
+    else
+      mkdir -p "$bucket"
+      mv "$entry" "$dest"
+      echo "moved: trees/$name -> trees/$prefix/$rest"
+    fi
+    migrated=$((migrated + 1))
+    continue
+  fi
+
+  echo "warning: unrecognized entry name, leaving in place: $name" >&2
+  skipped=$((skipped + 1))
+done
+
+if [ "$dry_run" = true ]; then
+  echo "dry-run complete: $migrated would be migrated, $skipped skipped."
+else
+  echo "migration complete: $migrated migrated, $skipped skipped."
+fi

--- a/scripts/migrate-trees-sharding.sh
+++ b/scripts/migrate-trees-sharding.sh
@@ -96,11 +96,18 @@ is_hex() {
 migrated=0
 skipped=0
 
-for entry in "$trees_dir"/*; do
-  # Handle an empty trees/ (the glob stays literal when nothing matches).
-  [ -e "$entry" ] || continue
-  [ -d "$entry" ] || continue
-
+# Enumerate top-level entries with `find ... -print0` streamed into the loop
+# rather than a `for entry in "$trees_dir"/*` glob. At the scale this migration
+# targets (millions of trees), a glob would force the shell to expand, sort,
+# and hold the entire entry list in memory before the first iteration — a large
+# up-front memory spike that can stall or OOM on a small host. `find -print0`
+# streams one entry at a time with no full-list materialization.
+#
+# Process substitution (`done < <(...)`) keeps the loop in the parent shell so
+# the `migrated`/`skipped` counters survive (a `find | while` pipe would run the
+# loop in a subshell and discard them), and avoids masking a `find` failure
+# under `set -o pipefail`.
+while IFS= read -r -d '' entry; do
   name="$(basename "$entry")"
 
   # Already-sharded bucket: 4 hex chars. Leave it in place (idempotent).
@@ -137,7 +144,7 @@ for entry in "$trees_dir"/*; do
 
   echo "warning: unrecognized entry name, leaving in place: $name" >&2
   skipped=$((skipped + 1))
-done
+done < <(find "$trees_dir" -mindepth 1 -maxdepth 1 -type d -print0)
 
 if [ "$dry_run" = true ]; then
   echo "dry-run complete: $migrated would be migrated, $skipped skipped."

--- a/sedimentree_fs_storage/src/lib.rs
+++ b/sedimentree_fs_storage/src/lib.rs
@@ -9,20 +9,28 @@
 //!
 //! # Storage Layout
 //!
+//! Trees are sharded one level deep under `trees/` by a hex bucket taken from
+//! the first two bytes of the `SedimentreeId` (65,536 buckets, `0000`..`ffff`).
+//! The leaf directory is the hex of the remaining 30 bytes, so the full id is
+//! never stored redundantly — it is reconstructed by concatenating the bucket
+//! and leaf names. Because the id is a cryptographic hash, its prefix bytes are
+//! uniformly distributed and buckets fill evenly with no extra hashing.
+//!
 //! Commits and fragments are stored together with their blobs:
 //!
 //! ```text
 //! root/
 //! └── trees/
-//!     └── {sedimentree_id_hex}/
-//!         ├── commits/
-//!         │   └── {commit_id_hex}/
-//!         │       ├── {digest_hex}.meta   ← Signed<LooseCommit> bytes
-//!         │       └── {digest_hex}.blob   ← Blob bytes
-//!         └── fragments/
-//!             └── {fragment_head_hex}/
-//!                 ├── {digest_hex}.meta   ← Signed<Fragment> bytes
-//!                 └── {digest_hex}.blob   ← Blob bytes
+//!     └── {id_prefix_hex}/                   ← bucket: first 2 bytes (4 hex chars)
+//!         └── {id_remainder_hex}/            ← leaf: remaining 30 bytes (60 hex chars)
+//!             ├── commits/
+//!             │   └── {commit_id_hex}/
+//!             │       ├── {digest_hex}.meta   ← Signed<LooseCommit> bytes
+//!             │       └── {digest_hex}.blob   ← Blob bytes
+//!             └── fragments/
+//!                 └── {fragment_head_hex}/
+//!                     ├── {digest_hex}.meta   ← Signed<Fragment> bytes
+//!                     └── {digest_hex}.blob   ← Blob bytes
 //! ```
 //!
 //! # Example
@@ -62,6 +70,15 @@ use thiserror::Error;
 /// the same content-addressed path.
 static TMP_NONCE: AtomicU64 = AtomicU64::new(0);
 
+/// Number of leading [`SedimentreeId`] bytes used as the on-disk bucket name
+/// under `trees/`. Two bytes give 65,536 buckets (`0000`..`ffff`).
+///
+/// Because a `SedimentreeId` is a cryptographic hash, its leading bytes are
+/// uniformly distributed, so this prefix shards trees evenly across buckets
+/// with no additional hashing. The remaining bytes form the leaf directory
+/// name, so the full id is never stored redundantly.
+const TREE_BUCKET_PREFIX_BYTES: usize = 2;
+
 /// Errors that can occur during filesystem storage operations.
 #[derive(Debug, Error)]
 pub enum FsStorageError {
@@ -85,19 +102,22 @@ pub enum FsStorageError {
 
 /// Filesystem-based storage backend.
 ///
-/// Uses a CAS layout with compound storage (commits/fragments stored with their blobs):
+/// Uses a CAS layout with compound storage (commits/fragments stored with their
+/// blobs), sharded one level deep by a hex bucket from the first two bytes of
+/// the `SedimentreeId`:
 /// ```text
 /// root/
 /// └── trees/
-///     └── {sedimentree_id_hex}/
-///         ├── commits/
-///         │   └── {commit_id_hex}/
-///         │       ├── {digest_hex}.meta   ← Signed<LooseCommit>
-///         │       └── {digest_hex}.blob   ← Blob
-///         └── fragments/
-///             └── {fragment_head_hex}/
-///                 ├── {digest_hex}.meta   ← Signed<Fragment>
-///                 └── {digest_hex}.blob   ← Blob
+///     └── {id_prefix_hex}/                   ← bucket: first 2 bytes (4 hex chars)
+///         └── {id_remainder_hex}/            ← leaf: remaining 30 bytes (60 hex chars)
+///             ├── commits/
+///             │   └── {commit_id_hex}/
+///             │       ├── {digest_hex}.meta   ← Signed<LooseCommit>
+///             │       └── {digest_hex}.blob   ← Blob
+///             └── fragments/
+///                 └── {fragment_head_hex}/
+///                     ├── {digest_hex}.meta   ← Signed<Fragment>
+///                     └── {digest_hex}.blob   ← Blob
 /// ```
 #[derive(Debug, Clone)]
 pub struct FsStorage {
@@ -130,15 +150,32 @@ impl FsStorage {
         let trees_dir = root.join("trees");
         let mut ids = Set::new();
 
-        if let Ok(entries) = std::fs::read_dir(trees_dir) {
-            for entry in entries.flatten() {
-                if let Ok(name) = entry.file_name().into_string()
-                    && let Ok(bytes) = hex::decode(&name)
-                    && bytes.len() == 32
+        // Two-level walk: trees/{bucket}/{leaf}. The bucket is the first
+        // `TREE_BUCKET_PREFIX_BYTES` of the id (hex-encoded), the leaf is the
+        // remaining bytes. A full id is reconstructed by concatenating the two.
+        let Ok(buckets) = std::fs::read_dir(&trees_dir) else {
+            return ids;
+        };
+
+        for bucket in buckets.flatten() {
+            let Ok(bucket_name) = bucket.file_name().into_string() else {
+                continue;
+            };
+
+            // Bucket dir names are exactly the hex of the prefix bytes.
+            if bucket_name.len() != TREE_BUCKET_PREFIX_BYTES * 2 {
+                continue;
+            }
+
+            let Ok(leaves) = std::fs::read_dir(bucket.path()) else {
+                continue;
+            };
+
+            for leaf in leaves.flatten() {
+                if let Ok(leaf_name) = leaf.file_name().into_string()
+                    && let Some(id) = Self::reconstruct_id(&bucket_name, &leaf_name)
                 {
-                    let mut arr = [0u8; 32];
-                    arr.copy_from_slice(&bytes);
-                    ids.insert(SedimentreeId::new(arr));
+                    ids.insert(id);
                 }
             }
         }
@@ -146,9 +183,31 @@ impl FsStorage {
         ids
     }
 
+    /// Reconstruct a [`SedimentreeId`] from its on-disk bucket + leaf names.
+    ///
+    /// The bucket holds the hex of the first `TREE_BUCKET_PREFIX_BYTES` of the
+    /// id; the leaf holds the hex of the remaining bytes. Concatenating them
+    /// yields the full 64-char hex id. Returns `None` for any name that does
+    /// not decode to exactly 32 bytes.
+    fn reconstruct_id(bucket_name: &str, leaf_name: &str) -> Option<SedimentreeId> {
+        let mut full_hex = String::with_capacity(bucket_name.len() + leaf_name.len());
+        full_hex.push_str(bucket_name);
+        full_hex.push_str(leaf_name);
+
+        let bytes = hex::decode(&full_hex).ok()?;
+        let arr: [u8; 32] = bytes.try_into().ok()?;
+        Some(SedimentreeId::new(arr))
+    }
+
     fn tree_path(&self, id: SedimentreeId) -> PathBuf {
-        let hex = hex::encode(id.as_bytes());
-        self.root.join("trees").join(hex)
+        // Shard into one level of hex buckets: trees/{bucket}/{leaf}. The id is
+        // already a cryptographic hash, so its prefix bytes are uniformly
+        // distributed — slicing the prefix gives an even fan-out for free with
+        // no additional hashing. See the module docs for the rationale.
+        let (prefix, rest) = id.as_bytes().split_at(TREE_BUCKET_PREFIX_BYTES);
+        let bucket = hex::encode(prefix);
+        let leaf = hex::encode(rest);
+        self.root.join("trees").join(bucket).join(leaf)
     }
 
     fn commits_dir(&self, id: SedimentreeId) -> PathBuf {

--- a/sedimentree_fs_storage/tests/roundtrip.rs
+++ b/sedimentree_fs_storage/tests/roundtrip.rs
@@ -251,3 +251,88 @@ async fn save_load_multiple_commits_roundtrip() -> testresult::TestResult {
 
     Ok(())
 }
+
+/// Sedimentree IDs are sharded on disk as `trees/{first-2-bytes}/{rest}`.
+/// Reopening storage must reconstruct every id exactly by concatenating the
+/// bucket and leaf directory names — including ids that share a bucket prefix
+/// (same first two bytes, different remainder), which exercises the two-level
+/// `load_tree_ids` walk rather than a flat single-level scan.
+#[tokio::test]
+async fn sedimentree_ids_roundtrip_through_sharded_layout() -> testresult::TestResult {
+    let dir = tempfile::tempdir()?;
+
+    // Construct ids that deliberately collide on the first two bytes (the
+    // bucket) but differ in the remainder (the leaf), plus an id in a
+    // different bucket entirely.
+    let mut share_a = [0u8; 32];
+    share_a[0] = 0xAB;
+    share_a[1] = 0xCD;
+    share_a[31] = 0x01;
+
+    let mut share_b = [0u8; 32];
+    share_b[0] = 0xAB;
+    share_b[1] = 0xCD;
+    share_b[31] = 0x02;
+
+    let mut other = [0u8; 32];
+    other[0] = 0x12;
+    other[1] = 0x34;
+    other[15] = 0xFF;
+
+    let expected: BTreeSet<SedimentreeId> = [share_a, share_b, other]
+        .into_iter()
+        .map(SedimentreeId::new)
+        .collect();
+
+    {
+        let storage = FsStorage::new(dir.path().to_path_buf())?;
+        for id in &expected {
+            Storage::<Sendable>::save_sedimentree_id(&storage, *id).await?;
+        }
+    }
+
+    // Reopen: forces load_tree_ids to walk trees/{bucket}/{leaf} from disk and
+    // rebuild the id set, rather than reading a warm in-memory cache.
+    let reopened = FsStorage::new(dir.path().to_path_buf())?;
+    let loaded = Storage::<Sendable>::load_all_sedimentree_ids(&reopened).await?;
+
+    let loaded_set: BTreeSet<SedimentreeId> = loaded.into_iter().collect();
+    assert_eq!(
+        loaded_set, expected,
+        "every sedimentree id must round-trip through the sharded on-disk layout"
+    );
+
+    Ok(())
+}
+
+/// A tree written under the sharded layout must be fully readable after a
+/// reopen — i.e. the bucket path used for writes matches the one used for
+/// reads. Guards against a bucket/leaf split mismatch between `tree_path` on
+/// the write and read sides.
+#[tokio::test]
+async fn commit_readable_after_reopen_under_sharding() -> testresult::TestResult {
+    let dir = tempfile::tempdir()?;
+    let signer = test_signer();
+    let id = make_sedimentree_id(0x7E);
+    let head = CommitId::new([0x99; 32]);
+
+    {
+        let storage = FsStorage::new(dir.path().to_path_buf())?;
+        let blob = Blob::new(vec![7; 32]);
+        let verified_blob = VerifiedBlobMeta::new(blob);
+        let verified: VerifiedMeta<LooseCommit> =
+            VerifiedMeta::seal::<Sendable, _>(&signer, (id, head, BTreeSet::new()), verified_blob)
+                .await;
+        Storage::<Sendable>::save_sedimentree_id(&storage, id).await?;
+        Storage::<Sendable>::save_loose_commit(&storage, id, verified).await?;
+    }
+
+    let reopened = FsStorage::new(dir.path().to_path_buf())?;
+    let loaded = Storage::<Sendable>::load_loose_commit(&reopened, id, head)
+        .await?
+        .expect("commit must be loadable from the sharded path after reopen");
+
+    assert_eq!(loaded.payload().head(), head);
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

Changes data layout on disk

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
