### PR TITLE
Drop coarse `Keyhive` locking in keyhive sync protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "keyhive_core"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed8e8a6e6b297464358edd9facdf86a0573b132af338932a18cd48439739d3b"
+checksum = "034de6a8565cc13585f08da0cd3fc80de3bfb2c9f81ec70b5c595dc08c9f8769"
 dependencies = [
  "beekem",
  "bincode",
@@ -5152,6 +5152,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "console-subscriber",
+ "dupe",
  "ed25519-dalek 2.2.0",
  "eyre",
  "future_form",
@@ -5328,6 +5329,7 @@ dependencies = [
  "blake3",
  "bolero",
  "ciborium",
+ "dupe",
  "ed25519-dalek 2.2.0",
  "future_form",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ iroh = "0.98.2"
 hyper = { version = "1.6", default-features = false }
 hyper-util = { version = "0.1", default-features = false }
 js-sys = { version = "=0.3.98", default-features = false }
-keyhive_core = "0.4.0"
+keyhive_core = "0.4.1"
 keyhive_crypto = "0.2.0"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"

--- a/subduction_cli/Cargo.toml
+++ b/subduction_cli/Cargo.toml
@@ -23,6 +23,7 @@ ciborium = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
+dupe = "0.9"
 ed25519-dalek = { workspace = true }
 eyre = { workspace = true }
 futures = { workspace = true }

--- a/subduction_cli/src/policy.rs
+++ b/subduction_cli/src/policy.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use async_lock::Mutex as AsyncMutex;
+use dupe::Dupe;
 use futures::{FutureExt, future::BoxFuture};
 use sedimentree_core::id::SedimentreeId;
 use subduction_core::{
@@ -54,8 +55,8 @@ impl ConnectionPolicy<future_form::Sendable> for CliKeyhivePolicyHandle {
         };
         let keyhive = Arc::clone(keyhive);
         async move {
-            let kh = keyhive.lock().await;
-            authorize_connect_with(&*kh, peer).await
+            let kh = { keyhive.lock().await.dupe() };
+            authorize_connect_with(&kh, peer).await
         }
         .boxed()
     }
@@ -78,8 +79,8 @@ impl StoragePolicy<future_form::Sendable> for CliKeyhivePolicyHandle {
         }
         let keyhive = Arc::clone(keyhive);
         async move {
-            let kh = keyhive.lock().await;
-            authorize_fetch_with(&*kh, peer, sedimentree_id).await
+            let kh = { keyhive.lock().await.dupe() };
+            authorize_fetch_with(&kh, peer, sedimentree_id).await
         }
         .boxed()
     }
@@ -98,8 +99,8 @@ impl StoragePolicy<future_form::Sendable> for CliKeyhivePolicyHandle {
         }
         let keyhive = Arc::clone(keyhive);
         async move {
-            let kh = keyhive.lock().await;
-            authorize_put_with(&*kh, requestor, author, sedimentree_id).await
+            let kh = { keyhive.lock().await.dupe() };
+            authorize_put_with(&kh, requestor, author, sedimentree_id).await
         }
         .boxed()
     }
