### PR TITLE
Hydrate from storage before outgoing batch sync

### DIFF
--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -21,13 +21,13 @@ use future_form::{FutureForm, Local, Sendable, future_form};
 use nonempty::NonEmpty;
 use sedimentree_core::{
     blob::Blob,
-    collections::{Entry, Map, Set},
+    collections::{Map, Set},
     crypto::digest::Digest,
     depth::DepthMetric,
     fragment::Fragment,
     id::SedimentreeId,
     loose_commit::{LooseCommit, id::CommitId},
-    sedimentree::{FingerprintSummary, Sedimentree, minimized::MinimizedSedimentree},
+    sedimentree::{FingerprintSummary, minimized::MinimizedSedimentree},
 };
 use subduction_crypto::{signed::Signed, verified_meta::VerifiedMeta};
 
@@ -706,22 +706,22 @@ impl<
         ) = {
             let mut locked = self.sedimentrees.get_shard_containing(&id).lock().await;
 
-            if let Entry::Vacant(entry) = locked.entry(id) {
-                let loose_commits: Vec<_> = commit_by_id
-                    .values()
-                    .map(|vm| vm.payload().clone())
-                    .collect();
-                let fragments: Vec<_> = fragment_by_id
-                    .values()
-                    .map(|vm| vm.payload().clone())
-                    .collect();
+            let loose_commits: Vec<_> = commit_by_id
+                .values()
+                .map(|vm| vm.payload().clone())
+                .collect();
+            let fragments: Vec<_> = fragment_by_id
+                .values()
+                .map(|vm| vm.payload().clone())
+                .collect();
 
-                if !loose_commits.is_empty() || !fragments.is_empty() {
-                    let sedimentree =
-                        Sedimentree::new(fragments, loose_commits).minimize(&self.depth_metric);
-                    entry.insert(MinimizedSedimentree::already_minimal(sedimentree));
-                    tracing::debug!("hydrated sedimentree {id:?} from storage for batch sync");
-                }
+            if ingest::try_insert_hydrated_minimal_tree(
+                locked.entry(id),
+                loose_commits,
+                fragments,
+                &self.depth_metric,
+            ) {
+                tracing::debug!("hydrated sedimentree {id:?} from storage for batch sync");
             }
 
             let sedimentree = locked.entry(id).or_default();

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -1237,12 +1237,14 @@ where
         id: SedimentreeId,
     ) -> Result<Option<NonEmpty<Blob>>, Store::Error> {
         tracing::debug!("Getting local blobs for sedimentree with id {:?}", id);
-        let tree = self.sedimentrees.get_cloned(&id).await;
-        if tree.is_none() {
-            return Ok(None);
-        }
+        ingest::hydrate_sedimentree_if_absent(
+            &self.sedimentrees,
+            &self.storage,
+            &self.depth_metric,
+            id,
+        )
+        .await?;
 
-        tracing::debug!("Found sedimentree with id {:?}", id);
         let local_access = self.storage.hydration_access();
         let mut results = Vec::new();
 
@@ -1284,7 +1286,7 @@ where
         if let Some(maybe_blobs) = self.get_blobs(id).await.map_err(IoError::Storage)? {
             Ok(Some(maybe_blobs))
         } else {
-            let tree = self.get_minimized_tree(id).await;
+            let tree = self.get_or_hydrate_minimized_tree(id).await.map_err(IoError::Storage)?;
             if let Some(tree) = tree {
                 let conns = self.all_connections().await;
                 for conn in conns {
@@ -2500,10 +2502,14 @@ where
         for conn in peer_conns {
             tracing::info!("Using connection to peer {}", to_ask);
             let seed = FingerprintSeed::random();
-            let resolver = self.get_minimized_tree(id).await.map_or_else(
-                || Sedimentree::default().fingerprint_resolver(&seed),
-                |t| t.fingerprint_resolver(&seed),
-            );
+            let resolver = self
+                .get_or_hydrate_minimized_tree(id)
+                .await
+                .map_err(IoError::Storage)?
+                .map_or_else(
+                    || Sedimentree::default().fingerprint_resolver(&seed),
+                    |t| t.fingerprint_resolver(&seed),
+                );
 
             tracing::debug!(
                 "Sending fingerprint summary for {:?}: {} commit fps, {} fragment fps",
@@ -2770,10 +2776,14 @@ where
                     for conn in peer_conns {
                         tracing::debug!("Using connection to peer {}", conn.peer_id());
                         let seed = FingerprintSeed::random();
-                        let resolver = self.get_minimized_tree(id).await.map_or_else(
-                            || Sedimentree::default().fingerprint_resolver(&seed),
-                            |t| t.fingerprint_resolver(&seed),
-                        );
+                        let resolver = self
+                            .get_or_hydrate_minimized_tree(id)
+                            .await
+                            .map_err(IoError::Storage)?
+                            .map_or_else(
+                                || Sedimentree::default().fingerprint_resolver(&seed),
+                                |t| t.fingerprint_resolver(&seed),
+                            );
 
                         // Mux missing means the peer was torn down between
                         // the connection snapshot and here; report it
@@ -3496,14 +3506,27 @@ where
     /// Clone out the **minimal** form of a stored sedimentree, minimizing it in
     /// place first if it is dirty.
     ///
-    /// Use this (rather than `sedimentrees.get_cloned`) on paths that feed the
-    /// wire — fingerprint summaries / resolvers — where a non-minimal tree
-    /// would produce an incorrect diff.
-    async fn get_minimized_tree(&self, id: SedimentreeId) -> Option<Sedimentree> {
+    /// Loads from local storage first when the sedimentree is not yet in memory
+    /// (per-doc hydration). Use this on paths that feed the wire — fingerprint
+    /// summaries / resolvers — where a non-minimal tree would produce an
+    /// incorrect diff, and where an empty in-memory tree would cause redundant
+    /// re-sync from peers.
+    async fn get_or_hydrate_minimized_tree(
+        &self,
+        id: SedimentreeId,
+    ) -> Result<Option<Sedimentree>, Store::Error> {
+        ingest::hydrate_sedimentree_if_absent(
+            &self.sedimentrees,
+            &self.storage,
+            &self.depth_metric,
+            id,
+        )
+        .await?;
+
         let mut shard = self.sedimentrees.get_shard_containing(&id).lock().await;
-        shard
+        Ok(shard
             .get_mut(&id)
-            .map(|entry| entry.minimized(&self.depth_metric).clone())
+            .map(|entry| entry.minimized(&self.depth_metric).clone()))
     }
 }
 

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -11,15 +11,16 @@
 
 use alloc::vec::Vec;
 use future_form::FutureForm;
+use futures::future::try_join;
 use sedimentree_core::{
     blob::Blob,
-    collections::{Map, Set},
+    collections::{Entry, Map, Set},
     crypto::digest::Digest,
     depth::DepthMetric,
     fragment::Fragment,
     id::SedimentreeId,
     loose_commit::LooseCommit,
-    sedimentree::minimized::MinimizedSedimentree,
+    sedimentree::{Sedimentree, minimized::MinimizedSedimentree},
 };
 use subduction_crypto::verified_meta::VerifiedMeta;
 
@@ -254,6 +255,76 @@ pub(crate) async fn insert_fragment_locally<
         .await;
 
     Ok(was_added)
+}
+
+/// Insert a minimized in-memory sedimentree if the shard entry is vacant.
+///
+/// Returns `true` when a tree was inserted. Used by the batch-sync responder
+/// (which has already loaded storage) and by [`hydrate_sedimentree_if_absent`].
+pub(crate) fn try_insert_hydrated_minimal_tree<Metric: DepthMetric>(
+    entry: Entry<'_, SedimentreeId, MinimizedSedimentree>,
+    loose_commits: Vec<LooseCommit>,
+    fragments: Vec<Fragment>,
+    depth_metric: &Metric,
+) -> bool {
+    if loose_commits.is_empty() && fragments.is_empty() {
+        return false;
+    }
+    if let Entry::Vacant(v) = entry {
+        let sedimentree = Sedimentree::new(fragments, loose_commits).minimize(depth_metric);
+        v.insert(MinimizedSedimentree::already_minimal(sedimentree));
+        true
+    } else {
+        false
+    }
+}
+
+/// Load a sedimentree from local storage into the in-memory cache if absent.
+///
+/// Per-doc hydration for outgoing sync: builds an accurate fingerprint summary
+/// without requiring a full startup [`Subduction::hydrate`]. No-op when the
+/// sedimentree is already in memory or storage has no data for `id`.
+pub(crate) async fn hydrate_sedimentree_if_absent<
+    Async: FutureForm,
+    Store: Storage<Async>,
+    Auth: StoragePolicy<Async>,
+    Metric: DepthMetric,
+    const SHARDS: usize,
+>(
+    sedimentrees: &ShardedMap<SedimentreeId, MinimizedSedimentree, SHARDS>,
+    storage: &StoragePowerbox<Store, Auth>,
+    depth_metric: &Metric,
+    id: SedimentreeId,
+) -> Result<(), Store::Error> {
+    if sedimentrees.get_cloned(&id).await.is_some() {
+        return Ok(());
+    }
+
+    let local_access = storage.hydration_access();
+    let (commits, fragments) = try_join(
+        local_access.load_loose_commits::<Async>(id),
+        local_access.load_fragments::<Async>(id),
+    )
+    .await?;
+
+    if commits.is_empty() && fragments.is_empty() {
+        return Ok(());
+    }
+
+    let loose_commits: Vec<LooseCommit> = commits.iter().map(|v| v.payload().clone()).collect();
+    let fragment_payloads: Vec<Fragment> = fragments.iter().map(|v| v.payload().clone()).collect();
+
+    let mut shard = sedimentrees.get_shard_containing(&id).lock().await;
+    if try_insert_hydrated_minimal_tree(
+        shard.entry(id),
+        loose_commits,
+        fragment_payloads,
+        depth_metric,
+    ) {
+        tracing::debug!("hydrated sedimentree {id:?} from storage");
+    }
+
+    Ok(())
 }
 
 /// Re-minimize a sedimentree in the in-memory cache.

--- a/subduction_core/tests/hydrate_before_sync.rs
+++ b/subduction_core/tests/hydrate_before_sync.rs
@@ -1,0 +1,158 @@
+//! Outgoing batch sync must hydrate per-doc from storage before building
+//! fingerprint summaries, so a cold in-memory tree does not advertise an
+//! empty state to peers when local storage already has data.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use core::time::Duration;
+use std::sync::Arc;
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::Blob,
+    id::SedimentreeId,
+    loose_commit::id::CommitId,
+};
+use subduction_core::{
+    connection::{
+        message::{BatchSyncRequest, SyncMessage},
+        test_utils::{ChannelMockConnection, InstantTimeout, TokioSpawn, test_signer},
+    },
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    sharded_map::ShardedMap,
+    storage::memory::MemoryStorage,
+    subduction::builder::SubductionBuilder,
+};
+use testresult::TestResult;
+
+fn make_unique_blob(seed: u8) -> Blob {
+    Blob::new(vec![seed; 32])
+}
+
+/// Populate shared storage via one Subduction instance, then sync from a
+/// second instance whose in-memory sedimentree map starts empty.
+#[tokio::test]
+async fn sync_with_all_peers_hydrates_from_storage_before_fingerprint() -> TestResult {
+    let storage = MemoryStorage::new();
+    let policy = Arc::new(OpenPolicy);
+
+    let (writer, _handler, _listener, _actor) = SubductionBuilder::<_, _, _, _, _, 256>::new()
+        .signer(test_signer())
+        .storage(storage.clone(), policy.clone())
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, ChannelMockConnection<SyncMessage>>();
+
+    let sed_id = SedimentreeId::new([0xAA; 32]);
+    const NUM_COMMITS: u8 = 5;
+
+    for i in 0..NUM_COMMITS {
+        writer
+            .add_commit(
+                sed_id,
+                CommitId::new([i + 1; 32]),
+                Default::default(),
+                make_unique_blob(i),
+            )
+            .await?;
+    }
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Cold node: same storage, empty in-memory sedimentrees (SW restart shape).
+    let empty_trees = Arc::new(ShardedMap::new());
+    let (cold, _handler, listener, actor2) = SubductionBuilder::<_, _, _, _, _, 256>::new()
+        .signer(test_signer())
+        .storage(storage, policy)
+        .sedimentrees(empty_trees)
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, ChannelMockConnection<SyncMessage>>();
+
+    assert!(
+        cold.sedimentrees().get_cloned(&sed_id).await.is_none(),
+        "cold node should start with no in-memory sedimentree"
+    );
+
+    let peer_id = PeerId::new([0xBB; 32]);
+    let (conn, handle) = ChannelMockConnection::new_with_handle(peer_id);
+    cold.add_connection(conn.authenticated()).await?;
+
+    tokio::spawn(listener);
+    tokio::spawn(actor2);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    let sync_task = tokio::spawn(async move {
+        cold.sync_with_all_peers(sed_id, false, Some(Duration::from_secs(5)))
+            .await
+    });
+
+    let msg = tokio::time::timeout(Duration::from_secs(5), handle.outbound_rx.recv())
+        .await
+        .expect("timed out waiting for BatchSyncRequest")
+        .expect("peer closed channel");
+
+    let SyncMessage::BatchSyncRequest(BatchSyncRequest {
+        fingerprint_summary,
+        ..
+    }) = msg
+    else {
+        panic!("expected BatchSyncRequest, got {msg:?}");
+    };
+
+    assert_eq!(
+        fingerprint_summary.commit_fingerprints().len(),
+        usize::from(NUM_COMMITS),
+        "fingerprint should reflect storage-backed commits, not an empty in-memory tree"
+    );
+
+    sync_task.abort();
+
+    Ok(())
+}
+
+/// `get_blobs` should read from storage even when the sedimentree is not yet
+/// in memory (after per-doc hydration).
+#[tokio::test]
+async fn get_blobs_hydrates_from_storage() -> TestResult {
+    let storage = MemoryStorage::new();
+    let policy = Arc::new(OpenPolicy);
+
+    let (writer, _handler, _listener, _actor) = SubductionBuilder::<_, _, _, _, _, 256>::new()
+        .signer(test_signer())
+        .storage(storage.clone(), policy.clone())
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, ChannelMockConnection<SyncMessage>>();
+
+    let sed_id = SedimentreeId::new([0xCC; 32]);
+    writer
+        .add_commit(
+            sed_id,
+            CommitId::new([1; 32]),
+            Default::default(),
+            make_unique_blob(42),
+        )
+        .await?;
+
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let empty_trees = Arc::new(ShardedMap::new());
+    let (cold, _handler, _listener, _actor) = SubductionBuilder::<_, _, _, _, _, 256>::new()
+        .signer(test_signer())
+        .storage(storage, policy)
+        .sedimentrees(empty_trees)
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build::<Sendable, ChannelMockConnection<SyncMessage>>();
+
+    let blobs = cold
+        .get_blobs(sed_id)
+        .await?
+        .expect("expected blobs from storage");
+
+    assert_eq!(blobs.len(), 1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add per-doc storage hydration (`hydrate_sedimentree_if_absent`) before building batch-sync fingerprint summaries, so a cold in-memory tree does not advertise an empty state when local storage already has commits/fragments.
- Replace `get_minimized_tree` with `get_or_hydrate_minimized_tree` on outgoing sync paths (`sync_with_peer`, `sync_with_all_peers`, `fetch_blobs` fallback).
- Fix `get_blobs` to hydrate from storage instead of returning `None` when the sedimentree is not yet in memory.
- Share insertion logic with the batch-sync responder via `try_insert_hydrated_minimal_tree`.

This mirrors the existing responder-side Vacant hydration in `SyncHandler::recv_batch_sync_request`, but on the **requester** path where Patchwork/automerge-repo hit empty fingerprints after SW restart.

## Test plan

- [x] `cargo test -p subduction_core --features test_utils --test hydrate_before_sync`
- [x] `cargo test -p subduction_core --features test_utils --test bidirectional_sync`
- [x] `cargo test -p subduction_core --features test_utils --test add_commit_sync`
- [x] `cargo test -p subduction_core --features test_utils --test recv_batch_sync_response`
- [x] `cargo test -p subduction_core --features test_utils --test minimize_sync`


Made with [Cursor](https://cursor.com)