### PR TITLE
Subduction Wasm init: positional atrgs -> options object

### DIFF
--- a/subduction_wasm/e2e/ephemeral.spec.ts
+++ b/subduction_wasm/e2e/ephemeral.spec.ts
@@ -162,18 +162,11 @@ async function setupPeer(
           }
         : null;
 
-      window.syncer = new Subduction(
+      window.syncer = new Subduction({
         signer,
-        new MemoryStorage(),
-        null, // service_name
-        null, // hash_metric_override
-        null, // max_pending_blob_requests
-        null, // max_resident_trees
-        null, // policy
-        null, // ephemeral_policy
-        null, // on_remote_heads
-        callback // on_ephemeral
-      );
+        storage: new MemoryStorage(),
+        onEphemeral: callback,
+      });
 
       const url = new URL(wsUrl);
       const serviceName = wsUrl.replace("ws://", "");

--- a/subduction_wasm/e2e/longpoll-connection.spec.ts
+++ b/subduction_wasm/e2e/longpoll-connection.spec.ts
@@ -117,7 +117,7 @@ test.describe("Long-Poll Connection Tests", () => {
 
       try {
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new window.subduction.MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new window.subduction.MemoryStorage() });
 
         const peerId = await syncer.connectDiscoverLongPoll(
           baseUrl,
@@ -154,7 +154,7 @@ test.describe("Long-Poll Connection Tests", () => {
 
       try {
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         await syncer.connectDiscoverLongPoll(
           baseUrl,
@@ -194,7 +194,7 @@ test.describe("Long-Poll Connection Tests", () => {
 
         // Peer A: connect, add data, sync to server
         const signerA = await WebCryptoSigner.setup();
-        const syncerA = new Subduction(signerA, new MemoryStorage());
+        const syncerA = new Subduction({ signer: signerA, storage: new MemoryStorage() });
 
         const authA = await SubductionLongPoll.tryDiscover(baseUrl, signerA, serviceName);
         const serverPeerId = authA.peerId;
@@ -207,7 +207,7 @@ test.describe("Long-Poll Connection Tests", () => {
 
         // Peer B: connect, sync from server, verify data arrived
         const signerB = await WebCryptoSigner.setup();
-        const syncerB = new Subduction(signerB, new MemoryStorage());
+        const syncerB = new Subduction({ signer: signerB, storage: new MemoryStorage() });
 
         const authB = await SubductionLongPoll.tryDiscover(baseUrl, signerB, serviceName);
         const serverPeerIdB = authB.peerId;
@@ -315,7 +315,7 @@ test.describe("Long-Poll Connection Tests", () => {
 
         // Now connect with a different signer using the known peer ID
         const signer2 = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer2, new MemoryStorage());
+        const syncer = new Subduction({ signer: signer2, storage: new MemoryStorage() });
 
         const knownAuth = await SubductionLongPoll.tryConnect(
           baseUrl,
@@ -356,8 +356,8 @@ test.describe("Long-Poll Connection Tests", () => {
         const signer1 = await WebCryptoSigner.setup();
         const signer2 = await WebCryptoSigner.setup();
 
-        const syncer1 = new Subduction(signer1, new MemoryStorage());
-        const syncer2 = new Subduction(signer2, new MemoryStorage());
+        const syncer1 = new Subduction({ signer: signer1, storage: new MemoryStorage() });
+        const syncer2 = new Subduction({ signer: signer2, storage: new MemoryStorage() });
 
         const serviceName = baseUrl.replace("http://", "");
 

--- a/subduction_wasm/e2e/messagechannel-connection.spec.ts
+++ b/subduction_wasm/e2e/messagechannel-connection.spec.ts
@@ -76,8 +76,8 @@ test.describe("MessageChannel Connection Tests", () => {
           AuthenticatedTransport.accept(makeMessagePortTransport(channel.port2), signerB),
         ]);
 
-        const syncerA = new Subduction(signerA, new MemoryStorage());
-        const syncerB = new Subduction(signerB, new MemoryStorage());
+        const syncerA = new Subduction({ signer: signerA, storage: new MemoryStorage() });
+        const syncerB = new Subduction({ signer: signerB, storage: new MemoryStorage() });
 
         const [isNewA, isNewB] = await Promise.all([
           syncerA.addConnection(authA),

--- a/subduction_wasm/e2e/peer-connection.spec.ts
+++ b/subduction_wasm/e2e/peer-connection.spec.ts
@@ -177,7 +177,7 @@ test.describe("Peer Connection Tests", () => {
       try {
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const url = new URL(wsUrl);
         const authenticated = await SubductionWebSocket.tryDiscover(
@@ -219,7 +219,7 @@ test.describe("Peer Connection Tests", () => {
       try {
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const url = new URL(wsUrl);
         const peerId = await syncer.connectDiscover(
@@ -258,7 +258,7 @@ test.describe("Peer Connection Tests", () => {
       try {
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const url = new URL(wsUrl);
         await syncer.connectDiscover(
@@ -299,7 +299,7 @@ test.describe("Peer Connection Tests", () => {
       try {
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const url = new URL(wsUrl);
         await syncer.connectDiscover(
@@ -337,8 +337,8 @@ test.describe("Peer Connection Tests", () => {
         const signer1 = await WebCryptoSigner.setup();
         const signer2 = await WebCryptoSigner.setup();
 
-        const syncer1 = new Subduction(signer1, new MemoryStorage());
-        const syncer2 = new Subduction(signer2, new MemoryStorage());
+        const syncer1 = new Subduction({ signer: signer1, storage: new MemoryStorage() });
+        const syncer2 = new Subduction({ signer: signer2, storage: new MemoryStorage() });
 
         const url = new URL(wsUrl);
         const serviceName = wsUrl.replace("ws://", "");
@@ -391,7 +391,7 @@ test.describe("Known Peer ID Connection", () => {
 
         // Now connect with a different signer using the known peer ID
         const signer2 = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer2, new MemoryStorage());
+        const syncer = new Subduction({ signer: signer2, storage: new MemoryStorage() });
 
         const knownAuth = await SubductionWebSocket.tryConnect(url, signer2, serverPeerId);
         const isNew = await syncer.addConnection(knownAuth.toTransport());
@@ -429,7 +429,7 @@ test.describe("onDisconnect Callback", () => {
       try {
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
         const url = new URL(wsUrl);
         const serviceName = wsUrl.replace("ws://", "");
 

--- a/subduction_wasm/e2e/subduction.spec.ts
+++ b/subduction_wasm/e2e/subduction.spec.ts
@@ -14,7 +14,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
         return {
           hasSyncer: !!syncer,
           hasStorage: !!storage,
@@ -31,10 +31,10 @@ test.describe("Subduction", () => {
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
 
-        const syncer1 = new Subduction(signer, storage);
+        const syncer1 = new Subduction({ signer, storage });
         const ids1 = await syncer1.sedimentreeIds();
 
-        const syncer2 = new Subduction(signer, storage);
+        const syncer2 = new Subduction({ signer, storage });
         const ids2 = await syncer2.sedimentreeIds();
 
         return {
@@ -73,7 +73,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const ids = await syncer.sedimentreeIds();
 
@@ -114,7 +114,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const peerIds = await syncer.getConnectedPeerIds();
 
@@ -134,7 +134,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         await syncer.disconnectAll();
         const peerIds = await syncer.getConnectedPeerIds();
@@ -156,7 +156,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, SedimentreeId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const testId = new Uint8Array(32);
         testId[0] = 1;
@@ -178,7 +178,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, SedimentreeId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const testId = new Uint8Array(32);
         testId[0] = 1;
@@ -200,7 +200,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, Digest, SedimentreeId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const sedimentreeId = SedimentreeId.fromBytes(new Uint8Array(32).fill(42));
         const testDigest = new Uint8Array(32);
@@ -223,7 +223,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, Digest, SedimentreeId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const sedimentreeId = SedimentreeId.fromBytes(new Uint8Array(32).fill(42));
         const testDigest = new Uint8Array(32);
@@ -252,8 +252,8 @@ test.describe("Subduction", () => {
         const storage1 = new MemoryStorage();
         const storage2 = new MemoryStorage();
 
-        const syncer1 = new Subduction(signer1, storage1);
-        const syncer2 = new Subduction(signer2, storage2);
+        const syncer1 = new Subduction({ signer: signer1, storage: storage1 });
+        const syncer2 = new Subduction({ signer: signer2, storage: storage2 });
 
         const ids1 = await syncer1.sedimentreeIds();
         const ids2 = await syncer2.sedimentreeIds();
@@ -488,7 +488,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, PeerId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const peerBytes = new Uint8Array(32);
         peerBytes[0] = 1;
@@ -510,7 +510,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(1));
         const blob = new Uint8Array([10, 20, 30, 40, 50]);
@@ -536,7 +536,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(2));
         const blobData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -565,7 +565,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(3));
 
@@ -598,7 +598,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(4));
 
@@ -631,7 +631,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(5));
         const head = new CommitId(new Uint8Array(32).fill(1));
@@ -655,7 +655,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId1 = SedimentreeId.fromBytes(new Uint8Array(32).fill(10));
         const sedId2 = SedimentreeId.fromBytes(new Uint8Array(32).fill(20));
@@ -683,7 +683,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         return {
           hasStorage: syncer.storage !== undefined && syncer.storage !== null,
@@ -699,7 +699,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(50));
         const blobData = new Uint8Array([10, 20, 30, 40, 50, 60, 70, 80]);
@@ -732,7 +732,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(51));
         const blob1 = new Uint8Array([1, 2, 3]);
@@ -766,7 +766,7 @@ test.describe("Subduction", () => {
         const storage = new MemoryStorage();
 
         // Create instance, add data
-        const syncer1 = new Subduction(signer, storage);
+        const syncer1 = new Subduction({ signer, storage });
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(60));
         const head = new CommitId(new Uint8Array(32).fill(1));
         await syncer1.addCommit(sedId, head, [], new Uint8Array([11, 22, 33]));
@@ -776,7 +776,7 @@ test.describe("Subduction", () => {
         const blobMetaSizeBefore = commitsBefore ? Number(commitsBefore[0].blobMeta.sizeBytes) : 0;
 
         // A new instance over the same storage hydrates on demand.
-        const syncer2 = new Subduction(signer, storage);
+        const syncer2 = new Subduction({ signer, storage });
         const idsAfter = await syncer2.sedimentreeIds();
         const commitsAfter = await syncer2.getCommits(sedId);
         const commitCountAfter = commitsAfter ? commitsAfter.length : 0;
@@ -807,7 +807,7 @@ test.describe("Subduction", () => {
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
 
-        const syncer1 = new Subduction(signer, storage);
+        const syncer1 = new Subduction({ signer, storage });
 
         // Create 3 sedimentrees with 2 commits each
         const ids = [
@@ -828,7 +828,7 @@ test.describe("Subduction", () => {
         const idsBefore = await syncer1.sedimentreeIds();
 
         // A new instance over the same storage hydrates on demand.
-        const syncer2 = new Subduction(signer, storage);
+        const syncer2 = new Subduction({ signer, storage });
         const idsAfter = await syncer2.sedimentreeIds();
 
         // Verify all 3 sedimentrees loaded with correct commit counts
@@ -858,7 +858,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(70));
 
@@ -890,7 +890,7 @@ test.describe("Subduction", () => {
       const result = await page.evaluate(async () => {
         const { Subduction, MemoryStorage, SedimentreeId, CommitId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
-        const syncer = new Subduction(signer, new MemoryStorage());
+        const syncer = new Subduction({ signer, storage: new MemoryStorage() });
 
         const sedId = SedimentreeId.fromBytes(new Uint8Array(32).fill(80));
         const blobData = new Uint8Array([99, 98, 97]);
@@ -928,7 +928,7 @@ test.describe("Subduction", () => {
         const { Subduction, MemoryStorage, Digest, SedimentreeId, WebCryptoSigner } = window.subduction;
         const signer = await WebCryptoSigner.setup();
         const storage = new MemoryStorage();
-        const syncer = new Subduction(signer, storage);
+        const syncer = new Subduction({ signer, storage });
 
         const sedimentreeId = SedimentreeId.fromBytes(new Uint8Array(32).fill(42));
         const digest1 = new Digest(new Uint8Array(32));

--- a/subduction_wasm/src/error.rs
+++ b/subduction_wasm/src/error.rs
@@ -38,6 +38,30 @@ impl From<WasmHydrationError> for JsValue {
     }
 }
 
+/// Error constructing a `Subduction` node from a `SubductionOptions` object.
+///
+/// Raised when a required field is missing. The TypeScript interface marks
+/// these fields as required, so this guards JavaScript callers (or any
+/// dynamically-built options object) that bypass the type checker.
+#[derive(Debug, Clone, Copy, Error, PartialEq, Eq, Hash)]
+pub enum WasmInitError {
+    /// The required `signer` field was missing (`undefined` or `null`).
+    #[error("`signer` is required in the Subduction options")]
+    MissingSigner,
+
+    /// The required `storage` field was missing (`undefined` or `null`).
+    #[error("`storage` is required in the Subduction options")]
+    MissingStorage,
+}
+
+impl From<WasmInitError> for JsValue {
+    fn from(err: WasmInitError) -> Self {
+        let js_err = js_sys::Error::new(&err.to_string());
+        js_err.set_name("InitError");
+        js_err.into()
+    }
+}
+
 /// A Wasm wrapper around the [`IoError`] type.
 ///
 /// This includes errors related to I/O operations,

--- a/subduction_wasm/src/signer.rs
+++ b/subduction_wasm/src/signer.rs
@@ -14,10 +14,26 @@ use future_form::{FutureForm, Local};
 use js_sys::{Promise, Uint8Array};
 use subduction_core::peer::id::PeerId;
 use subduction_crypto::signer::Signer;
-use wasm_bindgen::{JsCast, prelude::*};
+use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::JsFuture;
 
 use crate::peer_id::WasmPeerId;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_SIGNER: &str = r#"
+/**
+ * Cryptographic signer interface.
+ *
+ * Allows JavaScript code to provide signing implementations (e.g. hardware
+ * keys or remote signing services).
+ */
+export interface Signer {
+    /** Sign a message; returns the 64-byte Ed25519 signature (sync or async). */
+    sign(message: Uint8Array): Uint8Array | Promise<Uint8Array>;
+    /** The 32-byte Ed25519 verifying (public) key. */
+    verifyingKey(): Uint8Array;
+}
+"#;
 
 #[wasm_bindgen]
 extern "C" {
@@ -25,7 +41,9 @@ extern "C" {
     ///
     /// This allows JavaScript code to provide signing implementations
     /// (e.g., hardware keys or remote signing services).
-    #[wasm_bindgen(js_name = Signer)]
+    ///
+    /// Must match the `Signer` TypeScript interface emitted by this module.
+    #[wasm_bindgen(js_name = Signer, typescript_type = "Signer")]
     pub type JsSigner;
 
     /// Sign a message and return the 64-byte Ed25519 signature.

--- a/subduction_wasm/src/signer.rs
+++ b/subduction_wasm/src/signer.rs
@@ -14,7 +14,7 @@ use future_form::{FutureForm, Local};
 use js_sys::{Promise, Uint8Array};
 use subduction_core::peer::id::PeerId;
 use subduction_crypto::signer::Signer;
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 use wasm_bindgen_futures::JsFuture;
 
 use crate::peer_id::WasmPeerId;

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -59,7 +59,7 @@ use crate::{
     batch_input::{WasmCommitInput, WasmFragmentInput},
     error::{
         WasmAddConnectionError, WasmConnectError, WasmDisconnectionError, WasmHandshakeError,
-        WasmIoError, WasmLongPollConnectError, WasmWriteError,
+        WasmInitError, WasmIoError, WasmLongPollConnectError, WasmWriteError,
     },
     fragment::WasmFragmentRequested,
     peer_id::WasmPeerId,
@@ -176,15 +176,23 @@ impl WasmSubduction {
     /// `signer` and `storage` are required; all other fields are optional.
     /// See [`SubductionOptions`] for the full field list and defaults.
     ///
+    /// # Errors
+    ///
+    /// Returns a [`WasmInitError`] if the required `signer` or `storage` field
+    /// is missing (`undefined`/`null`). The TypeScript interface marks these as
+    /// required, so this only fires for callers that bypass the type checker.
+    ///
     /// # Panics
     ///
     /// Panics if `hashMetricOverride` is provided but the underlying JS value
     /// cannot be cast to a `Function`.
-    #[must_use]
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_lines)]
-    pub fn new(opts: &JsSubductionOptions) -> Self {
+    pub fn new(opts: &JsSubductionOptions) -> Result<Self, WasmInitError> {
         tracing::debug!("new Subduction node");
+
+        let signer = opts.signer().ok_or(WasmInitError::MissingSigner)?;
+        let opts_storage = opts.storage().ok_or(WasmInitError::MissingStorage)?;
 
         let default_roundtrip_timeout = opts
             .default_timeout_milliseconds()
@@ -192,7 +200,6 @@ impl WasmSubduction {
                 Duration::from_millis(u64::from(ms))
             });
 
-        let opts_storage = opts.storage();
         let js_storage = <JsStorage as AsRef<JsValue>>::as_ref(&opts_storage).clone();
 
         #[allow(clippy::expect_used)]
@@ -258,7 +265,7 @@ impl WasmSubduction {
         let (core, listener_fut, manager_fut) = Subduction::new(
             handler,
             discovery_id,
-            opts.signer(),
+            signer,
             sedimentrees,
             connections,
             subscriptions,
@@ -303,12 +310,12 @@ impl WasmSubduction {
             }
         });
 
-        Self {
+        Ok(Self {
             core,
             js_storage,
             ephemeral_handler: ephemeral_for_wasm,
             keyhive_handler,
-        }
+        })
     }
 
     /// Persist a whole [`Sedimentree`](sedimentree_wasm::WasmSedimentree)
@@ -1791,11 +1798,14 @@ extern "C" {
     #[wasm_bindgen(js_name = SubductionOptions, typescript_type = "SubductionOptions")]
     pub type JsSubductionOptions;
 
+    // `signer`/`storage` are required by the TS interface, but a JS caller can
+    // omit them; `Option` lets `new` detect absence and throw a clear error
+    // instead of silently wrapping `undefined`.
     #[wasm_bindgen(method, getter)]
-    fn signer(this: &JsSubductionOptions) -> JsSigner;
+    fn signer(this: &JsSubductionOptions) -> Option<JsSigner>;
 
     #[wasm_bindgen(method, getter)]
-    fn storage(this: &JsSubductionOptions) -> JsStorage;
+    fn storage(this: &JsSubductionOptions) -> Option<JsStorage>;
 
     #[wasm_bindgen(method, getter, js_name = serviceName)]
     fn service_name(this: &JsSubductionOptions) -> Option<String>;

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -147,6 +147,48 @@ type WasmSubductionCore = Subduction<
     WASM_SHARD_COUNT,
 >;
 
+#[wasm_bindgen]
+extern "C" {
+    /// Options for constructing a [`Subduction`](subduction_core::Subduction)
+    /// node. Passed as a single object literal: `new Subduction({ signer,
+    /// storage, ... })`.
+    #[wasm_bindgen(js_name = SubductionOptions)]
+    pub type SubductionOptions;
+
+    #[wasm_bindgen(method, getter)]
+    fn signer(this: &SubductionOptions) -> JsSigner;
+
+    #[wasm_bindgen(method, getter)]
+    fn storage(this: &SubductionOptions) -> JsStorage;
+
+    #[wasm_bindgen(method, getter, js_name = serviceName)]
+    fn service_name(this: &SubductionOptions) -> Option<String>;
+
+    #[wasm_bindgen(method, getter, js_name = hashMetricOverride)]
+    fn hash_metric_override(this: &SubductionOptions) -> Option<JsToDepth>;
+
+    #[wasm_bindgen(method, getter, js_name = maxPendingBlobRequests)]
+    fn max_pending_blob_requests(this: &SubductionOptions) -> Option<u32>;
+
+    #[wasm_bindgen(method, getter, js_name = maxResidentTrees)]
+    fn max_resident_trees(this: &SubductionOptions) -> Option<u32>;
+
+    #[wasm_bindgen(method, getter)]
+    fn policy(this: &SubductionOptions) -> Option<JsPolicy>;
+
+    #[wasm_bindgen(method, getter, js_name = ephemeralPolicy)]
+    fn ephemeral_policy(this: &SubductionOptions) -> Option<JsEphemeralPolicy>;
+
+    #[wasm_bindgen(method, getter, js_name = onRemoteHeads)]
+    fn on_remote_heads(this: &SubductionOptions) -> Option<js_sys::Function>;
+
+    #[wasm_bindgen(method, getter, js_name = onEphemeral)]
+    fn on_ephemeral(this: &SubductionOptions) -> Option<js_sys::Function>;
+
+    #[wasm_bindgen(method, getter, js_name = defaultTimeoutMilliseconds)]
+    fn default_timeout_milliseconds(this: &SubductionOptions) -> Option<u32>;
+}
+
 /// Wasm bindings for [`Subduction`](subduction_core::Subduction)
 #[wasm_bindgen(js_name = Subduction)]
 pub struct WasmSubduction {
@@ -166,53 +208,36 @@ impl core::fmt::Debug for WasmSubduction {
 
 #[wasm_bindgen(js_class = Subduction)]
 impl WasmSubduction {
-    /// Create a new [`Subduction`] instance.
+    /// Create a new [`Subduction`] instance from an options object.
     ///
-    /// # Arguments
+    /// ```js
+    /// new Subduction({ signer, storage, serviceName: "sync.example.com" });
+    /// ```
     ///
-    /// * `signer` - The cryptographic signer for this node's identity
-    /// * `storage` - Storage backend for persisting data
-    /// * `service_name` - Optional service identifier for discovery mode (e.g., `sync.example.com`).
-    ///   When set, clients can connect without knowing the server's peer ID.
-    /// * `hash_metric_override` - Optional custom depth metric function
-    /// * `max_pending_blob_requests` - Optional maximum number of pending blob requests (default: 10,000)
-    /// * `max_resident_trees` - Optional cap on the number of sedimentrees kept
-    ///   resident in memory (default: 1024). The in-memory map is an LRU cache
-    ///   over `IndexedDB`; cold trees are evicted and re-hydrated on demand. The
-    ///   cap is per-shard-approximate, with an effective floor of
-    ///   `WASM_SHARD_COUNT` (4). `0` or omitted uses the default. Grouped with
-    ///   `max_pending_blob_requests` as the capacity/tuning knobs.
-    /// * `policy` - Optional connection/storage authorization policy.
-    ///   Defaults to allow-all.
-    /// * `ephemeral_policy` - Optional ephemeral message authorization policy.
-    ///   Defaults to allow-all.
-    /// * `on_remote_heads` - Optional callback fired when a peer's heads change.
-    /// * `on_ephemeral` - Optional callback fired on inbound ephemeral messages.
-    /// * `default_timeout_milliseconds` - Optional default per-call total
-    ///   deadline (milliseconds) for roundtrip syncs when a call omits its own
-    ///   `timeout_milliseconds`. Omit for the built-in default (30000).
+    /// `signer` and `storage` are required; all other fields are optional.
+    /// See [`SubductionOptions`] for the full field list and defaults.
     ///
     /// # Panics
     ///
-    /// Panics if `hash_metric_override` is `Some` but the underlying JS value
+    /// Panics if `hashMetricOverride` is provided but the underlying JS value
     /// cannot be cast to a `Function`.
     #[must_use]
     #[wasm_bindgen(constructor)]
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        signer: JsSigner,
-        storage: JsStorage,
-        service_name: Option<String>,
-        hash_metric_override: Option<JsToDepth>,
-        max_pending_blob_requests: Option<usize>,
-        max_resident_trees: Option<usize>,
-        policy: Option<JsPolicy>,
-        ephemeral_policy: Option<JsEphemeralPolicy>,
-        on_remote_heads: Option<js_sys::Function>,
-        on_ephemeral: Option<js_sys::Function>,
-        default_timeout_milliseconds: Option<u32>,
-    ) -> Self {
+    pub fn new(options: SubductionOptions) -> Self {
         tracing::debug!("new Subduction node");
+
+        let signer = options.signer();
+        let storage = options.storage();
+        let service_name = options.service_name();
+        let hash_metric_override = options.hash_metric_override();
+        let max_pending_blob_requests = options.max_pending_blob_requests();
+        let max_resident_trees = options.max_resident_trees();
+        let policy = options.policy();
+        let ephemeral_policy = options.ephemeral_policy();
+        let on_remote_heads = options.on_remote_heads();
+        let on_ephemeral = options.on_ephemeral();
+        let default_timeout_milliseconds = options.default_timeout_milliseconds();
+
         let default_roundtrip_timeout = default_timeout_milliseconds
             .map_or(DEFAULT_ROUNDTRIP_TIMEOUT, |ms| {
                 Duration::from_millis(u64::from(ms))

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -182,7 +182,8 @@ impl WasmSubduction {
     /// cannot be cast to a `Function`.
     #[must_use]
     #[wasm_bindgen(constructor)]
-    pub fn new(opts: JsSubductionOptions) -> Self {
+    #[allow(clippy::too_many_lines)]
+    pub fn new(opts: &JsSubductionOptions) -> Self {
         tracing::debug!("new Subduction node");
 
         let default_roundtrip_timeout = opts

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -63,6 +63,7 @@ use crate::{
     },
     fragment::WasmFragmentRequested,
     peer_id::WasmPeerId,
+    remote_heads::JsRemoteHeadsObserver,
     signer::JsSigner,
     sync_stats::WasmSyncStats,
     topic::{JsTopic, WasmTopic},
@@ -147,48 +148,6 @@ type WasmSubductionCore = Subduction<
     WASM_SHARD_COUNT,
 >;
 
-#[wasm_bindgen]
-extern "C" {
-    /// Options for constructing a [`Subduction`](subduction_core::Subduction)
-    /// node. Passed as a single object literal: `new Subduction({ signer,
-    /// storage, ... })`.
-    #[wasm_bindgen(js_name = SubductionOptions)]
-    pub type SubductionOptions;
-
-    #[wasm_bindgen(method, getter)]
-    fn signer(this: &SubductionOptions) -> JsSigner;
-
-    #[wasm_bindgen(method, getter)]
-    fn storage(this: &SubductionOptions) -> JsStorage;
-
-    #[wasm_bindgen(method, getter, js_name = serviceName)]
-    fn service_name(this: &SubductionOptions) -> Option<String>;
-
-    #[wasm_bindgen(method, getter, js_name = hashMetricOverride)]
-    fn hash_metric_override(this: &SubductionOptions) -> Option<JsToDepth>;
-
-    #[wasm_bindgen(method, getter, js_name = maxPendingBlobRequests)]
-    fn max_pending_blob_requests(this: &SubductionOptions) -> Option<u32>;
-
-    #[wasm_bindgen(method, getter, js_name = maxResidentTrees)]
-    fn max_resident_trees(this: &SubductionOptions) -> Option<u32>;
-
-    #[wasm_bindgen(method, getter)]
-    fn policy(this: &SubductionOptions) -> Option<JsPolicy>;
-
-    #[wasm_bindgen(method, getter, js_name = ephemeralPolicy)]
-    fn ephemeral_policy(this: &SubductionOptions) -> Option<JsEphemeralPolicy>;
-
-    #[wasm_bindgen(method, getter, js_name = onRemoteHeads)]
-    fn on_remote_heads(this: &SubductionOptions) -> Option<js_sys::Function>;
-
-    #[wasm_bindgen(method, getter, js_name = onEphemeral)]
-    fn on_ephemeral(this: &SubductionOptions) -> Option<js_sys::Function>;
-
-    #[wasm_bindgen(method, getter, js_name = defaultTimeoutMilliseconds)]
-    fn default_timeout_milliseconds(this: &SubductionOptions) -> Option<u32>;
-}
-
 /// Wasm bindings for [`Subduction`](subduction_core::Subduction)
 #[wasm_bindgen(js_name = Subduction)]
 pub struct WasmSubduction {
@@ -223,52 +182,48 @@ impl WasmSubduction {
     /// cannot be cast to a `Function`.
     #[must_use]
     #[wasm_bindgen(constructor)]
-    pub fn new(options: SubductionOptions) -> Self {
+    pub fn new(opts: JsSubductionOptions) -> Self {
         tracing::debug!("new Subduction node");
 
-        let signer = options.signer();
-        let storage = options.storage();
-        let service_name = options.service_name();
-        let hash_metric_override = options.hash_metric_override();
-        let max_pending_blob_requests = options.max_pending_blob_requests();
-        let max_resident_trees = options.max_resident_trees();
-        let policy = options.policy();
-        let ephemeral_policy = options.ephemeral_policy();
-        let on_remote_heads = options.on_remote_heads();
-        let on_ephemeral = options.on_ephemeral();
-        let default_timeout_milliseconds = options.default_timeout_milliseconds();
-
-        let default_roundtrip_timeout = default_timeout_milliseconds
+        let default_roundtrip_timeout = opts
+            .default_timeout_milliseconds()
             .map_or(DEFAULT_ROUNDTRIP_TIMEOUT, |ms| {
                 Duration::from_millis(u64::from(ms))
             });
-        let js_storage = <JsStorage as AsRef<JsValue>>::as_ref(&storage).clone();
+
+        let opts_storage = opts.storage();
+        let js_storage = <JsStorage as AsRef<JsValue>>::as_ref(&opts_storage).clone();
+
         #[allow(clippy::expect_used)]
-        let raw_fn: Option<js_sys::Function> = hash_metric_override.map(|h| {
+        let raw_fn: Option<js_sys::Function> = opts.hash_metric_override().map(|h| {
             JsValue::from(h)
                 .dyn_into()
                 .expect("hash_metric_override is not a Function")
         });
-        let discovery_id = service_name.map(|name| DiscoveryId::new(name.as_bytes()));
+        let discovery_id = opts
+            .service_name()
+            .map(|name| DiscoveryId::new(name.as_bytes()));
         let depth_metric = WasmHashMetric(raw_fn);
-        let max_pending = max_pending_blob_requests.unwrap_or(DEFAULT_MAX_PENDING_BLOB_REQUESTS);
+        let max_pending = opts
+            .max_pending_blob_requests()
+            .map_or(DEFAULT_MAX_PENDING_BLOB_REQUESTS, |n| n as usize);
         // `None` or an explicit `0` falls back to the default cap.
-        let max_resident = match max_resident_trees {
-            Some(n) if n > 0 => n,
+        let max_resident = match opts.max_resident_trees() {
+            Some(n) if n > 0 => n as usize,
             _ => WASM_DEFAULT_MAX_RESIDENT_TREES,
         };
 
-        let policy = policy.unwrap_or_else(make_open_policy);
+        let policy = opts.policy().unwrap_or_else(make_open_policy);
 
         let connections = Arc::new(Mutex::new(Map::new()));
         let subscriptions = Arc::new(Mutex::new(Map::new()));
         let sedimentrees = Arc::new(BoundedShardedMap::new().with_capacity(max_resident));
         let pending_blob_requests = Arc::new(Mutex::new(PendingBlobRequests::new(max_pending)));
-        let powerbox = StoragePowerbox::new(storage, Arc::new(policy));
+        let powerbox = StoragePowerbox::new(opts_storage, Arc::new(policy));
 
-        let observer = match on_remote_heads {
-            Some(f) => crate::remote_heads::JsRemoteHeadsObserver::with_callback(f),
-            None => crate::remote_heads::JsRemoteHeadsObserver::new(),
+        let observer = match opts.on_remote_heads() {
+            Some(f) => JsRemoteHeadsObserver::with_callback(f),
+            None => JsRemoteHeadsObserver::new(),
         };
         let sync_handler = SyncHandler::with_remote_heads_observer(
             sedimentrees.clone(),
@@ -280,7 +235,9 @@ impl WasmSubduction {
             observer.clone(),
         );
 
-        let eph_policy = ephemeral_policy.unwrap_or_else(make_open_ephemeral_policy);
+        let eph_policy = opts
+            .ephemeral_policy()
+            .unwrap_or_else(make_open_ephemeral_policy);
         let (ephemeral_handler, ephemeral_rx) = EphemeralHandler::new(
             connections.clone(),
             eph_policy,
@@ -300,7 +257,7 @@ impl WasmSubduction {
         let (core, listener_fut, manager_fut) = Subduction::new(
             handler,
             discovery_id,
-            signer,
+            opts.signer(),
             sedimentrees,
             connections,
             subscriptions,
@@ -334,7 +291,9 @@ impl WasmSubduction {
 
         // Always drain the ephemeral channel to prevent "channel full" warnings
         // in EphemeralHandler when no JS callback is registered.
-        let observer = on_ephemeral.map(crate::ephemeral::JsEphemeralObserver::new);
+        let observer = opts
+            .on_ephemeral()
+            .map(crate::ephemeral::JsEphemeralObserver::new);
         wasm_bindgen_futures::spawn_local(async move {
             while let Ok(event) = ephemeral_rx.recv().await {
                 if let Some(ref obs) = observer {
@@ -1774,4 +1733,93 @@ impl From<WasmCallError> for js_sys::Error {
         js_err.set_name(err.0.error_name());
         js_err
     }
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_SUBDUCTION_OPTIONS: &str = r#"
+/**
+ * Options for constructing a `Subduction` node.
+ *
+ * Passed as a single object literal: `new Subduction({ signer, storage, ... })`.
+ * `signer` and `storage` are required; every other field is optional.
+ */
+export interface SubductionOptions {
+    /** The cryptographic signer for this node's identity. */
+    signer: Signer;
+    /** Storage backend for persisting data. */
+    storage: SedimentreeStorage;
+    /**
+     * Service identifier for discovery mode (e.g. `sync.example.com`). When
+     * set, clients can connect without knowing the server's peer ID.
+     */
+    serviceName?: string;
+    /** Custom depth metric function. */
+    hashMetricOverride?: (digest: Digest) => Depth;
+    /** Maximum number of pending blob requests (default: 10,000). */
+    maxPendingBlobRequests?: number;
+    /**
+     * Cap on the number of sedimentrees kept resident in memory (default:
+     * 1024). `0` or omitted uses the default.
+     */
+    maxResidentTrees?: number;
+    /** Connection/storage authorization policy. Defaults to allow-all. */
+    policy?: Policy;
+    /** Ephemeral message authorization policy. Defaults to allow-all. */
+    ephemeralPolicy?: EphemeralPolicy;
+    /** Callback fired when a peer's heads change. */
+    onRemoteHeads?: Function;
+    /** Callback fired on inbound ephemeral messages. */
+    onEphemeral?: Function;
+    /**
+     * Default per-call total deadline (milliseconds) for roundtrip syncs when
+     * a call omits its own `timeoutMilliseconds`. Omit for the built-in
+     * default (30000).
+     */
+    defaultTimeoutMilliseconds?: number;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    /// Options for constructing a [`Subduction`](subduction_core::Subduction)
+    /// node. Passed as a single object literal: `new Subduction({ signer,
+    /// storage, ... })`.
+    ///
+    /// Must match the `SubductionOptions` TypeScript interface emitted by this
+    /// module.
+    #[wasm_bindgen(js_name = SubductionOptions, typescript_type = "SubductionOptions")]
+    pub type JsSubductionOptions;
+
+    #[wasm_bindgen(method, getter)]
+    fn signer(this: &JsSubductionOptions) -> JsSigner;
+
+    #[wasm_bindgen(method, getter)]
+    fn storage(this: &JsSubductionOptions) -> JsStorage;
+
+    #[wasm_bindgen(method, getter, js_name = serviceName)]
+    fn service_name(this: &JsSubductionOptions) -> Option<String>;
+
+    #[wasm_bindgen(method, getter, js_name = hashMetricOverride)]
+    fn hash_metric_override(this: &JsSubductionOptions) -> Option<JsToDepth>;
+
+    #[wasm_bindgen(method, getter, js_name = maxPendingBlobRequests)]
+    fn max_pending_blob_requests(this: &JsSubductionOptions) -> Option<u32>;
+
+    #[wasm_bindgen(method, getter, js_name = maxResidentTrees)]
+    fn max_resident_trees(this: &JsSubductionOptions) -> Option<u32>;
+
+    #[wasm_bindgen(method, getter)]
+    fn policy(this: &JsSubductionOptions) -> Option<JsPolicy>;
+
+    #[wasm_bindgen(method, getter, js_name = ephemeralPolicy)]
+    fn ephemeral_policy(this: &JsSubductionOptions) -> Option<JsEphemeralPolicy>;
+
+    #[wasm_bindgen(method, getter, js_name = onRemoteHeads)]
+    fn on_remote_heads(this: &JsSubductionOptions) -> Option<js_sys::Function>;
+
+    #[wasm_bindgen(method, getter, js_name = onEphemeral)]
+    fn on_ephemeral(this: &JsSubductionOptions) -> Option<js_sys::Function>;
+
+    #[wasm_bindgen(method, getter, js_name = defaultTimeoutMilliseconds)]
+    fn default_timeout_milliseconds(this: &JsSubductionOptions) -> Option<u32>;
 }


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

- Closes #229

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