@@ -115,8 +116,8 @@ impl StoragePolicy<future_form::Sendable> for CliKeyhivePolicyHandle {
         let (legacy, keyhive_ids): (Vec<_>, Vec<_>) = ids.into_iter().partition(is_legacy);
         let keyhive = Arc::clone(keyhive);
         async move {
-            let kh = keyhive.lock().await;
-            let mut allowed = filter_authorized_fetch_with(&*kh, peer, keyhive_ids).await;
+            let kh = { keyhive.lock().await.dupe() };
+            let mut allowed = filter_authorized_fetch_with(&kh, peer, keyhive_ids).await;
             allowed.extend(legacy);
             allowed
         }

--- a/subduction_keyhive/Cargo.toml
+++ b/subduction_keyhive/Cargo.toml
@@ -19,6 +19,7 @@ bincode = { workspace = true }
 blake3 = { workspace = true }
 bolero = { workspace = true, optional = true, features = ["arbitrary"] }
 ciborium = { workspace = true }
+dupe = { version = "0.9", optional = true }
 ed25519-dalek = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 future_form = { workspace = true }
@@ -41,7 +42,7 @@ default = []
 bolero = ["dep:bolero"]
 handler = ["dep:async-channel", "dep:subduction_crypto", "std"]
 runtime = ["handler", "serde", "dep:tokio", "dep:tokio-util"]
-serde = ["dep:serde", "dep:serde_bytes", "dep:serde_json", "std"]
+serde = ["dep:serde", "dep:serde_bytes", "dep:serde_json", "dep:dupe", "std"]
 std = ["thiserror/std"]
 test-utils = ["dep:async-channel", "serde"]
 

--- a/subduction_keyhive/src/cache.rs
+++ b/subduction_keyhive/src/cache.rs
@@ -10,7 +10,9 @@
 
 use alloc::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
+use dupe::Dupe;
 use keyhive_core::{
+    keyhive::Keyhive,
     listener::membership::MembershipListener,
     principal::public::Public,
     store::ciphertext::{CiphertextStore, CiphertextStoreExt},
@@ -164,6 +166,7 @@ impl PeriodicEventCache {
         Conn::DisconnectError: 'static,
         Store: KeyhiveStorage<Async>,
         Async: future_form::FutureForm,
+        Keyhive<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng>: Dupe,
     {
         let total = protocol.total_ops().await;
         if self.last_total_ops == Some(total) {

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -37,6 +37,7 @@ use alloc::{
 };
 
 use async_lock::Mutex;
+use dupe::Dupe;
 use keyhive_core::{
     contact_card::ContactCard,
     event::{Event, static_event::StaticEvent},
@@ -145,6 +146,7 @@ where
     Conn::DisconnectError: 'static,
     Store: KeyhiveStorage<Async>,
     Async: future_form::FutureForm,
+    Keyhive<Async, Signer, CRef, Plaintext, CipherStore, Listener, Rng>: Dupe,
 {
     /// Create a new protocol handler.
     pub fn new(
@@ -277,8 +279,8 @@ where
         &self,
         skip_serialization: &BTreeSet<EventHash>,
     ) -> Result<crate::all_agent_events::AllAgentEvents, ProtocolError<Conn::SendError>> {
+        let keyhive = { self.keyhive.lock().await.dupe() };
         let (all_membership, all_prekey, all_cgka) = {
-            let keyhive = self.keyhive.lock().await;
             let all_membership = keyhive.membership_ops_for_all_agents().await;
             let all_prekey = keyhive.reachable_prekey_ops_for_all_agents().await;
             let all_cgka = keyhive.cgka_ops_for_all_agents().await;
@@ -901,18 +903,17 @@ where
         Ok(())
     }
 
-    /// Sign a message and send it to a peer.
-    async fn sign_and_send(
+    /// CBOR-serialize a message, sign it, and wrap it as a [`SignedMessage`].
+    pub(crate) async fn build_signed_message(
         &self,
-        target_peer_id: &KeyhivePeerId,
         message: Message,
         include_contact_card: bool,
-    ) -> Result<(), ProtocolError<Conn::SendError>> {
+    ) -> Result<SignedMessage, ProtocolError<Conn::SendError>> {
         let msg_bytes =
             cbor_serialize(&message).map_err(|e| SigningError::Serialization(e.to_string()))?;
 
         let signed: Signed<Vec<u8>> = {
-            let keyhive = self.keyhive.lock().await;
+            let keyhive = { self.keyhive.lock().await.dupe() };
             keyhive
                 .try_sign(msg_bytes)
                 .await
@@ -924,11 +925,23 @@ where
         let signed_bytes =
             bincode::serialize(&signed).map_err(|e| SigningError::Serialization(e.to_string()))?;
 
-        let signed_message = if include_contact_card {
+        Ok(if include_contact_card {
             SignedMessage::with_contact_card(signed_bytes, self.contact_card.clone())
         } else {
             SignedMessage::new(signed_bytes)
-        };
+        })
+    }
+
+    /// Sign a message and send it to a peer.
+    async fn sign_and_send(
+        &self,
+        target_peer_id: &KeyhivePeerId,
+        message: Message,
+        include_contact_card: bool,
+    ) -> Result<(), ProtocolError<Conn::SendError>> {
+        let signed_message = self
+            .build_signed_message(message, include_contact_card)
+            .await?;
 
         let conn = {
             let peers = self.peers.lock().await;
@@ -957,7 +970,7 @@ where
             .map_err(ProtocolError::InvalidIdentifier)?;
 
         let (our_events, their_events, public_events) = {
-            let keyhive = self.keyhive.lock().await;
+            let keyhive = { self.keyhive.lock().await.dupe() };
 
             let our_agent = keyhive.get_agent(our_id).await;
             let their_agent = keyhive.get_agent(their_id).await;


### PR DESCRIPTION
In the Keyhive sync protocol, dupe the `Keyhive` handle under a brief lock and release the coarse outer `Mutex` before serving, signing, and authorizing. 