### PR TITLE
Better tungstenite "over max frame" handling

### DIFF
--- a/subduction_core/src/transport.rs
+++ b/subduction_core/src/transport.rs
@@ -32,6 +32,10 @@ use future_form::FutureForm;
 ///
 /// - `send_bytes` must deliver the entire byte slice atomically (no partial sends).
 /// - `recv_bytes` must return a complete message frame (no fragmentation).
+/// - A `recv_bytes` error is terminal: the connection read loop treats any
+///   error as the end of the connection and tears it down. Transports that can
+///   recover from transient read failures must do so internally (retry below
+///   this layer) and only surface an error when the connection is truly gone.
 pub trait Transport<Async: FutureForm + ?Sized>: Clone + PartialEq {
     /// A problem when sending bytes.
     type SendError: core::error::Error;

--- a/subduction_iroh/src/tasks.rs
+++ b/subduction_iroh/src/tasks.rs
@@ -88,8 +88,16 @@ impl StreamReadErrorKind {
         use iroh::endpoint::{ReadError, ReadExactError};
 
         match e {
+            // Peer-driven terminations (graceful or abrupt) are benign: the
+            // connection was lost, the stream finished, the peer reset it
+            // (e.g. crash / SIGKILL surfacing as RESET_STREAM), or the stream
+            // is already closed. None of these is a local fault.
             StreamError::Read(
-                ReadExactError::ReadError(ReadError::ConnectionLost(_))
+                ReadExactError::ReadError(
+                    ReadError::ConnectionLost(_)
+                    | ReadError::Reset(_)
+                    | ReadError::ClosedStream,
+                )
                 | ReadExactError::FinishedEarly(_),
             )
             | StreamError::ConnectionClosed(_) => Self::ExpectedDisconnect,
@@ -238,6 +246,25 @@ mod tests {
         let code: u64 = kind.close_code().into();
         assert_eq!(code, 1009);
         assert!(!kind.close_reason().is_empty());
+    }
+
+    /// Peer-driven stream terminations (reset, already-closed) are benign
+    /// disconnects, not fatal errors.
+    #[test]
+    fn peer_stream_termination_is_expected_disconnect() {
+        use iroh::endpoint::{ReadError, ReadExactError};
+
+        let cases = [
+            StreamError::Read(ReadExactError::ReadError(ReadError::Reset(7u32.into()))),
+            StreamError::Read(ReadExactError::ReadError(ReadError::ClosedStream)),
+        ];
+        for err in cases {
+            assert_eq!(
+                StreamReadErrorKind::classify(&err),
+                StreamReadErrorKind::ExpectedDisconnect,
+                "{err:?} should be a benign disconnect"
+            );
+        }
     }
 
     /// Close-code mapping is stable across all kinds.

--- a/subduction_iroh/src/tasks.rs
+++ b/subduction_iroh/src/tasks.rs
@@ -94,9 +94,7 @@ impl StreamReadErrorKind {
             // is already closed. None of these is a local fault.
             StreamError::Read(
                 ReadExactError::ReadError(
-                    ReadError::ConnectionLost(_)
-                    | ReadError::Reset(_)
-                    | ReadError::ClosedStream,
+                    ReadError::ConnectionLost(_) | ReadError::Reset(_) | ReadError::ClosedStream,
                 )
                 | ReadExactError::FinishedEarly(_),
             )

--- a/subduction_iroh/src/tasks.rs
+++ b/subduction_iroh/src/tasks.rs
@@ -65,10 +65,69 @@ pub(crate) async fn write_framed(send: &mut SendStream, data: &[u8]) -> Result<(
     Ok(())
 }
 
+/// How a read error from the QUIC stream should be treated by the listener.
+///
+/// The log severity and the peer-visible close code both follow from the
+/// category, mirroring the WebSocket transport's error handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamReadErrorKind {
+    /// A benign disconnect: the peer closed the connection or finished the
+    /// stream. Normal lifecycle.
+    ExpectedDisconnect,
+
+    /// Peer-induced: the peer announced a frame larger than the configured cap.
+    /// Not a fault on this side, so it is logged at warn rather than error.
+    OverCapacity,
+
+    /// An unanticipated transport fault.
+    Fatal,
+}
+
+impl StreamReadErrorKind {
+    const fn classify(e: &StreamError) -> Self {
+        use iroh::endpoint::{ReadError, ReadExactError};
+
+        match e {
+            StreamError::Read(
+                ReadExactError::ReadError(ReadError::ConnectionLost(_))
+                | ReadExactError::FinishedEarly(_),
+            )
+            | StreamError::ConnectionClosed(_) => Self::ExpectedDisconnect,
+
+            StreamError::FrameTooLarge { .. } => Self::OverCapacity,
+
+            StreamError::Read(_) | StreamError::Write(_) => Self::Fatal,
+        }
+    }
+
+    /// QUIC application error code to close with. The numeric values match the
+    /// WebSocket Close codes (1009 Message Too Big, 1011 Internal Error) for
+    /// cross-transport consistency; `0` is the normal-close code.
+    fn close_code(self) -> iroh::endpoint::VarInt {
+        let code: u32 = match self {
+            Self::ExpectedDisconnect => 0,
+            Self::OverCapacity => 1009,
+            Self::Fatal => 1011,
+        };
+        code.into()
+    }
+
+    const fn close_reason(self) -> &'static [u8] {
+        match self {
+            Self::ExpectedDisconnect => b"subduction close",
+            Self::OverCapacity => b"frame exceeds size limit",
+            Self::Fatal => b"internal error",
+        }
+    }
+}
+
 /// Background task: reads framed messages from the QUIC recv stream and
 /// dispatches them to the connection's inbound channel as raw bytes.
 ///
-/// Exits when the recv stream is closed or an error occurs.
+/// On any exit — peer close, EOF, over-cap frame, or fatal error — the
+/// connection is torn down: the inbound channel is closed so a parked
+/// `recv_bytes` is notified immediately, and the QUIC connection is closed with
+/// an application error code reflecting the reason.
 ///
 /// # Errors
 ///
@@ -77,20 +136,58 @@ pub async fn listener_task(conn: IrohTransport, mut recv: RecvStream) -> Result<
     let peer_id = conn.quic_connection().remote_id();
     tracing::info!("starting iroh listener task for peer {peer_id}");
 
+    let outcome = read_loop(&conn, &mut recv, peer_id).await;
+
+    // Uniform teardown: close the inbound channel (notifying any parked
+    // `recv_bytes`) and the QUIC connection with a code reflecting the outcome.
+    let (code, reason) = match &outcome {
+        Ok(()) => (
+            StreamReadErrorKind::ExpectedDisconnect.close_code(),
+            StreamReadErrorKind::ExpectedDisconnect.close_reason(),
+        ),
+        Err(e) => {
+            let kind = match e {
+                RunError::Stream(stream_err) => StreamReadErrorKind::classify(stream_err),
+                // A closed inbound channel means the consumer is gone; treat as
+                // a normal teardown.
+                RunError::ChanSend(_) => StreamReadErrorKind::ExpectedDisconnect,
+            };
+            (kind.close_code(), kind.close_reason())
+        }
+    };
+    conn.close_with_code(code, reason);
+
+    tracing::info!("iroh listener task for peer {peer_id}: exiting");
+    outcome
+}
+
+/// Read framed messages until the stream ends or errors, forwarding each to the
+/// inbound channel. Logs read errors at a severity matching their category.
+async fn read_loop(
+    conn: &IrohTransport,
+    recv: &mut RecvStream,
+    peer_id: impl core::fmt::Display,
+) -> Result<(), RunError> {
     loop {
-        let bytes = match read_framed(&mut recv).await {
+        let bytes = match read_framed(recv).await {
             Ok(b) => b,
-            Err(StreamError::Read(iroh::endpoint::ReadExactError::ReadError(
-                iroh::endpoint::ReadError::ConnectionLost(e),
-            ))) => {
-                tracing::debug!("iroh connection closed: {e}");
-                break;
+            Err(e) => {
+                match StreamReadErrorKind::classify(&e) {
+                    StreamReadErrorKind::ExpectedDisconnect => {
+                        tracing::debug!("iroh connection closed for peer {peer_id}: {e}");
+                        return Ok(());
+                    }
+                    StreamReadErrorKind::OverCapacity => {
+                        tracing::warn!(
+                            "peer {peer_id} sent an over-capacity frame; closing connection: {e}"
+                        );
+                    }
+                    StreamReadErrorKind::Fatal => {
+                        tracing::error!("iroh read error for peer {peer_id}: {e}");
+                    }
+                }
+                return Err(e.into());
             }
-            Err(StreamError::Read(iroh::endpoint::ReadExactError::FinishedEarly(_))) => {
-                tracing::debug!("iroh stream finished (peer closed)");
-                break;
-            }
-            Err(e) => return Err(e.into()),
         };
 
         tracing::debug!("received {} inbound bytes from peer {peer_id}", bytes.len());
@@ -99,9 +196,6 @@ pub async fn listener_task(conn: IrohTransport, mut recv: RecvStream) -> Result<
             .await
             .map_err(|e| RunError::ChanSend(Box::new(e)))?;
     }
-
-    tracing::info!("iroh listener task for peer {peer_id}: exiting");
-    Ok(())
 }
 
 /// Background task: drains the outbound channel and writes framed messages
@@ -124,4 +218,39 @@ pub async fn sender_task(
 
     tracing::info!("sender task: outbound channel closed, shutting down");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StreamError, StreamReadErrorKind};
+
+    /// An over-cap frame classifies as `OverCapacity` and closes with the
+    /// 1009 (Message Too Big) application code.
+    #[test]
+    fn over_cap_classifies_and_closes_1009() {
+        let err = StreamError::FrameTooLarge {
+            actual: 100,
+            max: 10,
+        };
+        let kind = StreamReadErrorKind::classify(&err);
+        assert_eq!(kind, StreamReadErrorKind::OverCapacity);
+
+        let code: u64 = kind.close_code().into();
+        assert_eq!(code, 1009);
+        assert!(!kind.close_reason().is_empty());
+    }
+
+    /// Close-code mapping is stable across all kinds.
+    #[test]
+    fn close_code_mapping() {
+        let cases = [
+            (StreamReadErrorKind::ExpectedDisconnect, 0u64),
+            (StreamReadErrorKind::OverCapacity, 1009),
+            (StreamReadErrorKind::Fatal, 1011),
+        ];
+        for (kind, expected) in cases {
+            let code: u64 = kind.close_code().into();
+            assert_eq!(code, expected, "{kind:?} should close with {expected}");
+        }
+    }
 }

--- a/subduction_iroh/src/tasks.rs
+++ b/subduction_iroh/src/tasks.rs
@@ -5,7 +5,7 @@
 
 use alloc::vec::Vec;
 
-use iroh::endpoint::{RecvStream, SendStream};
+use iroh::endpoint::{ReadError, ReadExactError, RecvStream, SendStream};
 
 use crate::{
     error::{RunError, StreamError},
@@ -85,8 +85,6 @@ enum StreamReadErrorKind {
 
 impl StreamReadErrorKind {
     const fn classify(e: &StreamError) -> Self {
-        use iroh::endpoint::{ReadError, ReadExactError};
-
         match e {
             // Peer-driven terminations (graceful or abrupt) are benign: the
             // connection was lost, the stream finished, the peer reset it
@@ -228,6 +226,8 @@ pub async fn sender_task(
 
 #[cfg(test)]
 mod tests {
+    use iroh::endpoint::{ReadError, ReadExactError};
+
     use super::{StreamError, StreamReadErrorKind};
 
     /// An over-cap frame classifies as `OverCapacity` and closes with the
@@ -250,8 +250,6 @@ mod tests {
     /// disconnects, not fatal errors.
     #[test]
     fn peer_stream_termination_is_expected_disconnect() {
-        use iroh::endpoint::{ReadError, ReadExactError};
-
         let cases = [
             StreamError::Read(ReadExactError::ReadError(ReadError::Reset(7u32.into()))),
             StreamError::Read(ReadExactError::ReadError(ReadError::ClosedStream)),

--- a/subduction_iroh/src/transport.rs
+++ b/subduction_iroh/src/transport.rs
@@ -98,12 +98,23 @@ impl IrohTransport {
         self.inner.inbound_writer.send(bytes).await
     }
 
-    /// Close the connection's channels and the underlying QUIC connection.
+    /// Close the connection's channels and the underlying QUIC connection
+    /// with the default (normal) application error code.
     pub fn close(&self) {
+        self.close_with_code(0u32.into(), b"subduction close");
+    }
+
+    /// Close the connection's channels and the underlying QUIC connection
+    /// with an explicit application error code and reason.
+    ///
+    /// Closing the channels notifies any parked `recv_bytes` immediately; the
+    /// QUIC `close` is the graceful, peer-visible signal (with `code`/`reason`)
+    /// analogous to a WebSocket Close frame. Idempotent.
+    pub fn close_with_code(&self, code: iroh::endpoint::VarInt, reason: &[u8]) {
         self.inner.inbound_writer.close();
         self.inner.outbound_tx.close();
         self.inner.inbound_reader.close();
-        self.inner.quic_conn.close(0u32.into(), b"subduction close");
+        self.inner.quic_conn.close(code, reason);
     }
 
     /// Access the underlying iroh QUIC connection.

--- a/subduction_iroh/src/transport.rs
+++ b/subduction_iroh/src/transport.rs
@@ -155,7 +155,10 @@ impl Transport<Sendable> for IrohTransport {
 
         async move {
             let bytes = chan.recv().await.map_err(|_| {
-                tracing::error!("inbound channel closed unexpectedly");
+                // The inbound channel closes when the listener tears the
+                // connection down. This is the expected disconnect signal, not
+                // an error.
+                tracing::debug!("inbound channel closed; connection torn down");
                 RecvError
             })?;
 

--- a/subduction_iroh/tests/over_cap_frame.rs
+++ b/subduction_iroh/tests/over_cap_frame.rs
@@ -1,0 +1,112 @@
+//! Tests for the over-cap frame failure mode on the Iroh (QUIC) transport.
+//!
+//! When the listener reads a frame whose length prefix exceeds the cap, it
+//! tears the connection down: the inbound channel is closed so a parked
+//! `recv_bytes` is notified immediately, and the QUIC connection is closed with
+//! application error code 1009 (Message Too Big), the QUIC analog of a
+//! WebSocket Close(Size) frame.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    missing_docs,
+    unreachable_pub
+)]
+
+use std::time::Duration;
+
+use future_form::Sendable;
+use iroh::endpoint::presets;
+use subduction_core::{peer::id::PeerId, transport::Transport};
+use subduction_iroh::{tasks::listener_task, transport::IrohTransport};
+use testresult::TestResult;
+
+/// A frame prefix larger than the listener's 50 MiB cap.
+const OVER_CAP_LEN: u32 = 60 * 1024 * 1024;
+
+const TEST_ALPN: &[u8] = b"subduction-over-cap-test";
+
+#[tokio::test]
+async fn over_cap_frame_tears_down_and_closes_1009() -> TestResult {
+    // Two endpoints on loopback.
+    let server_ep = iroh::Endpoint::builder(presets::Minimal)
+        .alpns(vec![TEST_ALPN.to_vec()])
+        .bind()
+        .await
+        .expect("bind server endpoint");
+    let client_ep = iroh::Endpoint::builder(presets::Minimal)
+        .bind()
+        .await
+        .expect("bind client endpoint");
+
+    let server_addr = server_ep.addr();
+
+    // Server: accept the connection, accept a bi-stream, run the listener on the
+    // recv half. The send half is parked (we only care about the read path).
+    // The endpoint is returned so its QUIC driver keeps running long enough to
+    // transmit the CONNECTION_CLOSE frame to the client.
+    let server_join = tokio::spawn(async move {
+        let incoming = server_ep.accept().await.expect("incoming");
+        let conn = incoming.await.expect("accept connection");
+        let (_send, recv) = conn.accept_bi().await.expect("accept bi-stream");
+
+        let (transport, _outbound_rx): (IrohTransport, _) =
+            IrohTransport::new(PeerId::new([7u8; 32]), conn.clone());
+
+        // Park a consumer on the inbound channel, as `Subduction::listen` would.
+        let recv_transport = transport.clone();
+        let recv_join = tokio::spawn(async move {
+            Transport::<Sendable>::recv_bytes(&recv_transport).await
+        });
+
+        let listen_result = listener_task(transport, recv).await;
+        (server_ep, conn, recv_join, listen_result)
+    });
+
+    // Client: connect, open a bi-stream, write a raw over-cap length prefix.
+    let conn = client_ep
+        .connect(server_addr, TEST_ALPN)
+        .await
+        .expect("client connect");
+    let (mut send, _recv) = conn.open_bi().await.expect("open bi-stream");
+    send.write_all(&OVER_CAP_LEN.to_be_bytes())
+        .await
+        .expect("write over-cap length prefix");
+    // A few payload bytes (fewer than declared) so the listener acts on the
+    // length prefix, not on the (incomplete) payload.
+    send.write_all(&[0u8; 16]).await.expect("write payload");
+
+    let (_server_ep, _server_conn, recv_join, listen_result) =
+        tokio::time::timeout(Duration::from_secs(10), server_join)
+            .await
+            .expect("server task should finish promptly")
+            .expect("server task join");
+
+    // The listener returns an error for the over-cap frame.
+    assert!(
+        listen_result.is_err(),
+        "listener should error on an over-cap frame, got {listen_result:?}"
+    );
+
+    // The parked recv is notified promptly (inbound channel closed on teardown).
+    let recv_outcome = tokio::time::timeout(Duration::from_millis(500), recv_join)
+        .await
+        .expect("recv_bytes should resolve promptly after teardown")
+        .expect("recv task join");
+    assert!(
+        recv_outcome.is_err(),
+        "recv_bytes should return Err after the connection tears down"
+    );
+
+    // The client observes the remote (application) close with code 1009.
+    let reason = tokio::time::timeout(Duration::from_secs(5), conn.closed())
+        .await
+        .expect("client should observe the connection close");
+    let code = match reason {
+        iroh::endpoint::ConnectionError::ApplicationClosed(ref app) => u64::from(app.error_code),
+        other => panic!("expected ApplicationClosed, got {other:?}"),
+    };
+    assert_eq!(code, 1009, "over-cap should close with code 1009");
+
+    Ok(())
+}

--- a/subduction_iroh/tests/over_cap_frame.rs
+++ b/subduction_iroh/tests/over_cap_frame.rs
@@ -8,6 +8,7 @@
 
 #![allow(
     clippy::expect_used,
+    clippy::panic,
     clippy::unwrap_used,
     missing_docs,
     unreachable_pub
@@ -55,9 +56,8 @@ async fn over_cap_frame_tears_down_and_closes_1009() -> TestResult {
 
         // Park a consumer on the inbound channel, as `Subduction::listen` would.
         let recv_transport = transport.clone();
-        let recv_join = tokio::spawn(async move {
-            Transport::<Sendable>::recv_bytes(&recv_transport).await
-        });
+        let recv_join =
+            tokio::spawn(async move { Transport::<Sendable>::recv_bytes(&recv_transport).await });
 
         let listen_result = listener_task(transport, recv).await;
         (server_ep, conn, recv_join, listen_result)
@@ -102,11 +102,14 @@ async fn over_cap_frame_tears_down_and_closes_1009() -> TestResult {
     let reason = tokio::time::timeout(Duration::from_secs(5), conn.closed())
         .await
         .expect("client should observe the connection close");
-    let code = match reason {
-        iroh::endpoint::ConnectionError::ApplicationClosed(ref app) => u64::from(app.error_code),
-        other => panic!("expected ApplicationClosed, got {other:?}"),
+    let iroh::endpoint::ConnectionError::ApplicationClosed(app) = &reason else {
+        panic!("expected ApplicationClosed, got {reason:?}");
     };
-    assert_eq!(code, 1009, "over-cap should close with code 1009");
+    assert_eq!(
+        u64::from(app.error_code),
+        1009,
+        "over-cap should close with code 1009"
+    );
 
     Ok(())
 }

--- a/subduction_wasm/e2e/ephemeral.spec.ts
+++ b/subduction_wasm/e2e/ephemeral.spec.ts
@@ -74,7 +74,7 @@ test.beforeAll(async ({ browserName }) => {
 
   subductionServer = spawn(
     cliPath,
-    ["server", "--socket", `${WS_HOST}:${currentPort}`, "--ephemeral-key", "--open-policy"],
+    ["server", "--socket", `${WS_HOST}:${currentPort}`, "--ephemeral-key", "--auth", "open"],
     {
       cwd: path.join(__dirname, "../.."),
       stdio: "pipe",

--- a/subduction_wasm/e2e/longpoll-connection.spec.ts
+++ b/subduction_wasm/e2e/longpoll-connection.spec.ts
@@ -60,7 +60,7 @@ test.beforeAll(async ({ browserName }) => {
   // Start server with both transports enabled (default), ephemeral key for test isolation
   subductionServer = spawn(
     cliPath,
-    ["server", "--socket", `${LP_HOST}:${currentPort}`, "--ephemeral-key", "--open-policy"],
+    ["server", "--socket", `${LP_HOST}:${currentPort}`, "--ephemeral-key", "--auth", "open"],
     {
       cwd: path.join(__dirname, "../.."),
       stdio: "pipe",

--- a/subduction_websocket/Cargo.toml
+++ b/subduction_websocket/Cargo.toml
@@ -59,6 +59,10 @@ name = "round_trip"
 required-features = ["tokio_server", "tokio_client"]
 
 [[test]]
+name = "over_cap_frame_repro"
+required-features = ["tokio_server", "tokio_client"]
+
+[[test]]
 name = "tokio_tests"
 required-features = ["tokio_server", "tokio_client"]
 

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -385,10 +385,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
                             break Err(RunError::ChanSend(Box::new(e)));
                         }
 
-                        tracing::debug!(
-                            "forwarded inbound message to channel {}",
-                            self.chan_id
-                        );
+                        tracing::debug!("forwarded inbound message to channel {}", self.chan_id);
                     }
                     Ok(tungstenite::Message::Text(text)) => {
                         tracing::warn!("unexpected text message: {}", text);
@@ -555,9 +552,9 @@ impl ReadErrorKind {
         match e {
             Error::ConnectionClosed
             | Error::AlreadyClosed
-            | Error::Protocol(
-                tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
-            ) => Self::ExpectedDisconnect,
+            | Error::Protocol(tungstenite::error::ProtocolError::ResetWithoutClosingHandshake) => {
+                Self::ExpectedDisconnect
+            }
 
             // An over-cap inbound message is peer-induced, not our fault.
             Error::Capacity(CapacityError::MessageTooLong { .. }) => Self::OverCapacity,
@@ -721,11 +718,7 @@ mod tests {
     /// learns precisely why.
     #[test]
     fn classify_over_cap_originates_close_size() {
-        use tungstenite::{
-            Error,
-            error::CapacityError,
-            protocol::frame::coding::CloseCode,
-        };
+        use tungstenite::{Error, error::CapacityError, protocol::frame::coding::CloseCode};
 
         let err = Error::Capacity(CapacityError::MessageTooLong {
             size: 100,
@@ -770,11 +763,7 @@ mod tests {
     /// (1011 Internal Error).
     #[test]
     fn classify_unexpected_originates_close_error() {
-        use tungstenite::{
-            Error,
-            error::ProtocolError,
-            protocol::frame::coding::CloseCode,
-        };
+        use tungstenite::{Error, error::ProtocolError, protocol::frame::coding::CloseCode};
 
         // A protocol error other than the benign reset is unexpected.
         let err = Error::Protocol(ProtocolError::UnmaskedFrameFromClient);

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -353,69 +353,124 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
     #[allow(clippy::too_many_lines)]
     pub async fn listen(&self) -> Result<(), RunError> {
         tracing::info!("starting WebSocket listener for peer {:?}", self.peer_id);
-        let mut in_chan = self.ws_reader.lock().await;
-        while let Some(ws_msg) = in_chan.next().await {
-            tracing::debug!(
-                "received WebSocket message for peer {} on channel {}",
-                self.peer_id,
-                self.chan_id
-            );
 
-            match ws_msg {
-                Ok(tungstenite::Message::Binary(bytes)) => {
-                    self.inbound_writer
-                        .send(bytes.to_vec())
-                        .await
-                        .map_err(|e| {
+        // Outcome to return once the loop ends. Teardown (closing the inbound
+        // channel so a parked `recv_bytes` is notified) happens uniformly after
+        // the loop, regardless of *why* it ended — error, remote Close, or EOF.
+        // This is what stops the connection from sitting half-open until
+        // keepalive reaps it (~80 s with `KeepAlive::balanced`).
+        let outcome: Result<(), RunError> = {
+            let mut in_chan = self.ws_reader.lock().await;
+            loop {
+                let Some(ws_msg) = in_chan.next().await else {
+                    // Stream ended (EOF). The write half is already gone, so
+                    // there is nothing to gracefully close — just tear down.
+                    tracing::debug!(peer_id = ?self.peer_id, "websocket stream ended (EOF)");
+                    break Ok(());
+                };
+
+                tracing::debug!(
+                    "received WebSocket message for peer {} on channel {}",
+                    self.peer_id,
+                    self.chan_id
+                );
+
+                match ws_msg {
+                    Ok(tungstenite::Message::Binary(bytes)) => {
+                        if let Err(e) = self.inbound_writer.send(bytes.to_vec()).await {
                             tracing::error!(
                                 "failed to send inbound message to channel {}",
                                 self.chan_id,
                             );
-                            RunError::ChanSend(Box::new(e))
-                        })?;
+                            break Err(RunError::ChanSend(Box::new(e)));
+                        }
 
-                    tracing::debug!("forwarded inbound message to channel {}", self.chan_id);
-                }
-                Ok(tungstenite::Message::Text(text)) => {
-                    tracing::warn!("unexpected text message: {}", text);
-                }
-                Ok(tungstenite::Message::Ping(p)) => {
-                    tracing::trace!(size = p.len(), peer_id = ?self.peer_id, "received ping");
-                    // Non-blocking so a saturated outbound queue can't
-                    // stall the listener. A dropped pong may cost one
-                    // keepalive cycle on the remote side.
-                    if let Err(e) = self.outbound_tx.try_send(tungstenite::Message::Pong(p)) {
-                        tracing::warn!(
-                            error = ?e,
-                            peer_id = ?self.peer_id,
-                            "dropped pong reply (outbound full or closed)"
+                        tracing::debug!(
+                            "forwarded inbound message to channel {}",
+                            self.chan_id
                         );
                     }
-                }
-                Ok(tungstenite::Message::Pong(p)) => {
-                    tracing::trace!(size = p.len(), peer_id = ?self.peer_id, "received pong");
-                    self.pong_received.store(true, Ordering::Relaxed);
-                }
-                Ok(tungstenite::Message::Frame(f)) => {
-                    tracing::warn!("unexpected frame: {:x?}", f);
-                }
-                Ok(tungstenite::Message::Close(_)) => {
-                    tracing::info!("received close message, shutting down listener");
-                    break;
-                }
-                Err(e) => {
-                    // Distinguish between expected disconnects and real errors
-                    if is_expected_disconnect(&e) {
-                        tracing::debug!("connection closed: {}", e);
-                    } else {
-                        tracing::error!("error reading from websocket: {}", e);
+                    Ok(tungstenite::Message::Text(text)) => {
+                        tracing::warn!("unexpected text message: {}", text);
                     }
-                    Err(e)?;
+                    Ok(tungstenite::Message::Ping(p)) => {
+                        tracing::trace!(size = p.len(), peer_id = ?self.peer_id, "received ping");
+                        // Non-blocking so a saturated outbound queue can't
+                        // stall the listener. A dropped pong may cost one
+                        // keepalive cycle on the remote side.
+                        if let Err(e) = self.outbound_tx.try_send(tungstenite::Message::Pong(p)) {
+                            tracing::warn!(
+                                error = ?e,
+                                peer_id = ?self.peer_id,
+                                "dropped pong reply (outbound full or closed)"
+                            );
+                        }
+                    }
+                    Ok(tungstenite::Message::Pong(p)) => {
+                        tracing::trace!(size = p.len(), peer_id = ?self.peer_id, "received pong");
+                        self.pong_received.store(true, Ordering::Relaxed);
+                    }
+                    Ok(tungstenite::Message::Frame(f)) => {
+                        tracing::warn!("unexpected frame: {:x?}", f);
+                    }
+                    Ok(tungstenite::Message::Close(_)) => {
+                        // The peer initiated the close; `tungstenite` has
+                        // already auto-echoed the Close reply, so we must NOT
+                        // originate our own (it would be a redundant
+                        // double-close). Just stop reading.
+                        tracing::info!(
+                            peer_id = ?self.peer_id,
+                            "received close message, shutting down listener"
+                        );
+                        break Ok(());
+                    }
+                    Err(e) => {
+                        // Classify once; the category drives log severity and
+                        // whether *we* originate a graceful Close frame.
+                        let kind = ReadErrorKind::classify(&e);
+                        match kind {
+                            ReadErrorKind::ExpectedDisconnect => {
+                                tracing::debug!(peer_id = ?self.peer_id, "connection closed: {e}");
+                            }
+                            ReadErrorKind::OverCapacity => {
+                                // Peer-induced (they sent a message exceeding
+                                // our cap). Not a server fault — warn, don't
+                                // error.
+                                tracing::warn!(
+                                    peer_id = ?self.peer_id,
+                                    "peer sent an over-capacity message; closing connection: {e}"
+                                );
+                            }
+                            ReadErrorKind::Fatal => {
+                                tracing::error!(
+                                    peer_id = ?self.peer_id,
+                                    "error reading from websocket: {e}"
+                                );
+                            }
+                        }
+
+                        // For errors where we are the party ending the
+                        // connection (over-cap / fatal), send a best-effort
+                        // graceful Close frame so the peer learns why. The
+                        // sender task drains it before the channel-close below
+                        // takes effect (`async-channel` allows buffered
+                        // messages to be received after `close()`).
+                        if let Some(close_frame) = kind.close_frame() {
+                            drop(self.outbound_tx.try_send(close_frame));
+                        }
+
+                        break Err(RunError::from(e));
+                    }
                 }
             }
-        }
+        };
 
-        Ok(())
+        // Uniform teardown: the read half is dead however we got here, so close
+        // both channels. This notifies a parked `recv_bytes` immediately and
+        // exits the sender task (after it flushes any queued graceful Close).
+        self.close_channels();
+
+        outcome
     }
 }
 
@@ -462,18 +517,86 @@ impl<T: AsyncRead + AsyncWrite + Unpin> WebSocket<T, Sendable> {
     }
 }
 
-/// Check if a WebSocket error is an expected disconnect (not a real error).
+/// How a read error from the WebSocket should be treated by the listener.
 ///
-/// These are normal occurrences when the remote end closes without a proper
-/// WebSocket close handshake (e.g., browser tab closed, network disconnect).
-const fn is_expected_disconnect(e: &tungstenite::Error) -> bool {
-    use tungstenite::Error;
-    matches!(
-        e,
-        Error::ConnectionClosed
+/// Parsing the raw [`tungstenite::Error`] into this category up front keeps the
+/// listen loop's branching honest: the log severity and the teardown decision
+/// both follow from the category rather than from ad-hoc `matches!` checks
+/// scattered through the loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReadErrorKind {
+    /// A benign disconnect: the remote end went away, with or without a clean
+    /// close handshake (browser tab closed, network drop, TCP reset). Normal
+    /// lifecycle, log quietly.
+    ExpectedDisconnect,
+
+    /// Peer-induced: the remote sent a message larger than our configured cap.
+    /// This is the peer's doing, not a fault on our side, so it should not be
+    /// logged at error severity. The connection cannot continue (the framing
+    /// is desynchronized once an over-cap frame is seen), so it is still a
+    /// teardown condition — just not an *alarm* condition.
+    OverCapacity,
+
+    /// A genuine transport/protocol fault we did not anticipate. Log loudly and
+    /// tear the connection down.
+    Fatal,
+}
+
+impl ReadErrorKind {
+    /// Classify a [`tungstenite::Error`] surfaced while reading.
+    #[allow(
+        clippy::wildcard_enum_match_arm,
+        reason = "anything we don't explicitly name is, by definition, an \
+                  unanticipated fatal read error; a catch-all is the correct \
+                  default and means new tungstenite variants fail safe."
+    )]
+    pub(crate) const fn classify(e: &tungstenite::Error) -> Self {
+        use tungstenite::{Error, error::CapacityError};
+        match e {
+            Error::ConnectionClosed
             | Error::AlreadyClosed
-            | Error::Protocol(tungstenite::error::ProtocolError::ResetWithoutClosingHandshake)
-    )
+            | Error::Protocol(
+                tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+            ) => Self::ExpectedDisconnect,
+
+            // An over-cap inbound message is peer-induced, not our fault.
+            Error::Capacity(CapacityError::MessageTooLong { .. }) => Self::OverCapacity,
+
+            _ => Self::Fatal,
+        }
+    }
+
+    /// The graceful RFC 6455 Close frame to send to the peer for this error
+    /// kind, or `None` if we should not originate a Close.
+    ///
+    /// We only originate a Close when *we* are the party deciding to end the
+    /// connection because of a problem:
+    ///
+    /// - [`Self::OverCapacity`] → `1009 Message Too Big`: tells the peer
+    ///   precisely why (their message exceeded our cap) so it can react
+    ///   (chunk, surface an error) instead of blindly reconnecting.
+    /// - [`Self::Fatal`] → `1011 Internal Error`: an unanticipated server-side
+    ///   condition.
+    /// - [`Self::ExpectedDisconnect`] → `None`: the *remote* initiated the
+    ///   close (or the socket is already gone). `tungstenite` auto-echoes the
+    ///   peer's Close frame, so originating our own would be a redundant
+    ///   double-close.
+    ///
+    /// This is a pure function of the category — unit-testable without a socket.
+    fn close_frame(self) -> Option<tungstenite::Message> {
+        use tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
+
+        let (code, reason) = match self {
+            Self::OverCapacity => (CloseCode::Size, "message exceeds size limit"),
+            Self::Fatal => (CloseCode::Error, "internal error"),
+            Self::ExpectedDisconnect => return None,
+        };
+
+        Some(tungstenite::Message::Close(Some(CloseFrame {
+            code,
+            reason: reason.into(),
+        })))
+    }
 }
 
 /// Keepalive task body.
@@ -591,6 +714,77 @@ mod tests {
     #[allow(clippy::expect_used, reason = "test-only helper")]
     const fn nz(n: u32) -> NonZeroU32 {
         NonZeroU32::new(n).expect("non-zero")
+    }
+
+    /// An over-cap message is peer-induced: classified as `OverCapacity`, and
+    /// we originate a graceful `Close(Size)` (1009 Message Too Big) so the peer
+    /// learns precisely why.
+    #[test]
+    fn classify_over_cap_originates_close_size() {
+        use tungstenite::{
+            Error,
+            error::CapacityError,
+            protocol::frame::coding::CloseCode,
+        };
+
+        let err = Error::Capacity(CapacityError::MessageTooLong {
+            size: 100,
+            max_size: 10,
+        });
+        let kind = ReadErrorKind::classify(&err);
+        assert_eq!(kind, ReadErrorKind::OverCapacity);
+
+        let Some(tungstenite::Message::Close(Some(frame))) = kind.close_frame() else {
+            unreachable!("over-cap must originate a Close(Some(_)) frame");
+        };
+        assert_eq!(frame.code, CloseCode::Size, "over-cap should send 1009");
+        assert!(!frame.reason.is_empty(), "should carry a reason string");
+    }
+
+    /// Benign disconnects classify as `ExpectedDisconnect` and do NOT originate
+    /// a Close frame: the remote already initiated the close (tungstenite
+    /// auto-echoes), so we must not double-close.
+    #[test]
+    fn classify_expected_disconnects_send_no_close() {
+        use tungstenite::{Error, error::ProtocolError};
+
+        for err in [
+            Error::ConnectionClosed,
+            Error::AlreadyClosed,
+            Error::Protocol(ProtocolError::ResetWithoutClosingHandshake),
+        ] {
+            let kind = ReadErrorKind::classify(&err);
+            assert_eq!(
+                kind,
+                ReadErrorKind::ExpectedDisconnect,
+                "{err:?} should be an expected disconnect"
+            );
+            assert!(
+                kind.close_frame().is_none(),
+                "expected disconnects must not originate a Close frame ({err:?})"
+            );
+        }
+    }
+
+    /// An unanticipated read error is `Fatal`: we originate a `Close(Error)`
+    /// (1011 Internal Error).
+    #[test]
+    fn classify_unexpected_originates_close_error() {
+        use tungstenite::{
+            Error,
+            error::ProtocolError,
+            protocol::frame::coding::CloseCode,
+        };
+
+        // A protocol error other than the benign reset is unexpected.
+        let err = Error::Protocol(ProtocolError::UnmaskedFrameFromClient);
+        let kind = ReadErrorKind::classify(&err);
+        assert_eq!(kind, ReadErrorKind::Fatal);
+
+        let Some(tungstenite::Message::Close(Some(frame))) = kind.close_frame() else {
+            unreachable!("fatal must originate a Close(Some(_)) frame");
+        };
+        assert_eq!(frame.code, CloseCode::Error, "fatal should send 1011");
     }
 
     async fn create_mock_websocket_stream() -> WebSocketStream<Cursor<Vec<u8>>> {

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -16,6 +16,11 @@ use future_form::{FutureForm, Local, Sendable, future_form};
 use futures::{FutureExt, future::BoxFuture};
 use futures_util::{AsyncRead, AsyncWrite, StreamExt};
 use subduction_core::{peer::id::PeerId, transport::Transport};
+use tungstenite::{
+    Error, Message,
+    error::{CapacityError, ProtocolError},
+    protocol::{CloseFrame, frame::coding::CloseCode},
+};
 
 use crate::{
     error::{DisconnectionError, RecvError, RunError, SendError},
@@ -547,12 +552,11 @@ impl ReadErrorKind {
                   unanticipated fatal read error; a catch-all is the correct \
                   default and means new tungstenite variants fail safe."
     )]
-    pub(crate) const fn classify(e: &tungstenite::Error) -> Self {
-        use tungstenite::{Error, error::CapacityError};
+    pub(crate) const fn classify(e: &Error) -> Self {
         match e {
             Error::ConnectionClosed
             | Error::AlreadyClosed
-            | Error::Protocol(tungstenite::error::ProtocolError::ResetWithoutClosingHandshake) => {
+            | Error::Protocol(ProtocolError::ResetWithoutClosingHandshake) => {
                 Self::ExpectedDisconnect
             }
 
@@ -580,16 +584,14 @@ impl ReadErrorKind {
     ///   double-close.
     ///
     /// This is a pure function of the category — unit-testable without a socket.
-    fn close_frame(self) -> Option<tungstenite::Message> {
-        use tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
-
+    fn close_frame(self) -> Option<Message> {
         let (code, reason) = match self {
             Self::OverCapacity => (CloseCode::Size, "message exceeds size limit"),
             Self::Fatal => (CloseCode::Error, "internal error"),
             Self::ExpectedDisconnect => return None,
         };
 
-        Some(tungstenite::Message::Close(Some(CloseFrame {
+        Some(Message::Close(Some(CloseFrame {
             code,
             reason: reason.into(),
         })))
@@ -612,8 +614,6 @@ where
     S: Sleeper<Async>,
     Async: FutureForm + ?Sized,
 {
-    use tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
-
     let mut consecutive_misses: u32 = 0;
     let threshold = config.missed_pong_threshold.get();
 
@@ -718,8 +718,6 @@ mod tests {
     /// learns precisely why.
     #[test]
     fn classify_over_cap_originates_close_size() {
-        use tungstenite::{Error, error::CapacityError, protocol::frame::coding::CloseCode};
-
         let err = Error::Capacity(CapacityError::MessageTooLong {
             size: 100,
             max_size: 10,
@@ -727,7 +725,7 @@ mod tests {
         let kind = ReadErrorKind::classify(&err);
         assert_eq!(kind, ReadErrorKind::OverCapacity);
 
-        let Some(tungstenite::Message::Close(Some(frame))) = kind.close_frame() else {
+        let Some(Message::Close(Some(frame))) = kind.close_frame() else {
             unreachable!("over-cap must originate a Close(Some(_)) frame");
         };
         assert_eq!(frame.code, CloseCode::Size, "over-cap should send 1009");
@@ -739,8 +737,6 @@ mod tests {
     /// auto-echoes), so we must not double-close.
     #[test]
     fn classify_expected_disconnects_send_no_close() {
-        use tungstenite::{Error, error::ProtocolError};
-
         for err in [
             Error::ConnectionClosed,
             Error::AlreadyClosed,
@@ -763,23 +759,18 @@ mod tests {
     /// (1011 Internal Error).
     #[test]
     fn classify_unexpected_originates_close_error() {
-        use tungstenite::{Error, error::ProtocolError, protocol::frame::coding::CloseCode};
-
         // A protocol error other than the benign reset is unexpected.
         let err = Error::Protocol(ProtocolError::UnmaskedFrameFromClient);
         let kind = ReadErrorKind::classify(&err);
         assert_eq!(kind, ReadErrorKind::Fatal);
 
-        let Some(tungstenite::Message::Close(Some(frame))) = kind.close_frame() else {
+        let Some(Message::Close(Some(frame))) = kind.close_frame() else {
             unreachable!("fatal must originate a Close(Some(_)) frame");
         };
         assert_eq!(frame.code, CloseCode::Error, "fatal should send 1011");
     }
 
     async fn create_mock_websocket_stream() -> WebSocketStream<Cursor<Vec<u8>>> {
-        use async_tungstenite::WebSocketStream;
-        use futures::io::Cursor;
-
         let buffer = Cursor::new(Vec::new());
         WebSocketStream::from_raw_socket(buffer, tungstenite::protocol::Role::Client, None).await
     }
@@ -819,8 +810,6 @@ mod tests {
     /// `Close(Away, ...)`. Mock-time so we're CI-jitter-free.
     #[tokio::test(start_paused = true)]
     async fn keepalive_loop_times_out_on_silent_peer() -> TestResult {
-        use tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
-
         let (outbound_tx, outbound_rx) = async_channel::bounded::<tungstenite::Message>(16);
         let (inbound_writer, inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
         let pong_received = Arc::new(AtomicBool::new(false));

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -247,7 +247,11 @@ impl<T, Async: FutureForm> Transport<Async> for WebSocket<T, Async> {
 
         Async::from_future(async move {
             let bytes = chan.recv().await.map_err(|_| {
-                tracing::error!("inbound channel closed unexpectedly");
+                // The inbound channel closes when the listener tears the
+                // connection down (peer close, EOF, over-cap, fatal, or
+                // keepalive timeout). This is the expected disconnect signal,
+                // not an error.
+                tracing::debug!("inbound channel closed; connection torn down");
                 RecvError
             })?;
 

--- a/subduction_websocket/tests/over_cap_frame_repro.rs
+++ b/subduction_websocket/tests/over_cap_frame_repro.rs
@@ -1,0 +1,394 @@
+//! Characterization tests for the over-cap WebSocket frame failure mode.
+//!
+//! These tests pin down the *current* (buggy) behavior so that any fix can be
+//! evaluated against a concrete reproduction rather than against a reading of
+//! the `tungstenite` source. They encode two load-bearing facts:
+//!
+//! 1. [`oversized_frame_poisons_receiver_stream`] — an inbound frame whose
+//!    declared length exceeds the receiver's `max_frame_size` returns
+//!    `Err(Capacity(MessageTooLong))` and leaves the `tungstenite` stream
+//!    **unrecoverable**: a small, valid follow-up message sent on the same
+//!    connection is *not* cleanly delivered. This is why a "skip the offending
+//!    message and keep reading" strategy is impossible at the transport layer,
+//!    and why prevention (chunking) — not recovery — is the durable fix.
+//!
+//! 2. [`listen_does_not_close_inbound_channel_on_over_cap`] — the current
+//!    [`WebSocket::listen`] returns `Err` on an over-cap inbound frame but does
+//!    **not** close the inbound channel. A concurrent `recv_bytes` is therefore
+//!    left parked instead of promptly observing the disconnect; the rest of the
+//!    stack only learns the peer is gone via keepalive (~80 s with
+//!    [`KeepAlive::balanced`]). This is the "bail badly" behavior we intend to
+//!    change.
+//!
+//! If a future change makes either fact no longer hold (e.g. `tungstenite`
+//! learns to drain-and-discard an over-cap frame, or `listen` is changed to
+//! cascade a close), these tests should be updated deliberately — they are the
+//! canary for the assumptions the fix design rests on.
+
+#![allow(clippy::expect_used, reason = "test-only assertions")]
+#![allow(clippy::unwrap_used, reason = "test-only assertions")]
+#![allow(clippy::panic, reason = "an intentional assertion failure in a test")]
+
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use tokio::net::{TcpListener, TcpStream};
+use tungstenite::protocol::WebSocketConfig;
+
+/// Receiver-side cap used for both tests. Small so we can exceed it cheaply.
+const RECV_CAP: usize = 4 * 1024;
+
+/// Marker byte filling the small follow-up message, so we can recognize it
+/// among any post-error frames.
+const MARKER: u8 = 0x5A;
+
+/// Build a connected client/server `WebSocketStream` pair over loopback TCP,
+/// with the *server* (receiver) configured to the given cap on both message
+/// and frame size — mirroring the project convention of setting them equal.
+async fn connected_pair(
+    recv_cap: usize,
+) -> (
+    async_tungstenite::WebSocketStream<
+        async_tungstenite::tokio::TokioAdapter<TcpStream>,
+    >,
+    async_tungstenite::WebSocketStream<
+        async_tungstenite::tokio::TokioAdapter<TcpStream>,
+    >,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+
+    let recv_config = WebSocketConfig::default()
+        .max_message_size(Some(recv_cap))
+        .max_frame_size(Some(recv_cap));
+
+    let server_join = tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.expect("accept tcp");
+        async_tungstenite::tokio::accept_async_with_config(tcp, Some(recv_config))
+            .await
+            .expect("ws accept")
+    });
+
+    let tcp = TcpStream::connect(addr).await.expect("connect tcp");
+    let uri = format!("ws://{addr}/");
+    let (client_ws, _resp) =
+        async_tungstenite::tokio::client_async_with_config(uri, tcp, None)
+            .await
+            .expect("ws client");
+
+    let server_ws = server_join.await.expect("server task");
+    (client_ws, server_ws)
+}
+
+/// LOAD-BEARING CLAIM: an over-cap frame poisons the receiver stream.
+///
+/// The sender writes one binary frame larger than the receiver's cap, then a
+/// small valid binary frame tagged with a distinctive byte. The receiver must
+/// (a) see `MessageTooLong` and (b) be **unable** to then read that small
+/// follow-up on any subsequent poll — proving the stream cannot be
+/// resynchronized after the offending frame.
+///
+/// ## Why "poisoned" — the mechanism
+///
+/// In `tungstenite::protocol::frame::FrameSocket::read_frame`
+/// (`frame/mod.rs:170-210`):
+///
+/// - The frame header is parsed and consumed off the internal `in_buffer`
+///   (`advance`, line 175), and stashed in `self.header`.
+/// - If the declared length exceeds `max_frame_size`, it returns
+///   `Err(MessageTooLong)` at line 182 — *before* the payload bytes are read or
+///   discarded, and *before* `self.header.take()` at line 210.
+///
+/// So after the error: (1) the oversized payload bytes are still unread in the
+/// socket, and (2) `self.header` is still `Some(<oversized>)`. The next
+/// `read_frame` re-enters with that stuck header and tries forever to assemble
+/// a frame it will never admit — or misreads leftover payload as a new header.
+/// There is no drain-and-skip path. The follow-up message is unreachable.
+#[tokio::test]
+async fn oversized_frame_poisons_receiver_stream() {
+    let (mut client_ws, mut server_ws) = connected_pair(RECV_CAP).await;
+
+    // One oversized message (browsers send this as a single unfragmented
+    // frame), followed by a small valid one with a recognizable marker byte.
+    let oversized = vec![0xABu8; RECV_CAP * 2];
+    let small = vec![MARKER; 16];
+
+    let sender = tokio::spawn(async move {
+        client_ws
+            .send(tungstenite::Message::Binary(oversized.into()))
+            .await
+            .expect("send oversized");
+        client_ws
+            .send(tungstenite::Message::Binary(small.into()))
+            .await
+            .expect("send small");
+        // Keep the client alive so the server's failure is about the frame,
+        // not about the TCP connection being torn down.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        client_ws
+    });
+
+    // First read: the over-cap frame must surface as MessageTooLong.
+    let first = server_ws.next().await.expect("a first item");
+    let err = first.expect_err("over-cap frame must be an error, not delivered");
+    assert!(
+        matches!(
+            err,
+            tungstenite::Error::Capacity(
+                tungstenite::error::CapacityError::MessageTooLong { .. }
+            )
+        ),
+        "expected Capacity(MessageTooLong), got {err:?}"
+    );
+
+    // Now poll the stream several more times. If it were recoverable, the small
+    // follow-up (a `Binary` whose bytes are all MARKER) would appear on one of
+    // these reads. Record the exact sequence so the mechanism is visible, and
+    // assert the follow-up NEVER arrives cleanly.
+    let mut transcript: Vec<String> = Vec::new();
+    let mut recovered_followup = false;
+
+    for attempt in 0..5 {
+        // Bound each poll so a permanently-stuck read can't hang the test.
+        let polled = tokio::time::timeout(Duration::from_millis(200), server_ws.next()).await;
+
+        match polled {
+            Err(_elapsed) => {
+                transcript.push(format!("attempt {attempt}: read STUCK (timed out)"));
+                // A stuck read is itself proof of non-recovery; stop probing.
+                break;
+            }
+            Ok(None) => {
+                transcript.push(format!("attempt {attempt}: stream ended (None)"));
+                break;
+            }
+            Ok(Some(Err(e))) => {
+                transcript.push(format!("attempt {attempt}: Err({e:?})"));
+            }
+            Ok(Some(Ok(tungstenite::Message::Binary(bytes)))) => {
+                let is_followup = bytes.len() == 16 && bytes.iter().all(|&b| b == MARKER);
+                transcript.push(format!(
+                    "attempt {attempt}: Ok(Binary[{} bytes], is_followup={is_followup})",
+                    bytes.len()
+                ));
+                if is_followup {
+                    recovered_followup = true;
+                    break;
+                }
+            }
+            Ok(Some(Ok(other))) => {
+                transcript.push(format!("attempt {attempt}: Ok({other:?})"));
+            }
+        }
+    }
+
+    let report = transcript.join("\n  ");
+    assert!(
+        !recovered_followup,
+        "stream unexpectedly recovered: the small follow-up message was \
+         delivered cleanly after the over-cap frame. If this is now reachable, \
+         tungstenite gained a drain-and-skip path and the 'skip-and-continue' \
+         design becomes viable — revisit the fix plan.\n  Transcript:\n  {report}"
+    );
+
+    // Surface the transcript on success too, so the mechanism is inspectable
+    // with `--nocapture`.
+    eprintln!("post-error read transcript (no clean follow-up):\n  {report}");
+
+    let _client_ws = sender.await.expect("sender task");
+}
+
+/// REGRESSION: a fatal/peer-induced `listen()` error tears the connection down
+/// promptly.
+///
+/// When `listen()` exits on an over-cap inbound frame (peer-induced) or any
+/// other fatal read error, the connection must tear itself down so the rest of
+/// the stack learns the peer is gone *now*, not ~80 s later when keepalive
+/// reaps it. Concretely: a `recv_bytes()` parked on the inbound channel resolves
+/// with `Err` shortly after `listen()` returns its error.
+///
+/// Before the fix, `listen()` returned `Err` but left the inbound channel open,
+/// so the parked `recv_bytes()` hung until keepalive. The fix classifies the
+/// read error (`ReadErrorKind`) and, for `OverCapacity`/`Fatal`, calls
+/// `close_channels()` before returning — which is what this test pins down.
+///
+/// We drive a real `subduction_websocket::WebSocket` receiver against a raw
+/// `async-tungstenite` sender, run `listen()` and a concurrent `recv_bytes()`
+/// together, and require the recv to resolve within a short budget.
+#[tokio::test]
+async fn listen_error_tears_down_connection_promptly() {
+    use future_form::Sendable;
+    use subduction_core::peer::id::PeerId;
+    use subduction_websocket::websocket::WebSocket;
+
+    let (mut client_ws, server_ws) = connected_pair(RECV_CAP).await;
+
+    let (ws, sender_task): (
+        WebSocket<async_tungstenite::tokio::TokioAdapter<TcpStream>, Sendable>,
+        _,
+    ) = WebSocket::new(server_ws, PeerId::new([7u8; 32]));
+
+    // Spawn the sender task (drives the write half) so the receiver is fully
+    // operational, matching production wiring.
+    let sender_join = tokio::spawn(sender_task);
+
+    // A consumer parked on the inbound channel, exactly as `Subduction::listen`
+    // would be. After the fix it must observe the disconnect promptly.
+    let ws_for_recv = ws.clone();
+    let recv_join = tokio::spawn(async move {
+        subduction_core::transport::Transport::<Sendable>::recv_bytes(&ws_for_recv).await
+    });
+
+    // Sender: one over-cap frame, then keep reading its own stream so we can
+    // observe the graceful Close frame the receiver originates. Returns the
+    // first Close frame's code (if any) for a wire-level assertion below.
+    let oversized = vec![0xCDu8; RECV_CAP * 2];
+    let client_join = tokio::spawn(async move {
+        client_ws
+            .send(tungstenite::Message::Binary(oversized.into()))
+            .await
+            .expect("send oversized");
+
+        // Drain inbound frames until we see a Close (or the stream ends).
+        let mut close_code = None;
+        for _ in 0..10 {
+            match tokio::time::timeout(Duration::from_millis(300), client_ws.next()).await {
+                Ok(Some(Ok(tungstenite::Message::Close(frame)))) => {
+                    close_code = frame.map(|f| f.code);
+                    break;
+                }
+                Ok(Some(Ok(_other))) => {}
+                Ok(Some(Err(_)) | None) | Err(_) => break,
+            }
+        }
+        close_code
+    });
+
+    // `listen()` should observe the over-cap frame and return an error.
+    let listen_result = tokio::time::timeout(Duration::from_secs(5), ws.listen())
+        .await
+        .expect("listen should resolve (not hang) on an over-cap frame");
+
+    assert!(
+        listen_result.is_err(),
+        "listen() should return Err on an over-cap inbound frame, got {listen_result:?}"
+    );
+
+    // DESIRED: the parked recv resolves (with Err) promptly because the
+    // connection tore itself down. FAILS today: recv stays parked, so the
+    // timeout elapses.
+    let recv_outcome = tokio::time::timeout(Duration::from_millis(500), recv_join).await;
+
+    assert!(
+        recv_outcome.is_ok(),
+        "recv_bytes should be notified promptly after listen() errors out \
+         (connection tears itself down instead of waiting ~80 s for keepalive). \
+         If this times out, the teardown-on-fatal-error path has regressed."
+    );
+    let recv_result = recv_outcome.expect("recv resolved within budget").expect("recv task joined");
+    assert!(
+        recv_result.is_err(),
+        "the prompt recv result should be an Err (disconnect), got Ok"
+    );
+
+    // WIRE-LEVEL PROOF: the receiver originated a graceful Close frame, and the
+    // peer (this raw client) actually received it with code 1009 (Size /
+    // "Message Too Big") — not just an abrupt TCP drop.
+    let close_code = client_join.await.expect("client task");
+    assert_eq!(
+        close_code,
+        Some(tungstenite::protocol::frame::coding::CloseCode::Size),
+        "peer should receive a graceful Close(Size) frame on over-cap, got {close_code:?}"
+    );
+
+    // Cleanup.
+    ws.close_channels();
+    drop(sender_join.await);
+}
+
+/// REGRESSION: a clean peer-initiated disconnect also notifies a parked
+/// `recv_bytes` promptly — and does NOT make us originate a duplicate Close.
+///
+/// When the peer sends a `Message::Close`, `tungstenite` auto-echoes the Close
+/// reply, so our listener must only tear down its channels (notifying
+/// `recv_bytes`) without enqueuing a second Close of its own. Before folding the
+/// clean-close/EOF paths into the uniform teardown, this `recv_bytes` would have
+/// hung until keepalive.
+#[tokio::test]
+async fn clean_close_tears_down_promptly_without_double_close() {
+    use future_form::Sendable;
+    use subduction_core::peer::id::PeerId;
+    use subduction_websocket::websocket::WebSocket;
+
+    // Equal, generous cap: nothing here is over-cap; we exercise the clean path.
+    let (mut client_ws, server_ws) = connected_pair(RECV_CAP).await;
+
+    let (ws, sender_task): (
+        WebSocket<async_tungstenite::tokio::TokioAdapter<TcpStream>, Sendable>,
+        _,
+    ) = WebSocket::new(server_ws, PeerId::new([9u8; 32]));
+    let sender_join = tokio::spawn(sender_task);
+
+    // Parked consumer, as `Subduction::listen` would be.
+    let ws_for_recv = ws.clone();
+    let recv_join = tokio::spawn(async move {
+        subduction_core::transport::Transport::<Sendable>::recv_bytes(&ws_for_recv).await
+    });
+
+    // Peer initiates a clean close, then drains its own stream to observe how
+    // many Close frames come back. tungstenite auto-echoes exactly one; our
+    // listener must not add a second.
+    let client_join = tokio::spawn(async move {
+        client_ws
+            .send(tungstenite::Message::Close(Some(
+                tungstenite::protocol::CloseFrame {
+                    code: tungstenite::protocol::frame::coding::CloseCode::Normal,
+                    reason: "bye".into(),
+                },
+            )))
+            .await
+            .expect("send close");
+
+        let mut close_frames = 0u32;
+        for _ in 0..10 {
+            match tokio::time::timeout(Duration::from_millis(200), client_ws.next()).await {
+                Ok(Some(Ok(tungstenite::Message::Close(_)))) => close_frames += 1,
+                Ok(Some(Ok(_other))) => {}
+                Ok(Some(Err(_)) | None) | Err(_) => break,
+            }
+        }
+        close_frames
+    });
+
+    // listen() should return Ok(()) on a clean remote close.
+    let listen_result = tokio::time::timeout(Duration::from_secs(5), ws.listen())
+        .await
+        .expect("listen should resolve on a clean remote close");
+    assert!(
+        listen_result.is_ok(),
+        "clean remote close should be Ok(()), got {listen_result:?}"
+    );
+
+    // The parked recv must be notified promptly (the newly-closed gap).
+    let recv_outcome = tokio::time::timeout(Duration::from_millis(500), recv_join).await;
+    assert!(
+        recv_outcome.is_ok(),
+        "recv_bytes should be notified promptly on a clean remote close, not \
+         left parked until keepalive"
+    );
+    let recv_result = recv_outcome
+        .expect("recv resolved within budget")
+        .expect("recv task joined");
+    assert!(recv_result.is_err(), "recv after disconnect should be Err");
+
+    // No duplicate Close: tungstenite's auto-echo is the only Close the peer
+    // sees (we must not originate our own on the peer-initiated path).
+    let close_frames = client_join.await.expect("client task");
+    assert!(
+        close_frames <= 1,
+        "expected at most one (auto-echoed) Close frame, saw {close_frames}"
+    );
+
+    ws.close_channels();
+    drop(sender_join.await);
+}

--- a/subduction_websocket/tests/over_cap_frame_repro.rs
+++ b/subduction_websocket/tests/over_cap_frame_repro.rs
@@ -24,7 +24,10 @@
 
 use std::time::Duration;
 
+use future_form::Sendable;
 use futures_util::StreamExt;
+use subduction_core::peer::id::PeerId;
+use subduction_websocket::websocket::WebSocket;
 use tokio::net::{TcpListener, TcpStream};
 use tungstenite::protocol::WebSocketConfig;
 
@@ -182,10 +185,6 @@ async fn oversized_frame_poisons_receiver_stream() {
 /// together, and requires the recv to resolve within a short budget.
 #[tokio::test]
 async fn listen_error_tears_down_connection_promptly() {
-    use future_form::Sendable;
-    use subduction_core::peer::id::PeerId;
-    use subduction_websocket::websocket::WebSocket;
-
     let (mut client_ws, server_ws) = connected_pair(RECV_CAP).await;
 
     let (ws, sender_task): (
@@ -277,10 +276,6 @@ async fn listen_error_tears_down_connection_promptly() {
 /// without enqueuing a second Close of its own.
 #[tokio::test]
 async fn clean_close_tears_down_promptly_without_double_close() {
-    use future_form::Sendable;
-    use subduction_core::peer::id::PeerId;
-    use subduction_websocket::websocket::WebSocket;
-
     // Nothing here is over-cap; this exercises the clean-close path.
     let (mut client_ws, server_ws) = connected_pair(RECV_CAP).await;
 

--- a/subduction_websocket/tests/over_cap_frame_repro.rs
+++ b/subduction_websocket/tests/over_cap_frame_repro.rs
@@ -1,29 +1,22 @@
-//! Characterization tests for the over-cap WebSocket frame failure mode.
+//! Tests for the over-cap WebSocket frame failure mode.
 //!
-//! These tests pin down the *current* (buggy) behavior so that any fix can be
-//! evaluated against a concrete reproduction rather than against a reading of
-//! the `tungstenite` source. They encode two load-bearing facts:
+//! Two properties are covered:
 //!
-//! 1. [`oversized_frame_poisons_receiver_stream`] — an inbound frame whose
-//!    declared length exceeds the receiver's `max_frame_size` returns
-//!    `Err(Capacity(MessageTooLong))` and leaves the `tungstenite` stream
-//!    **unrecoverable**: a small, valid follow-up message sent on the same
-//!    connection is *not* cleanly delivered. This is why a "skip the offending
-//!    message and keep reading" strategy is impossible at the transport layer,
-//!    and why prevention (chunking) — not recovery — is the durable fix.
+//! 1. An inbound frame whose declared length exceeds the receiver's
+//!    `max_frame_size` returns `Err(Capacity(MessageTooLong))` and leaves the
+//!    `tungstenite` stream unrecoverable: a small, valid follow-up message on
+//!    the same connection is not delivered. A "skip the offending message and
+//!    keep reading" strategy is therefore impossible at the transport layer.
 //!
-//! 2. [`listen_does_not_close_inbound_channel_on_over_cap`] — the current
-//!    [`WebSocket::listen`] returns `Err` on an over-cap inbound frame but does
-//!    **not** close the inbound channel. A concurrent `recv_bytes` is therefore
-//!    left parked instead of promptly observing the disconnect; the rest of the
-//!    stack only learns the peer is gone via keepalive (~80 s with
-//!    [`KeepAlive::balanced`]). This is the "bail badly" behavior we intend to
-//!    change.
+//! 2. When [`WebSocket::listen`] exits on an over-cap or otherwise fatal read
+//!    error, it closes the inbound channel so a parked `recv_bytes` is notified
+//!    immediately rather than stranding until keepalive reaps the peer (~80 s
+//!    with [`KeepAlive::balanced`]), and it sends the peer a graceful Close
+//!    frame.
 //!
-//! If a future change makes either fact no longer hold (e.g. `tungstenite`
-//! learns to drain-and-discard an over-cap frame, or `listen` is changed to
-//! cascade a close), these tests should be updated deliberately — they are the
-//! canary for the assumptions the fix design rests on.
+//! Property 1 is a fact about `tungstenite`. If a future version drains and
+//! discards an over-cap frame, [`oversized_frame_poisons_receiver_stream`]
+//! should be revisited.
 
 #![allow(clippy::expect_used, reason = "test-only assertions")]
 #![allow(clippy::unwrap_used, reason = "test-only assertions")]
@@ -80,30 +73,18 @@ async fn connected_pair(
     (client_ws, server_ws)
 }
 
-/// LOAD-BEARING CLAIM: an over-cap frame poisons the receiver stream.
+/// An over-cap frame leaves the receiver stream unrecoverable.
 ///
 /// The sender writes one binary frame larger than the receiver's cap, then a
-/// small valid binary frame tagged with a distinctive byte. The receiver must
-/// (a) see `MessageTooLong` and (b) be **unable** to then read that small
-/// follow-up on any subsequent poll — proving the stream cannot be
-/// resynchronized after the offending frame.
+/// small valid binary frame tagged with a distinctive byte. The receiver sees
+/// `MessageTooLong` on the over-cap frame and cannot read the small follow-up
+/// on any subsequent poll.
 ///
-/// ## Why "poisoned" — the mechanism
-///
-/// In `tungstenite::protocol::frame::FrameSocket::read_frame`
-/// (`frame/mod.rs:170-210`):
-///
-/// - The frame header is parsed and consumed off the internal `in_buffer`
-///   (`advance`, line 175), and stashed in `self.header`.
-/// - If the declared length exceeds `max_frame_size`, it returns
-///   `Err(MessageTooLong)` at line 182 — *before* the payload bytes are read or
-///   discarded, and *before* `self.header.take()` at line 210.
-///
-/// So after the error: (1) the oversized payload bytes are still unread in the
-/// socket, and (2) `self.header` is still `Some(<oversized>)`. The next
-/// `read_frame` re-enters with that stuck header and tries forever to assemble
-/// a frame it will never admit — or misreads leftover payload as a new header.
-/// There is no drain-and-skip path. The follow-up message is unreachable.
+/// `tungstenite` returns `MessageTooLong` after parsing the over-cap frame's
+/// header but before consuming its payload, and without discarding the stuck
+/// header. The unread payload bytes remain in the socket and the next read
+/// re-encounters the same header, so there is no way to resynchronize and
+/// reach the follow-up message.
 #[tokio::test]
 async fn oversized_frame_poisons_receiver_stream() {
     let (mut client_ws, mut server_ws) = connected_pair(RECV_CAP).await;
@@ -185,36 +166,27 @@ async fn oversized_frame_poisons_receiver_stream() {
     let report = transcript.join("\n  ");
     assert!(
         !recovered_followup,
-        "stream unexpectedly recovered: the small follow-up message was \
-         delivered cleanly after the over-cap frame. If this is now reachable, \
-         tungstenite gained a drain-and-skip path and the 'skip-and-continue' \
-         design becomes viable — revisit the fix plan.\n  Transcript:\n  {report}"
+        "the small follow-up message was delivered cleanly after the over-cap \
+         frame, so the stream resynchronized. If tungstenite now drains and \
+         discards over-cap frames, revisit this test.\n  Transcript:\n  {report}"
     );
 
-    // Surface the transcript on success too, so the mechanism is inspectable
-    // with `--nocapture`.
-    eprintln!("post-error read transcript (no clean follow-up):\n  {report}");
+    // Surface the transcript with `--nocapture`.
+    eprintln!("post-error read transcript:\n  {report}");
 
     let _client_ws = sender.await.expect("sender task");
 }
 
-/// REGRESSION: a fatal/peer-induced `listen()` error tears the connection down
-/// promptly.
+/// A fatal/peer-induced `listen()` error tears the connection down promptly.
 ///
-/// When `listen()` exits on an over-cap inbound frame (peer-induced) or any
-/// other fatal read error, the connection must tear itself down so the rest of
-/// the stack learns the peer is gone *now*, not ~80 s later when keepalive
-/// reaps it. Concretely: a `recv_bytes()` parked on the inbound channel resolves
-/// with `Err` shortly after `listen()` returns its error.
+/// When `listen()` exits on an over-cap inbound frame (or any other fatal read
+/// error), it closes the inbound channel so a `recv_bytes()` parked on it
+/// resolves with `Err` immediately, rather than stranding until keepalive reaps
+/// the peer (~80 s). It also sends the peer a graceful Close frame.
 ///
-/// Before the fix, `listen()` returned `Err` but left the inbound channel open,
-/// so the parked `recv_bytes()` hung until keepalive. The fix classifies the
-/// read error (`ReadErrorKind`) and, for `OverCapacity`/`Fatal`, calls
-/// `close_channels()` before returning — which is what this test pins down.
-///
-/// We drive a real `subduction_websocket::WebSocket` receiver against a raw
-/// `async-tungstenite` sender, run `listen()` and a concurrent `recv_bytes()`
-/// together, and require the recv to resolve within a short budget.
+/// Drives a real `subduction_websocket::WebSocket` receiver against a raw
+/// `async-tungstenite` sender, runs `listen()` and a concurrent `recv_bytes()`
+/// together, and requires the recv to resolve within a short budget.
 #[tokio::test]
 async fn listen_error_tears_down_connection_promptly() {
     use future_form::Sendable;
@@ -232,8 +204,8 @@ async fn listen_error_tears_down_connection_promptly() {
     // operational, matching production wiring.
     let sender_join = tokio::spawn(sender_task);
 
-    // A consumer parked on the inbound channel, exactly as `Subduction::listen`
-    // would be. After the fix it must observe the disconnect promptly.
+    // A consumer parked on the inbound channel, as `Subduction::listen` would
+    // be. It must observe the disconnect promptly.
     let ws_for_recv = ws.clone();
     let recv_join = tokio::spawn(async move {
         subduction_core::transport::Transport::<Sendable>::recv_bytes(&ws_for_recv).await
@@ -264,7 +236,7 @@ async fn listen_error_tears_down_connection_promptly() {
         close_code
     });
 
-    // `listen()` should observe the over-cap frame and return an error.
+    // `listen()` observes the over-cap frame and returns an error.
     let listen_result = tokio::time::timeout(Duration::from_secs(5), ws.listen())
         .await
         .expect("listen should resolve (not hang) on an over-cap frame");
@@ -274,16 +246,14 @@ async fn listen_error_tears_down_connection_promptly() {
         "listen() should return Err on an over-cap inbound frame, got {listen_result:?}"
     );
 
-    // DESIRED: the parked recv resolves (with Err) promptly because the
-    // connection tore itself down. FAILS today: recv stays parked, so the
-    // timeout elapses.
+    // The parked recv resolves (with Err) because the connection tore itself
+    // down.
     let recv_outcome = tokio::time::timeout(Duration::from_millis(500), recv_join).await;
 
     assert!(
         recv_outcome.is_ok(),
-        "recv_bytes should be notified promptly after listen() errors out \
-         (connection tears itself down instead of waiting ~80 s for keepalive). \
-         If this times out, the teardown-on-fatal-error path has regressed."
+        "recv_bytes should be notified promptly after listen() errors out, \
+         instead of waiting ~80 s for keepalive"
     );
     let recv_result = recv_outcome.expect("recv resolved within budget").expect("recv task joined");
     assert!(
@@ -291,9 +261,8 @@ async fn listen_error_tears_down_connection_promptly() {
         "the prompt recv result should be an Err (disconnect), got Ok"
     );
 
-    // WIRE-LEVEL PROOF: the receiver originated a graceful Close frame, and the
-    // peer (this raw client) actually received it with code 1009 (Size /
-    // "Message Too Big") — not just an abrupt TCP drop.
+    // The peer receives a graceful Close(Size) frame (1009 Message Too Big),
+    // not an abrupt TCP drop.
     let close_code = client_join.await.expect("client task");
     assert_eq!(
         close_code,
@@ -301,26 +270,23 @@ async fn listen_error_tears_down_connection_promptly() {
         "peer should receive a graceful Close(Size) frame on over-cap, got {close_code:?}"
     );
 
-    // Cleanup.
     ws.close_channels();
     drop(sender_join.await);
 }
 
-/// REGRESSION: a clean peer-initiated disconnect also notifies a parked
-/// `recv_bytes` promptly — and does NOT make us originate a duplicate Close.
+/// A clean peer-initiated disconnect notifies a parked `recv_bytes` promptly
+/// and does not originate a duplicate Close.
 ///
 /// When the peer sends a `Message::Close`, `tungstenite` auto-echoes the Close
-/// reply, so our listener must only tear down its channels (notifying
-/// `recv_bytes`) without enqueuing a second Close of its own. Before folding the
-/// clean-close/EOF paths into the uniform teardown, this `recv_bytes` would have
-/// hung until keepalive.
+/// reply, so the listener only tears down its channels (notifying `recv_bytes`)
+/// without enqueuing a second Close of its own.
 #[tokio::test]
 async fn clean_close_tears_down_promptly_without_double_close() {
     use future_form::Sendable;
     use subduction_core::peer::id::PeerId;
     use subduction_websocket::websocket::WebSocket;
 
-    // Equal, generous cap: nothing here is over-cap; we exercise the clean path.
+    // Nothing here is over-cap; this exercises the clean-close path.
     let (mut client_ws, server_ws) = connected_pair(RECV_CAP).await;
 
     let (ws, sender_task): (
@@ -369,7 +335,7 @@ async fn clean_close_tears_down_promptly_without_double_close() {
         "clean remote close should be Ok(()), got {listen_result:?}"
     );
 
-    // The parked recv must be notified promptly (the newly-closed gap).
+    // The parked recv is notified promptly.
     let recv_outcome = tokio::time::timeout(Duration::from_millis(500), recv_join).await;
     assert!(
         recv_outcome.is_ok(),

--- a/subduction_websocket/tests/over_cap_frame_repro.rs
+++ b/subduction_websocket/tests/over_cap_frame_repro.rs
@@ -41,12 +41,8 @@ const MARKER: u8 = 0x5A;
 async fn connected_pair(
     recv_cap: usize,
 ) -> (
-    async_tungstenite::WebSocketStream<
-        async_tungstenite::tokio::TokioAdapter<TcpStream>,
-    >,
-    async_tungstenite::WebSocketStream<
-        async_tungstenite::tokio::TokioAdapter<TcpStream>,
-    >,
+    async_tungstenite::WebSocketStream<async_tungstenite::tokio::TokioAdapter<TcpStream>>,
+    async_tungstenite::WebSocketStream<async_tungstenite::tokio::TokioAdapter<TcpStream>>,
 ) {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("local_addr");
@@ -64,10 +60,9 @@ async fn connected_pair(
 
     let tcp = TcpStream::connect(addr).await.expect("connect tcp");
     let uri = format!("ws://{addr}/");
-    let (client_ws, _resp) =
-        async_tungstenite::tokio::client_async_with_config(uri, tcp, None)
-            .await
-            .expect("ws client");
+    let (client_ws, _resp) = async_tungstenite::tokio::client_async_with_config(uri, tcp, None)
+        .await
+        .expect("ws client");
 
     let server_ws = server_join.await.expect("server task");
     (client_ws, server_ws)
@@ -115,9 +110,7 @@ async fn oversized_frame_poisons_receiver_stream() {
     assert!(
         matches!(
             err,
-            tungstenite::Error::Capacity(
-                tungstenite::error::CapacityError::MessageTooLong { .. }
-            )
+            tungstenite::Error::Capacity(tungstenite::error::CapacityError::MessageTooLong { .. })
         ),
         "expected Capacity(MessageTooLong), got {err:?}"
     );
@@ -255,7 +248,9 @@ async fn listen_error_tears_down_connection_promptly() {
         "recv_bytes should be notified promptly after listen() errors out, \
          instead of waiting ~80 s for keepalive"
     );
-    let recv_result = recv_outcome.expect("recv resolved within budget").expect("recv task joined");
+    let recv_result = recv_outcome
+        .expect("recv resolved within budget")
+        .expect("recv task joined");
     assert!(
         recv_result.is_err(),
         "the prompt recv result should be an Err (disconnect), got Ok"


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
