### PR TITLE
Share bytes by `Arc` in keyhive protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5329,6 +5329,8 @@ dependencies = [
  "blake3",
  "bolero",
  "ciborium",
+ "criterion",
+ "dhat",
  "dupe",
  "ed25519-dalek 2.2.0",
  "future_form",

--- a/subduction_keyhive/Cargo.toml
+++ b/subduction_keyhive/Cargo.toml
@@ -25,6 +25,7 @@ futures = { workspace = true }
 future_form = { workspace = true }
 subduction_core = { workspace = true }
 subduction_crypto = { workspace = true, optional = true }
+dhat = { workspace = true, optional = true }
 keyhive_core = { workspace = true }
 keyhive_crypto = { workspace = true }
 sedimentree_core = { workspace = true }
@@ -45,14 +46,25 @@ runtime = ["handler", "serde", "dep:tokio", "dep:tokio-util"]
 serde = ["dep:serde", "dep:serde_bytes", "dep:serde_json", "dep:dupe", "std"]
 std = ["thiserror/std"]
 test-utils = ["dep:async-channel", "serde"]
+# In-crate heap-profiling harness (the periodic-cache serving/refresh membench
+# in cache/membench.rs). Installs dhat as the global allocator. Run with:
+#   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
+#       serving_membench -- --nocapture --exact
+dhat-heap = ["dep:dhat", "test-utils"]
 
 [dev-dependencies]
 async-channel = { workspace = true }
+criterion = { workspace = true }
 nonempty = "0.10.0"
 subduction_core = { workspace = true, features = ["std", "test_utils"] }
 subduction_crypto = { workspace = true }
 testresult = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
+
+[[bench]]
+name = "periodic_cache"
+harness = false
+required-features = ["test-utils"]
 
 [lints]
 workspace = true

--- a/subduction_keyhive/benches/periodic_cache.rs
+++ b/subduction_keyhive/benches/periodic_cache.rs
@@ -1,0 +1,284 @@
+//! Benchmark: the server's periodic event cache (`PeriodicEventCache`) build cost.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo bench -p subduction_keyhive --features test-utils --bench periodic_cache
+//! ```
+//!
+//! The 2 s `refresh_cache` calls `KeyhiveProtocol::all_agent_events`, which builds
+//! a per-agent reachable-hash set for every agent. This
+//! bench measures how that build's time and the resulting cache size scale with
+//! the number of peers/docs, under two access shapes:
+//!
+//! - `public`: N peer agents are known to the server; each of N docs is shared
+//!   with the Public agent (mirrors the load test's `setPublicAccess`).
+//! - `members`: additionally, each doc lists K specific peers as Read members
+//!   (mirrors cross-subscription / non-public reachability).
+//!
+//! For each (shape, N) the size table is printed once to stderr: agents, total
+//! per-agent hash entries (Sigma |`agent_hashes`[a]|), distinct events. The criterion
+//! timing measures the `all_agent_events` rebuild itself (run every 2 s in production).
+
+#![allow(
+    missing_docs,
+    unreachable_pub,
+    clippy::cast_possible_truncation,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::wildcard_enum_match_arm
+)]
+
+use std::collections::BTreeSet;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use futures::executor::block_on;
+use keyhive_core::{
+    access::Access,
+    principal::{agent::Agent, identifier::Identifier, membered::Membered, public::Public},
+};
+use nonempty::nonempty;
+use subduction_keyhive::{
+    AllAgentEvents,
+    test_utils::{
+        SimpleKeyhive, TestProtocol, create_channel_pair, keyhive_peer_id, make_keyhive,
+        make_protocol_with_shared_keyhive, sync_pair_rounds,
+    },
+};
+
+/// Access shape for the generated docs.
+#[derive(Clone, Copy)]
+enum Shape {
+    /// Each doc shared with the Public agent only.
+    Public,
+    /// Each doc additionally lists `K` specific peers as Read members.
+    Members(usize),
+    /// Each doc lists all other N - 1 peers as Read members.
+    AllOthers,
+}
+
+/// Measured cache size for one built configuration.
+struct Sizes {
+    agents: usize,
+    agent_hash_entries: usize,
+    /// Largest single per-agent reachable set.
+    max_per_agent: usize,
+    events: usize,
+}
+
+impl Sizes {
+    /// Snapshot the cache-relevant sizes of a built [`AllAgentEvents`].
+    fn from_events(events: &AllAgentEvents) -> Self {
+        Self {
+            agents: events.agent_count(),
+            agent_hash_entries: events.agent_hashes.values().map(BTreeSet::len).sum(),
+            max_per_agent: events
+                .agent_hashes
+                .values()
+                .map(BTreeSet::len)
+                .max()
+                .unwrap_or(0),
+            events: events.event_count(),
+        }
+    }
+}
+
+/// Build a server keyhive with `n` known peer agents and `n` docs under `shape`,
+/// wrap it in a protocol, and report the resulting cache snapshot size.
+async fn build(n: usize, shape: Shape) -> (TestProtocol, Sizes) {
+    let server = make_keyhive().await;
+
+    // N peer keyhives, and make the server aware of each as an agent (mirrors
+    // the server learning peer identities via SUK ingest under load).
+    let mut peers: Vec<SimpleKeyhive> = Vec::with_capacity(n);
+    for _ in 0..n {
+        peers.push(make_keyhive().await);
+    }
+    for p in &peers {
+        let cc = p.contact_card().await.expect("contact_card");
+        server
+            .receive_contact_card(&cc)
+            .await
+            .expect("receive_contact_card");
+    }
+
+    // N docs owned by the server, shared per `shape`.
+    for i in 0..n {
+        let fill = ((i % 251) + 1) as u8;
+        let doc = server
+            .generate_doc(vec![], nonempty![[fill; 32]])
+            .await
+            .expect("generate_doc");
+        let doc_id = doc.lock().await.doc_id();
+        let membered = Membered::Document(doc_id, doc.clone());
+        match shape {
+            Shape::Public => {
+                let public_agent: Agent<_, _, _, _> = Public.individual().into();
+                server
+                    .add_member(public_agent, &membered, Access::Read, &[])
+                    .await
+                    .expect("add_member public");
+            }
+            Shape::Members(_) | Shape::AllOthers => {
+                let k = match shape {
+                    Shape::Members(k) => k.min(n.saturating_sub(1)),
+                    _ => n.saturating_sub(1),
+                };
+                for step in 1..=k {
+                    let j = (i + step) % n;
+                    if j == i {
+                        continue;
+                    }
+                    let id: Identifier = peers[j].id().into();
+                    if let Some(agent) = server.get_agent(id).await {
+                        server
+                            .add_member(agent, &membered, Access::Read, &[])
+                            .await
+                            .expect("add_member peer");
+                    }
+                }
+            }
+        }
+    }
+
+    let (proto, _shared, _storage) = make_protocol_with_shared_keyhive(server).await;
+
+    let events = proto
+        .all_agent_events(&BTreeSet::new())
+        .await
+        .expect("all_agent_events");
+    let sizes = Sizes::from_events(&events);
+    (proto, sizes)
+}
+
+/// Each of N peers owns its own public doc, adds the server as a Relay member,
+/// then syncs keyhive through the server. The server then ingests the graph
+/// (peer-owned docs + cross-propagated individual / prekey ops), unlike `build`
+/// where the server owns every doc. Returns the server's resulting cache snapshot.
+async fn build_synced(n: usize) -> (TestProtocol, Sizes) {
+    let server_kh = make_keyhive().await;
+    let server_id = keyhive_peer_id(&server_kh);
+    let server_cc = server_kh.contact_card().await.expect("server cc");
+    let server_identifier: Identifier = server_kh.id().into();
+
+    let mut peer_khs: Vec<SimpleKeyhive> = Vec::with_capacity(n);
+    for _ in 0..n {
+        peer_khs.push(make_keyhive().await);
+    }
+    // Contact cards both directions so peer<->server can sync.
+    for p in &peer_khs {
+        let p_cc = p.contact_card().await.expect("peer cc");
+        server_kh
+            .receive_contact_card(&p_cc)
+            .await
+            .expect("server recv cc");
+        p.receive_contact_card(&server_cc)
+            .await
+            .expect("peer recv cc");
+    }
+    // Each peer owns a doc, makes it public, and grants the server relay (Read).
+    for (i, p) in peer_khs.iter().enumerate() {
+        let fill = ((i % 251) + 1) as u8;
+        let doc = p
+            .generate_doc(vec![], nonempty![[fill; 32]])
+            .await
+            .expect("generate_doc");
+        let doc_id = doc.lock().await.doc_id();
+        let membered = Membered::Document(doc_id, doc.clone());
+        let public_agent: Agent<_, _, _, _> = Public.individual().into();
+        p.add_member(public_agent, &membered, Access::Read, &[])
+            .await
+            .expect("add public");
+        let server_agent = p
+            .get_agent(server_identifier)
+            .await
+            .expect("server agent known to peer");
+        p.add_member(server_agent, &membered, Access::Read, &[])
+            .await
+            .expect("add server relay");
+    }
+
+    let (server_proto, _server_shared, _) = make_protocol_with_shared_keyhive(server_kh).await;
+    for p_kh in peer_khs {
+        let p_id = keyhive_peer_id(&p_kh);
+        let (p_proto, _p_shared, _) = make_protocol_with_shared_keyhive(p_kh).await;
+        let (p_conn, s_conn) = create_channel_pair(p_id.clone(), &server_id);
+        p_proto.add_peer(server_id.clone(), p_conn.clone()).await;
+        server_proto.add_peer(p_id.clone(), s_conn.clone()).await;
+        // Bidirectional sync so the server ingests this peer's keyhive state.
+        sync_pair_rounds(
+            &p_proto,
+            &server_proto,
+            &p_id,
+            &server_id,
+            &p_conn,
+            &s_conn,
+            3,
+        )
+        .await;
+    }
+
+    let events = server_proto
+        .all_agent_events(&BTreeSet::new())
+        .await
+        .expect("all_agent_events");
+    let sizes = Sizes::from_events(&events);
+    (server_proto, sizes)
+}
+
+/// Benchmark `all_agent_events` (the per-refresh rebuild) across N for one shape,
+/// printing the size table to stderr as configurations are built.
+fn bench_shape(c: &mut Criterion, label: &str, shape: Shape, sizes: &[usize]) {
+    let mut group = c.benchmark_group(format!("all_agent_events/{label}"));
+    group.sample_size(10);
+    eprintln!("\n=== {label} : cache size scaling ===");
+    eprintln!("    N | agents | agent_hash_entries | max/agent | events");
+    for &n in sizes {
+        let (proto, s) = block_on(build(n, shape));
+        eprintln!(
+            "{n:5} | {:6} | {:18} | {:9} | {:6}",
+            s.agents, s.agent_hash_entries, s.max_per_agent, s.events
+        );
+        group.bench_with_input(BenchmarkId::from_parameter(n), &proto, |b, proto| {
+            b.iter(|| {
+                block_on(proto.all_agent_events(&BTreeSet::new())).expect("all_agent_events")
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_synced(c: &mut Criterion, sizes: &[usize]) {
+    let mut group = c.benchmark_group("all_agent_events/synced");
+    group.sample_size(10);
+    eprintln!(
+        "\n=== synced (real peers own public docs + server relay, synced) : cache size scaling ==="
+    );
+    eprintln!("    N | agents | agent_hash_entries | max/agent | events");
+    for &n in sizes {
+        let (proto, s) = block_on(build_synced(n));
+        eprintln!(
+            "{n:5} | {:6} | {:18} | {:9} | {:6}",
+            s.agents, s.agent_hash_entries, s.max_per_agent, s.events
+        );
+        group.bench_with_input(BenchmarkId::from_parameter(n), &proto, |b, proto| {
+            b.iter(|| {
+                block_on(proto.all_agent_events(&BTreeSet::new())).expect("all_agent_events")
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_cache(c: &mut Criterion) {
+    let sizes = [25usize, 50, 100, 200];
+    bench_shape(c, "public", Shape::Public, &sizes);
+    bench_shape(c, "members_k5", Shape::Members(5), &sizes);
+    // Dense graph: every agent reads every other doc.
+    bench_shape(c, "all_to_all", Shape::AllOthers, &[10usize, 20, 40, 80]);
+    // Peers own docs + sync through the server.
+    bench_synced(c, &[10usize, 25, 50]);
+}
+
+criterion_group!(benches, bench_cache);
+criterion_main!(benches);

--- a/subduction_keyhive/src/all_agent_events.rs
+++ b/subduction_keyhive/src/all_agent_events.rs
@@ -5,7 +5,7 @@
 use alloc::collections::{BTreeMap, BTreeSet};
 
 use crate::{
-    message::{CborBytes, EventBytes, EventHash},
+    message::{EventHash, EventPair},
     peer_id::KeyhivePeerId,
 };
 
@@ -15,8 +15,9 @@ pub struct AllAgentEvents {
     /// Per-agent reachable hash sets.
     pub agent_hashes: BTreeMap<KeyhivePeerId, BTreeSet<EventHash>>,
     /// Bincode-serialized `StaticEvent` bytes paired with pre-encoded CBOR
-    /// byte-string framing.
-    pub event_data: BTreeMap<EventHash, (EventBytes, CborBytes)>,
+    /// byte-string framing, [`Arc`](alloc::sync::Arc)-shared so the cache and
+    /// every served response reference one copy.
+    pub event_data: BTreeMap<EventHash, EventPair>,
 }
 
 impl AllAgentEvents {

--- a/subduction_keyhive/src/all_agent_events.rs
+++ b/subduction_keyhive/src/all_agent_events.rs
@@ -2,22 +2,21 @@
 
 #![cfg(all(feature = "serde", feature = "std"))]
 
-use alloc::collections::{BTreeMap, BTreeSet};
-
-use crate::{
-    message::{EventHash, EventPair},
-    peer_id::KeyhivePeerId,
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
 };
+
+use crate::{message::EventHash, peer_id::KeyhivePeerId};
 
 /// Per-agent event snapshot, deduplicated by hash.
 #[derive(Debug, Clone, Default)]
 pub struct AllAgentEvents {
     /// Per-agent reachable hash sets.
     pub agent_hashes: BTreeMap<KeyhivePeerId, BTreeSet<EventHash>>,
-    /// Bincode-serialized `StaticEvent` bytes paired with pre-encoded CBOR
-    /// byte-string framing, [`Arc`](alloc::sync::Arc)-shared so the cache and
-    /// every served response reference one copy.
-    pub event_data: BTreeMap<EventHash, EventPair>,
+    /// Bincode-serialized `StaticEvent` bytes, [`Arc`](alloc::sync::Arc)-shared
+    /// so the cache and every served response reference one copy.
+    pub event_data: BTreeMap<EventHash, Arc<[u8]>>,
 }
 
 impl AllAgentEvents {

--- a/subduction_keyhive/src/cache.rs
+++ b/subduction_keyhive/src/cache.rs
@@ -25,7 +25,7 @@ use keyhive_crypto::{content::reference::ContentRef, signer::async_signer::Async
 use crate::{
     KeyhivePeerId, KeyhiveProtocol, ProtocolError,
     connection::KeyhiveConnection,
-    message::{AgentHashMap, EventHash, EventPair},
+    message::{AgentHashMap, EventHash},
     storage::KeyhiveStorage,
 };
 
@@ -45,13 +45,13 @@ pub(crate) struct PeriodicEventCache {
     public_hashes: BTreeSet<EventHash>,
 
     /// The public set materialized as an `AgentHashMap`.
-    public_pair: Arc<AgentHashMap>,
+    public_map: Arc<AgentHashMap>,
 
-    /// Hash -> raw event bytes paired with pre-encoded CBOR byte-string, `Arc`-shared.
-    /// Monotonic growth across refreshes. Events are immutable, so entries are never
-    /// invalidated. Served responses clone the `Arc`s, not the bytes, so concurrent
+    /// Hash -> `Arc`-shared bincode event bytes. Monotonic growth across
+    /// refreshes. Events are immutable, so entries are never invalidated.
+    /// Served responses clone the `Arc`s, not the bytes, so concurrent
     /// responses share this one copy.
-    event_data: BTreeMap<EventHash, EventPair>,
+    event_data: BTreeMap<EventHash, Arc<[u8]>>,
 
     /// Last keyhive `total_ops` seen, so refresh can skip rebuilds
     /// when nothing has changed.
@@ -64,7 +64,7 @@ impl PeriodicEventCache {
         Self {
             agent_hashes: BTreeMap::new(),
             public_hashes: BTreeSet::new(),
-            public_pair: Arc::new(AgentHashMap::new()),
+            public_map: Arc::new(AgentHashMap::new()),
             event_data: BTreeMap::new(),
             last_total_ops: None,
         }
@@ -99,8 +99,8 @@ impl PeriodicEventCache {
     ///
     /// Every event the public agent can see is unconditionally included,
     /// plus events reachable to both `a` and `b`. Returns an `Arc`-shared
-    /// map whose values are [`EventPair`]s (`Arc`-shared bytes), so callers
-    /// share the cache's single copy rather than deep-copying.
+    /// map whose values are `Arc`-shared bytes, so callers share the cache's
+    /// single copy rather than deep-copying.
     pub(crate) fn events_for_peer_pair(
         &self,
         a: &KeyhivePeerId,
@@ -108,31 +108,31 @@ impl PeriodicEventCache {
     ) -> Arc<AgentHashMap> {
         let (Some(ha), Some(hb)) = (self.agent_hashes.get(a), self.agent_hashes.get(b)) else {
             // Unknown peer: served set is the public set.
-            return self.public_pair.dupe();
+            return self.public_map.dupe();
         };
 
         // Private events reachable to both a and b, beyond the public set and
         // present in the byte store.
         let mut private = ha
             .intersection(hb)
-            .filter(|h| !self.public_pair.contains_key(*h))
-            .filter_map(|h| self.event_data.get(h).map(|pair| (*h, pair.dupe())))
+            .filter(|h| !self.public_map.contains_key(*h))
+            .filter_map(|h| self.event_data.get(h).map(|bytes| (*h, bytes.dupe())))
             .peekable();
 
         if private.peek().is_none() {
-            return self.public_pair.dupe();
+            return self.public_map.dupe();
         }
 
-        let mut out = (*self.public_pair).clone();
+        let mut out = (*self.public_map).clone();
         out.extend(private);
         Arc::new(out)
     }
 
-    /// Build the public set as an `AgentHashMap`
-    fn build_public_pair(&self) -> AgentHashMap {
+    /// Build the public set as an `AgentHashMap`.
+    fn build_public_map(&self) -> AgentHashMap {
         self.public_hashes
             .iter()
-            .filter_map(|h| self.event_data.get(h).map(|pair| (*h, pair.dupe())))
+            .filter_map(|h| self.event_data.get(h).map(|bytes| (*h, bytes.dupe())))
             .collect()
     }
 
@@ -206,14 +206,15 @@ impl PeriodicEventCache {
         self.public_hashes = new_public;
         // Materialize the public set once per refresh so per-request serving
         // can share it by `Arc` instead of rebuilding it.
-        self.public_pair = Arc::new(self.build_public_pair());
+        self.public_map = Arc::new(self.build_public_map());
         self.last_total_ops = Some(total);
         Ok(true)
     }
 }
 
-/// Heap-profiling membenches, gated behind `dhat-heap`.
-#[cfg(all(test, feature = "dhat-heap", feature = "test-utils"))]
+/// Heap-profiling membenches, gated behind `dhat-heap` (which implies
+/// `test-utils`).
+#[cfg(all(test, feature = "dhat-heap"))]
 mod membench;
 
 #[cfg(test)]
@@ -230,11 +231,9 @@ mod tests {
     fn events_for_peer_pair_returns_only_public_when_peers_unknown() {
         let mut cache = PeriodicEventCache::new();
         let h: EventHash = [9; 32];
-        cache
-            .event_data
-            .insert(h, (vec![1, 2, 3].into(), vec![0x43, 1, 2, 3].into()));
+        cache.event_data.insert(h, vec![1, 2, 3].into());
         cache.public_hashes.insert(h);
-        cache.public_pair = Arc::new(cache.build_public_pair());
+        cache.public_map = Arc::new(cache.build_public_map());
 
         let result = cache.events_for_peer_pair(&peer(1), &peer(2));
         assert_eq!(result.len(), 1);
@@ -250,13 +249,11 @@ mod tests {
         let bob_only: EventHash = [3; 32];
 
         for h in [public_h, shared_h, alice_only, bob_only] {
-            cache
-                .event_data
-                .insert(h, (vec![h[0]].into(), vec![0x41, h[0]].into()));
+            cache.event_data.insert(h, vec![h[0]].into());
         }
 
         cache.public_hashes.insert(public_h);
-        cache.public_pair = Arc::new(cache.build_public_pair());
+        cache.public_map = Arc::new(cache.build_public_map());
 
         let mut alice = BTreeSet::new();
         alice.insert(shared_h);
@@ -283,11 +280,9 @@ mod tests {
         let mut cache = PeriodicEventCache::new();
         let public_h: EventHash = [9; 32];
         let ghost_h: EventHash = [4; 32];
-        cache
-            .event_data
-            .insert(public_h, (vec![1].into(), vec![0x41, 1].into()));
+        cache.event_data.insert(public_h, vec![1].into());
         cache.public_hashes.insert(public_h);
-        cache.public_pair = Arc::new(cache.build_public_pair());
+        cache.public_map = Arc::new(cache.build_public_map());
 
         cache
             .agent_hashes
@@ -306,15 +301,13 @@ mod tests {
     fn events_for_peer_pair_shares_public_arc_when_no_private_events() {
         let mut cache = PeriodicEventCache::new();
         let public_h: EventHash = [9; 32];
-        cache
-            .event_data
-            .insert(public_h, (vec![1].into(), vec![0x41, 1].into()));
+        cache.event_data.insert(public_h, vec![1].into());
         cache.public_hashes.insert(public_h);
-        cache.public_pair = Arc::new(cache.build_public_pair());
+        cache.public_map = Arc::new(cache.build_public_map());
 
         // Unknown peers -> public-only -> shares the cached Arc (no allocation).
         let r1 = cache.events_for_peer_pair(&peer(1), &peer(2));
-        assert!(Arc::ptr_eq(&r1, &cache.public_pair));
+        assert!(Arc::ptr_eq(&r1, &cache.public_map));
 
         // Known peers whose intersection is only the public hash -> still shared.
         cache
@@ -324,7 +317,7 @@ mod tests {
             .agent_hashes
             .insert(peer(2), BTreeSet::from([public_h]));
         let r2 = cache.events_for_peer_pair(&peer(1), &peer(2));
-        assert!(Arc::ptr_eq(&r2, &cache.public_pair));
+        assert!(Arc::ptr_eq(&r2, &cache.public_map));
     }
 
     #[test]
@@ -332,14 +325,10 @@ mod tests {
         let mut cache = PeriodicEventCache::new();
         let public_h: EventHash = [9; 32];
         let private_h: EventHash = [5; 32];
-        cache
-            .event_data
-            .insert(public_h, (vec![1].into(), vec![0x41, 1].into()));
-        cache
-            .event_data
-            .insert(private_h, (vec![2].into(), vec![0x41, 2].into()));
+        cache.event_data.insert(public_h, vec![1].into());
+        cache.event_data.insert(private_h, vec![2].into());
         cache.public_hashes.insert(public_h);
-        cache.public_pair = Arc::new(cache.build_public_pair());
+        cache.public_map = Arc::new(cache.build_public_map());
 
         // Both peers reach the private hash beyond the public set, so the rare
         // clone-and-extend path runs.
@@ -352,11 +341,11 @@ mod tests {
 
         let result = cache.events_for_peer_pair(&peer(1), &peer(2));
         // A fresh map, not an alias of the shared public set.
-        assert!(!Arc::ptr_eq(&result, &cache.public_pair));
+        assert!(!Arc::ptr_eq(&result, &cache.public_map));
         assert_eq!(result.len(), 2);
         assert!(result.contains_key(&public_h));
         assert!(result.contains_key(&private_h));
         // The shared public map is left untouched (still public-only).
-        assert_eq!(cache.public_pair.len(), 1);
+        assert_eq!(cache.public_map.len(), 1);
     }
 }

--- a/subduction_keyhive/src/cache.rs
+++ b/subduction_keyhive/src/cache.rs
@@ -5,10 +5,13 @@
 //! - Global byte stores: keyed by hash, deduplicated across all
 //!   agents. Events are immutable so these grow monotonically.
 //!
-//! [`hashes_for_peer_pair`](PeriodicEventCache::hashes_for_peer_pair)
+//! [`events_for_peer_pair`](PeriodicEventCache::events_for_peer_pair)
 //! joins the per-agent sets with the global byte stores at request time.
 
-use alloc::collections::{BTreeMap, BTreeSet, btree_map::Entry};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use dupe::Dupe;
 use keyhive_core::{
@@ -22,7 +25,7 @@ use keyhive_crypto::{content::reference::ContentRef, signer::async_signer::Async
 use crate::{
     KeyhivePeerId, KeyhiveProtocol, ProtocolError,
     connection::KeyhiveConnection,
-    message::{AgentHashMap, CborBytes, EventBytes, EventHash},
+    message::{AgentHashMap, EventHash, EventPair},
     storage::KeyhiveStorage,
 };
 
@@ -41,10 +44,14 @@ pub(crate) struct PeriodicEventCache {
     /// Unioned into every peer pair's hash set without intersection.
     public_hashes: BTreeSet<EventHash>,
 
-    /// Hash -> raw event bytes paired with pre-encoded CBOR byte-string
-    /// framing. Monotonic growth across refreshes. Events are immutable,
-    /// so entries are never invalidated.
-    event_data: BTreeMap<EventHash, (EventBytes, CborBytes)>,
+    /// The public set materialized as an `AgentHashMap`.
+    public_pair: Arc<AgentHashMap>,
+
+    /// Hash -> raw event bytes paired with pre-encoded CBOR byte-string, `Arc`-shared.
+    /// Monotonic growth across refreshes. Events are immutable, so entries are never
+    /// invalidated. Served responses clone the `Arc`s, not the bytes, so concurrent
+    /// responses share this one copy.
+    event_data: BTreeMap<EventHash, EventPair>,
 
     /// Last keyhive `total_ops` seen, so refresh can skip rebuilds
     /// when nothing has changed.
@@ -53,10 +60,11 @@ pub(crate) struct PeriodicEventCache {
 
 impl PeriodicEventCache {
     /// Create an empty cache.
-    pub(crate) const fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             agent_hashes: BTreeMap::new(),
             public_hashes: BTreeSet::new(),
+            public_pair: Arc::new(AgentHashMap::new()),
             event_data: BTreeMap::new(),
             last_total_ops: None,
         }
@@ -90,34 +98,42 @@ impl PeriodicEventCache {
     /// Public hashes ∪ (A ∩ B).
     ///
     /// Every event the public agent can see is unconditionally included,
-    /// plus events reachable to *both* `a` and `b`. Returns a map keyed
-    /// by hash with `(EventBytes, CborBytes)` cloned from the byte stores.
+    /// plus events reachable to both `a` and `b`. Returns an `Arc`-shared
+    /// map whose values are [`EventPair`]s (`Arc`-shared bytes), so callers
+    /// share the cache's single copy rather than deep-copying.
     pub(crate) fn events_for_peer_pair(
         &self,
         a: &KeyhivePeerId,
         b: &KeyhivePeerId,
-    ) -> AgentHashMap {
-        let mut out = AgentHashMap::new();
-        for h in &self.public_hashes {
-            self.insert_pair_entry(&mut out, *h);
+    ) -> Arc<AgentHashMap> {
+        let (Some(ha), Some(hb)) = (self.agent_hashes.get(a), self.agent_hashes.get(b)) else {
+            // Unknown peer: served set is the public set.
+            return self.public_pair.dupe();
+        };
+
+        // Private events reachable to both a and b, beyond the public set and
+        // present in the byte store.
+        let mut private = ha
+            .intersection(hb)
+            .filter(|h| !self.public_pair.contains_key(*h))
+            .filter_map(|h| self.event_data.get(h).map(|pair| (*h, pair.dupe())))
+            .peekable();
+
+        if private.peek().is_none() {
+            return self.public_pair.dupe();
         }
-        if let (Some(ha), Some(hb)) = (self.agent_hashes.get(a), self.agent_hashes.get(b)) {
-            for h in ha.intersection(hb) {
-                if let Entry::Vacant(e) = out.entry(*h)
-                    && let Some((eb, cb)) = self.event_data.get(h)
-                {
-                    e.insert((eb.clone(), cb.clone()));
-                }
-            }
-        }
-        out
+
+        let mut out = (*self.public_pair).clone();
+        out.extend(private);
+        Arc::new(out)
     }
 
-    /// Insert `hash`'s deduplicated bytes into `out`.
-    fn insert_pair_entry(&self, out: &mut AgentHashMap, hash: EventHash) {
-        if let Some((eb, cb)) = self.event_data.get(&hash) {
-            out.insert(hash, (eb.clone(), cb.clone()));
-        }
+    /// Build the public set as an `AgentHashMap`
+    fn build_public_pair(&self) -> AgentHashMap {
+        self.public_hashes
+            .iter()
+            .filter_map(|h| self.event_data.get(h).map(|pair| (*h, pair.dupe())))
+            .collect()
     }
 
     /// Refresh the cache from the protocol's keyhive view.
@@ -188,10 +204,17 @@ impl PeriodicEventCache {
 
         self.agent_hashes = new_agent_hashes;
         self.public_hashes = new_public;
+        // Materialize the public set once per refresh so per-request serving
+        // can share it by `Arc` instead of rebuilding it.
+        self.public_pair = Arc::new(self.build_public_pair());
         self.last_total_ops = Some(total);
         Ok(true)
     }
 }
+
+/// Heap-profiling membenches, gated behind `dhat-heap`.
+#[cfg(all(test, feature = "dhat-heap", feature = "test-utils"))]
+mod membench;
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
@@ -203,15 +226,15 @@ mod tests {
     fn peer(seed: u8) -> KeyhivePeerId {
         KeyhivePeerId::from_bytes([seed; 32])
     }
-
     #[test]
     fn events_for_peer_pair_returns_only_public_when_peers_unknown() {
         let mut cache = PeriodicEventCache::new();
         let h: EventHash = [9; 32];
         cache
             .event_data
-            .insert(h, (vec![1, 2, 3], vec![0x43, 1, 2, 3]));
+            .insert(h, (vec![1, 2, 3].into(), vec![0x43, 1, 2, 3].into()));
         cache.public_hashes.insert(h);
+        cache.public_pair = Arc::new(cache.build_public_pair());
 
         let result = cache.events_for_peer_pair(&peer(1), &peer(2));
         assert_eq!(result.len(), 1);
@@ -227,10 +250,13 @@ mod tests {
         let bob_only: EventHash = [3; 32];
 
         for h in [public_h, shared_h, alice_only, bob_only] {
-            cache.event_data.insert(h, (vec![h[0]], vec![0x41, h[0]]));
+            cache
+                .event_data
+                .insert(h, (vec![h[0]].into(), vec![0x41, h[0]].into()));
         }
 
         cache.public_hashes.insert(public_h);
+        cache.public_pair = Arc::new(cache.build_public_pair());
 
         let mut alice = BTreeSet::new();
         alice.insert(shared_h);
@@ -248,5 +274,89 @@ mod tests {
         assert!(!result.contains_key(&alice_only), "alice-only excluded");
         assert!(!result.contains_key(&bob_only), "bob-only excluded");
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn events_for_peer_pair_excludes_intersection_hash_absent_from_store() {
+        // A hash reachable to both peers but never serialized into event_data
+        // must not appear, and the served map must equal the public set.
+        let mut cache = PeriodicEventCache::new();
+        let public_h: EventHash = [9; 32];
+        let ghost_h: EventHash = [4; 32];
+        cache
+            .event_data
+            .insert(public_h, (vec![1].into(), vec![0x41, 1].into()));
+        cache.public_hashes.insert(public_h);
+        cache.public_pair = Arc::new(cache.build_public_pair());
+
+        cache
+            .agent_hashes
+            .insert(peer(1), BTreeSet::from([ghost_h]));
+        cache
+            .agent_hashes
+            .insert(peer(2), BTreeSet::from([ghost_h]));
+
+        let result = cache.events_for_peer_pair(&peer(1), &peer(2));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&public_h));
+        assert!(!result.contains_key(&ghost_h), "unserialized hash excluded");
+    }
+
+    #[test]
+    fn events_for_peer_pair_shares_public_arc_when_no_private_events() {
+        let mut cache = PeriodicEventCache::new();
+        let public_h: EventHash = [9; 32];
+        cache
+            .event_data
+            .insert(public_h, (vec![1].into(), vec![0x41, 1].into()));
+        cache.public_hashes.insert(public_h);
+        cache.public_pair = Arc::new(cache.build_public_pair());
+
+        // Unknown peers -> public-only -> shares the cached Arc (no allocation).
+        let r1 = cache.events_for_peer_pair(&peer(1), &peer(2));
+        assert!(Arc::ptr_eq(&r1, &cache.public_pair));
+
+        // Known peers whose intersection is only the public hash -> still shared.
+        cache
+            .agent_hashes
+            .insert(peer(1), BTreeSet::from([public_h]));
+        cache
+            .agent_hashes
+            .insert(peer(2), BTreeSet::from([public_h]));
+        let r2 = cache.events_for_peer_pair(&peer(1), &peer(2));
+        assert!(Arc::ptr_eq(&r2, &cache.public_pair));
+    }
+
+    #[test]
+    fn events_for_peer_pair_returns_fresh_arc_with_private_events() {
+        let mut cache = PeriodicEventCache::new();
+        let public_h: EventHash = [9; 32];
+        let private_h: EventHash = [5; 32];
+        cache
+            .event_data
+            .insert(public_h, (vec![1].into(), vec![0x41, 1].into()));
+        cache
+            .event_data
+            .insert(private_h, (vec![2].into(), vec![0x41, 2].into()));
+        cache.public_hashes.insert(public_h);
+        cache.public_pair = Arc::new(cache.build_public_pair());
+
+        // Both peers reach the private hash beyond the public set, so the rare
+        // clone-and-extend path runs.
+        cache
+            .agent_hashes
+            .insert(peer(1), BTreeSet::from([public_h, private_h]));
+        cache
+            .agent_hashes
+            .insert(peer(2), BTreeSet::from([public_h, private_h]));
+
+        let result = cache.events_for_peer_pair(&peer(1), &peer(2));
+        // A fresh map, not an alias of the shared public set.
+        assert!(!Arc::ptr_eq(&result, &cache.public_pair));
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&public_h));
+        assert!(result.contains_key(&private_h));
+        // The shared public map is left untouched (still public-only).
+        assert_eq!(cache.public_pair.len(), 1);
     }
 }

--- a/subduction_keyhive/src/cache/membench.rs
+++ b/subduction_keyhive/src/cache/membench.rs
@@ -67,7 +67,7 @@ fn serving_membench() {
     use nonempty::nonempty;
 
     use crate::{
-        message::{Message, SharedBytes},
+        message::Message,
         test_utils::{keyhive_peer_id, make_keyhive, make_protocol_with_shared_keyhive},
     };
 
@@ -199,7 +199,7 @@ fn serving_membench() {
         //   "off":       hold only the Arc-shared per-pair maps. A warm peer
         //                 whose found_ops diff is empty.
         //   "cold":      also hold found_ops = the full event set as
-        //                 `Vec<SharedBytes>`, which clones the cache `Arc`s
+        //                 `Vec<Arc<[u8]>>`, which clones the cache `Arc`s
         //                 rather than copying bytes.
         //   "serialize": build and hold one serialized `SyncResponse` frame
         //                 per peer, dropping the maps and found_ops first (as
@@ -209,7 +209,7 @@ fn serving_membench() {
             let cold = wire == "cold";
             let serialize = wire == "serialize";
             let pre = dhat::HeapStats::get();
-            let mut inflight: Vec<(Arc<AgentHashMap>, Vec<SharedBytes>)> =
+            let mut inflight: Vec<(Arc<AgentHashMap>, Vec<Arc<[u8]>>)> =
                 Vec::with_capacity(if serialize { 0 } else { serve });
             let mut frames: Vec<alloc::vec::Vec<u8>> =
                 Vec::with_capacity(if serialize { serve } else { 0 });
@@ -219,8 +219,7 @@ fn serving_membench() {
                 let response = cache.events_for_peer_pair(&local, &peer);
                 per_response = response.len();
                 if serialize {
-                    let found_ops: Vec<SharedBytes> =
-                        response.values().map(|(eb, _)| eb.dupe()).collect();
+                    let found_ops: Vec<Arc<[u8]>> = response.values().map(Dupe::dupe).collect();
                     let msg = Message::SyncResponse {
                         sender_id: local.clone(),
                         target_id: peer,
@@ -234,8 +233,8 @@ fn serving_membench() {
                     frames.push(buf);
                     // response and found_ops drop here, as in the handler.
                 } else {
-                    let found_ops: Vec<SharedBytes> = if cold {
-                        response.values().map(|(eb, _)| eb.dupe()).collect()
+                    let found_ops: Vec<Arc<[u8]>> = if cold {
+                        response.values().map(Dupe::dupe).collect()
                     } else {
                         Vec::new()
                     };

--- a/subduction_keyhive/src/cache/membench.rs
+++ b/subduction_keyhive/src/cache/membench.rs
@@ -26,6 +26,10 @@
 
 use super::*;
 
+/// One held in-flight response in the serve phase: the `Arc`-shared per-pair
+/// map plus its wire-built `found_ops` (empty unless the `cold` mode builds it).
+type InflightResponse = (Arc<AgentHashMap>, Vec<Arc<[u8]>>);
+
 /// Read a `usize` tuning knob from env var `key`, falling back to `default`.
 /// Shared by the `dhat-heap` membench tests below.
 fn env_usize(key: &str, default: usize) -> usize {
@@ -209,7 +213,7 @@ fn serving_membench() {
             let cold = wire == "cold";
             let serialize = wire == "serialize";
             let pre = dhat::HeapStats::get();
-            let mut inflight: Vec<(Arc<AgentHashMap>, Vec<Arc<[u8]>>)> =
+            let mut inflight: Vec<InflightResponse> =
                 Vec::with_capacity(if serialize { 0 } else { serve });
             let mut frames: Vec<alloc::vec::Vec<u8>> =
                 Vec::with_capacity(if serialize { serve } else { 0 });

--- a/subduction_keyhive/src/cache/membench.rs
+++ b/subduction_keyhive/src/cache/membench.rs
@@ -3,11 +3,13 @@
 //! Gated behind `dhat-heap` (which installs dhat as the global allocator)
 //! so normal builds and `cargo test` are unaffected.
 //!
-//! Run:
+//! Both are `#[ignore]`d: dhat's profiler is a global singleton, so the two
+//! cannot run concurrently (the default multi-threaded runner would panic with
+//! "a profiler is already running"). Run one at a time, explicitly:
 //!   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
-//!       serving_membench -- --nocapture --exact
+//!       serving_membench -- --nocapture --include-ignored
 //!   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
-//!       keyhive_baseline_membench -- --nocapture --exact
+//!       keyhive_baseline_membench -- --nocapture --include-ignored
 
 #![allow(
     clippy::cast_precision_loss,
@@ -49,8 +51,9 @@ fn env_usize(key: &str, default: usize) -> usize {
 /// MEMBENCH_K (5), MEMBENCH_ROT (5), MEMBENCH_ITERS (10), MEMBENCH_EDITS (5),
 /// MEMBENCH_SERVE (500). Run:
 ///   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
-///       serving_membench -- --nocapture --exact
+///       serving_membench -- --nocapture --include-ignored
 #[test]
+#[ignore = "dhat profiling harness; run explicitly, one at a time (global profiler)"]
 fn serving_membench() {
     use alloc::vec::Vec;
 
@@ -268,8 +271,9 @@ fn serving_membench() {
 /// Params (env, defaults): MEMBENCH_N (100), MEMBENCH_K (5),
 /// MEMBENCH_ROT (5). Run:
 ///   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
-///       keyhive_baseline_membench -- --nocapture --exact
+///       keyhive_baseline_membench -- --nocapture --include-ignored
 #[test]
+#[ignore = "dhat profiling harness; run explicitly, one at a time (global profiler)"]
 fn keyhive_baseline_membench() {
     use alloc::vec::Vec;
 

--- a/subduction_keyhive/src/cache/membench.rs
+++ b/subduction_keyhive/src/cache/membench.rs
@@ -1,0 +1,390 @@
+//! In-crate heap-profiling membenches for the periodic event cache.
+//!
+//! Gated behind `dhat-heap` (which installs dhat as the global allocator)
+//! so normal builds and `cargo test` are unaffected.
+//!
+//! Run:
+//!   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
+//!       serving_membench -- --nocapture --exact
+//!   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
+//!       keyhive_baseline_membench -- --nocapture --exact
+
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::indexing_slicing,
+    clippy::items_after_statements,
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::unwrap_used
+)]
+
+use super::*;
+
+/// Read a `usize` tuning knob from env var `key`, falling back to `default`.
+/// Shared by the `dhat-heap` membench tests below.
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// In-crate heap membench for the periodic cache, run under dhat as the
+/// global allocator. It exercises `cache.refresh` (the periodic rebuild) and
+/// `cache.events_for_peer_pair` (per-peer serving) directly, so heap
+/// behaviour is measured against the real methods with no test-only API.
+///
+/// Two phases:
+///   1. REFRESH: build a dense server keyhive, then loop `cache.refresh`
+///      while injecting PCS edits, reporting retained and peak heap per
+///      iteration.
+///   2. SERVE: hold `MEMBENCH_SERVE` concurrent `events_for_peer_pair`
+///      responses at once and report the heap they occupy.
+///
+/// Parameters come from env vars (defaults in parens): MEMBENCH_N (100),
+/// MEMBENCH_K (5), MEMBENCH_ROT (5), MEMBENCH_ITERS (10), MEMBENCH_EDITS (5),
+/// MEMBENCH_SERVE (500). Run:
+///   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
+///       serving_membench -- --nocapture --exact
+#[test]
+fn serving_membench() {
+    use alloc::vec::Vec;
+
+    use keyhive_core::{
+        access::Access,
+        principal::{
+            agent::Agent, identifier::Identifier, individual::op::KeyOp, membered::Membered,
+            public::Public,
+        },
+    };
+    use nonempty::nonempty;
+
+    use crate::{
+        message::{Message, SharedBytes},
+        test_utils::{keyhive_peer_id, make_keyhive, make_protocol_with_shared_keyhive},
+    };
+
+    let n = env_usize("MEMBENCH_N", 100);
+    let k = env_usize("MEMBENCH_K", 5);
+    let rotations = env_usize("MEMBENCH_ROT", 5);
+    let iters = env_usize("MEMBENCH_ITERS", 10);
+    let edits = env_usize("MEMBENCH_EDITS", 5);
+    let serve = env_usize("MEMBENCH_SERVE", 500);
+    // Wire-build model for the serve phase: "off" (default) holds only the
+    // Arc-shared per-pair maps (a warm peer, whose found_ops diff is empty);
+    // "cold" also builds found_ops = the full event set per response (a peer
+    // that has nothing yet).
+    let wire = std::env::var("MEMBENCH_WIRE").unwrap_or_else(|_| "off".into());
+    const MB: f64 = 1024.0 * 1024.0;
+
+    let _profiler = dhat::Profiler::new_heap();
+    eprintln!(
+        "\nserving_membench: N={n} K={k} rotations={rotations} iters={iters} \
+         edits/iter={edits} serve={serve}"
+    );
+
+    futures::executor::block_on(async move {
+        // Build a dense server keyhive: N peer agents known (contact
+        // card + prekey rotations), N public docs each with K peer readers.
+        let server = make_keyhive().await;
+        let mut peers = Vec::with_capacity(n);
+        for _ in 0..n {
+            peers.push(make_keyhive().await);
+        }
+        for p in &peers {
+            let cc = p.contact_card().await.expect("contact_card");
+            server
+                .receive_contact_card(&cc)
+                .await
+                .expect("receive_contact_card");
+            for _ in 0..rotations {
+                let add = p.expand_prekeys().await.expect("expand_prekeys");
+                server
+                    .receive_prekey_op(&KeyOp::Add(add.clone()))
+                    .await
+                    .expect("receive add");
+                let rot = p
+                    .rotate_prekey(add.payload().share_key)
+                    .await
+                    .expect("rotate_prekey");
+                server
+                    .receive_prekey_op(&KeyOp::Rotate(rot))
+                    .await
+                    .expect("receive rotate");
+            }
+        }
+        let mut docs = Vec::with_capacity(n);
+        for i in 0..n {
+            let fill = ((i % 251) + 1) as u8;
+            let doc = server
+                .generate_doc(vec![], nonempty![[fill; 32]])
+                .await
+                .expect("generate_doc");
+            let doc_id = doc.lock().await.doc_id();
+            let membered = Membered::Document(doc_id, doc.clone());
+            let public_agent: Agent<_, _, _, _> = Public.individual().into();
+            server
+                .add_member(public_agent, &membered, Access::Read, &[])
+                .await
+                .expect("add public");
+            for step in 1..=k.min(n.saturating_sub(1)) {
+                let j = (i + step) % n;
+                if j == i {
+                    continue;
+                }
+                let id: Identifier = peers[j].id().into();
+                if let Some(agent) = server.get_agent(id).await {
+                    server
+                        .add_member(agent, &membered, Access::Read, &[])
+                        .await
+                        .expect("add member");
+                }
+            }
+            docs.push(doc);
+        }
+
+        // Server's own peer id (the `local` side of every served pair),
+        // captured before the keyhive is moved into the protocol.
+        let local = keyhive_peer_id(&server);
+        let peer_ids: Vec<KeyhivePeerId> = peers.iter().map(keyhive_peer_id).collect();
+        let (proto, shared, _storage) = make_protocol_with_shared_keyhive(server).await;
+
+        // ---- Phase 1: REFRESH (real cache.refresh) over a mutating graph.
+        let mut cache = PeriodicEventCache::new();
+        let base = dhat::HeapStats::get();
+        eprintln!(
+            "\n[build] retained={:.1} MB  peak={:.1} MB  (docs={})",
+            base.curr_bytes as f64 / MB,
+            base.max_bytes as f64 / MB,
+            docs.len()
+        );
+        eprintln!("[refresh]  iter | rebuilt | retained MB | peak MB");
+        for it in 0..iters {
+            for e in 0..edits {
+                if docs.is_empty() {
+                    break;
+                }
+                let idx = (it * edits + e) % docs.len();
+                let doc = docs[idx].clone();
+                let _op = shared.lock().await.force_pcs_update(doc).await;
+            }
+            let rebuilt = cache.refresh(&proto).await.expect("refresh");
+            let s = dhat::HeapStats::get();
+            eprintln!(
+                "{it:9} | {:7} | {:11.1} | {:7.1}",
+                if rebuilt { "yes" } else { "skip" },
+                s.curr_bytes as f64 / MB,
+                s.max_bytes as f64 / MB,
+            );
+        }
+        let after_refresh = dhat::HeapStats::get();
+        eprintln!(
+            "[refresh] retained={:.1} MB  peak={:.1} MB  | cache: {} agents, \
+             {} public hashes, {} event_data entries",
+            after_refresh.curr_bytes as f64 / MB,
+            after_refresh.max_bytes as f64 / MB,
+            cache.agent_count(),
+            cache.public_hashes().len(),
+            cache.event_data.len(),
+        );
+
+        // ---- Phase 2: SERVE. Hold `serve` concurrent responses. Modes:
+        //   "off":       hold only the Arc-shared per-pair maps. A warm peer
+        //                 whose found_ops diff is empty.
+        //   "cold":      also hold found_ops = the full event set as
+        //                 `Vec<SharedBytes>`, which clones the cache `Arc`s
+        //                 rather than copying bytes.
+        //   "serialize": build and hold one serialized `SyncResponse` frame
+        //                 per peer, dropping the maps and found_ops first (as
+        //                 the handler does once the frame is queued for send).
+        //                 Models an outbound send queue of full responses.
+        if serve > 0 {
+            let cold = wire == "cold";
+            let serialize = wire == "serialize";
+            let pre = dhat::HeapStats::get();
+            let mut inflight: Vec<(Arc<AgentHashMap>, Vec<SharedBytes>)> =
+                Vec::with_capacity(if serialize { 0 } else { serve });
+            let mut frames: Vec<alloc::vec::Vec<u8>> =
+                Vec::with_capacity(if serialize { serve } else { 0 });
+            let mut per_response = 0;
+            for m in 0..serve {
+                let peer = peer_ids[m % peer_ids.len()].clone();
+                let response = cache.events_for_peer_pair(&local, &peer);
+                per_response = response.len();
+                if serialize {
+                    let found_ops: Vec<SharedBytes> =
+                        response.values().map(|(eb, _)| eb.dupe()).collect();
+                    let msg = Message::SyncResponse {
+                        sender_id: local.clone(),
+                        target_id: peer,
+                        requested: alloc::vec::Vec::new(),
+                        found: found_ops,
+                        sync_responder_total: 0,
+                        sync_requester_total: 0,
+                    };
+                    let mut buf = alloc::vec::Vec::new();
+                    ciborium::into_writer(&msg, &mut buf).expect("encode SyncResponse");
+                    frames.push(buf);
+                    // response and found_ops drop here, as in the handler.
+                } else {
+                    let found_ops: Vec<SharedBytes> = if cold {
+                        response.values().map(|(eb, _)| eb.dupe()).collect()
+                    } else {
+                        Vec::new()
+                    };
+                    inflight.push((response, found_ops));
+                }
+            }
+            let s = dhat::HeapStats::get();
+            eprintln!(
+                "\n[serve] {serve} concurrent responses, ~{per_response} events each, \
+                 wire={wire}\n  \
+                 before={:.1} MB  live={:.1} MB  peak={:.1} MB  (Δlive {:+.1} MB)",
+                pre.curr_bytes as f64 / MB,
+                s.curr_bytes as f64 / MB,
+                s.max_bytes as f64 / MB,
+                (s.curr_bytes as i64 - pre.curr_bytes as i64) as f64 / MB,
+            );
+            core::hint::black_box((&inflight, &frames));
+        }
+    });
+}
+
+/// In-crate heap membench isolating the **keyhive-on BASELINE**: the
+/// retained footprint of the server's keyhive op-graph after ingesting N
+/// peers (contact cards + prekey rotations) and N public docs (public + K
+/// readers), with NO cache and NO serving. It reports retained heap at each
+/// build stage so the baseline can be attributed to ingest vs prekeys vs
+/// docs vs membership and scaled vs N, then drops the client keyhives (which
+/// do not exist on the real server) before the final reading so the number
+/// is the server op-graph alone. On `_profiler` drop dhat writes
+/// `dhat-heap.json` (cwd) whose retained set is the server op-graph. Load it in
+/// the dhat viewer to see which `keyhive_core` structures dominate.
+///
+/// Params (env, defaults): MEMBENCH_N (100), MEMBENCH_K (5),
+/// MEMBENCH_ROT (5). Run:
+///   cargo test -p subduction_keyhive --release --features test-utils,dhat-heap \
+///       keyhive_baseline_membench -- --nocapture --exact
+#[test]
+fn keyhive_baseline_membench() {
+    use alloc::vec::Vec;
+
+    use keyhive_core::{
+        access::Access,
+        principal::{
+            agent::Agent, identifier::Identifier, individual::op::KeyOp, membered::Membered,
+            public::Public,
+        },
+    };
+    use nonempty::nonempty;
+
+    use crate::test_utils::{keyhive_peer_id, make_keyhive};
+
+    let n = env_usize("MEMBENCH_N", 100);
+    let k = env_usize("MEMBENCH_K", 5);
+    let rotations = env_usize("MEMBENCH_ROT", 5);
+    const MB: f64 = 1024.0 * 1024.0;
+
+    let _profiler = dhat::Profiler::new_heap();
+    eprintln!("\nkeyhive_baseline_membench: N={n} K={k} rotations={rotations}");
+
+    futures::executor::block_on(async move {
+        macro_rules! stage {
+            ($label:expr) => {{
+                let s = dhat::HeapStats::get();
+                eprintln!(
+                    "[{:<26}] retained={:8.1} MB  peak={:8.1} MB",
+                    $label,
+                    s.curr_bytes as f64 / MB,
+                    s.max_bytes as f64 / MB,
+                );
+            }};
+        }
+
+        let server = make_keyhive().await;
+        stage!("empty server");
+
+        // N client keyhives, used only to mint events the server ingests.
+        let mut peers = Vec::with_capacity(n);
+        for _ in 0..n {
+            peers.push(make_keyhive().await);
+        }
+        stage!("N client keyhives");
+
+        for p in &peers {
+            let cc = p.contact_card().await.expect("contact_card");
+            server
+                .receive_contact_card(&cc)
+                .await
+                .expect("receive_contact_card");
+        }
+        stage!("+ contact cards");
+
+        for p in &peers {
+            for _ in 0..rotations {
+                let add = p.expand_prekeys().await.expect("expand_prekeys");
+                server
+                    .receive_prekey_op(&KeyOp::Add(add.clone()))
+                    .await
+                    .expect("receive add");
+                let rot = p
+                    .rotate_prekey(add.payload().share_key)
+                    .await
+                    .expect("rotate_prekey");
+                server
+                    .receive_prekey_op(&KeyOp::Rotate(rot))
+                    .await
+                    .expect("receive rotate");
+            }
+        }
+        stage!("+ prekey rotations");
+
+        let mut docs = Vec::with_capacity(n);
+        for i in 0..n {
+            let fill = ((i % 251) + 1) as u8;
+            let doc = server
+                .generate_doc(vec![], nonempty![[fill; 32]])
+                .await
+                .expect("generate_doc");
+            let doc_id = doc.lock().await.doc_id();
+            let membered = Membered::Document(doc_id, doc.clone());
+            let public_agent: Agent<_, _, _, _> = Public.individual().into();
+            server
+                .add_member(public_agent, &membered, Access::Read, &[])
+                .await
+                .expect("add public");
+            docs.push(membered);
+        }
+        stage!("+ N public docs");
+
+        for (i, membered) in docs.iter().enumerate() {
+            for step in 1..=k.min(n.saturating_sub(1)) {
+                let j = (i + step) % n;
+                if j == i {
+                    continue;
+                }
+                let id: Identifier = peers[j].id().into();
+                if let Some(agent) = server.get_agent(id).await {
+                    server
+                        .add_member(agent, membered, Access::Read, &[])
+                        .await
+                        .expect("add member");
+                }
+            }
+        }
+        stage!("+ K readers/doc");
+
+        // The real server never holds the client keyhives; drop them so the
+        // final reading is the server op-graph alone.
+        let peer_ids: Vec<KeyhivePeerId> = peers.iter().map(keyhive_peer_id).collect();
+        drop(peers);
+        stage!("SERVER BASELINE (peers dropped)");
+
+        // Keep the server op-graph (and only it) alive for the dhat dump.
+        core::hint::black_box((&server, &docs, &peer_ids));
+    });
+}

--- a/subduction_keyhive/src/lib.rs
+++ b/subduction_keyhive/src/lib.rs
@@ -6,6 +6,13 @@
 
 extern crate alloc;
 
+// Heap-profiling global allocator for the in-crate periodic-cache membench
+// (`cache::tests::serving_membench`). Only installed under the `dhat-heap`
+// feature so normal builds and `cargo test` are unaffected.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static DHAT_ALLOC: dhat::Alloc = dhat::Alloc;
+
 mod collections;
 
 pub mod connection;

--- a/subduction_keyhive/src/message.rs
+++ b/subduction_keyhive/src/message.rs
@@ -1,6 +1,6 @@
 //! Message types for the keyhive sync protocol.
 
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
 use crate::peer_id::KeyhivePeerId;
 
@@ -15,8 +15,19 @@ pub type EventBytes = Vec<u8>;
 /// [`EventBytes`] wrapped as a CBOR byte string (major type 2).
 pub type CborBytes = Vec<u8>;
 
+/// Reference-counted serialized-event bytes.
+///
+/// The periodic cache stores one copy of each event's bytes and hands every
+/// peer-pair response an `Arc` clone rather than copying the bytes, so
+/// concurrent responses share a single copy.
+pub type SharedBytes = Arc<[u8]>;
+
+/// A cached event's two serialized forms shared via `Arc`: the bincode
+/// [`EventBytes`] and its CBOR byte-string framing ([`CborBytes`]).
+pub type EventPair = (SharedBytes, SharedBytes);
+
 /// Hash-keyed map of serialized events for a peer or peer pair.
-pub type AgentHashMap = BTreeMap<EventHash, (EventBytes, CborBytes)>;
+pub type AgentHashMap = BTreeMap<EventHash, EventPair>;
 
 /// The keyhive sync protocol messages.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,7 +87,7 @@ pub enum Message {
         ///
         /// These are operations we have that the initiator is missing.
         #[cfg_attr(feature = "serde", serde(with = "crate::serde_compat::vec_byte_buf"))]
-        found: Vec<EventBytes>,
+        found: Vec<SharedBytes>,
 
         /// Total operation count for the responder (intersection + pending).
         ///
@@ -102,7 +113,7 @@ pub enum Message {
 
         /// The serialized operations being sent.
         #[cfg_attr(feature = "serde", serde(with = "crate::serde_compat::vec_byte_buf"))]
-        ops: Vec<EventBytes>,
+        ops: Vec<SharedBytes>,
 
         /// Total operation count for the responder (from the sync response).
         ///
@@ -301,7 +312,7 @@ mod wire_format_tests {
             sender_id: peer(1),
             target_id: peer(2),
             requested: vec![[3u8; 32]],
-            found: vec![vec![10, 11, 12], vec![20, 21]],
+            found: vec![vec![10, 11, 12].into(), vec![20, 21].into()],
             sync_responder_total: 5,
             sync_requester_total: 4,
         };
@@ -320,7 +331,7 @@ mod wire_format_tests {
         let msg = Message::SyncOps {
             sender_id: peer(1),
             target_id: peer(2),
-            ops: vec![vec![1, 2, 3], vec![4, 5]],
+            ops: vec![vec![1, 2, 3].into(), vec![4, 5].into()],
             sync_responder_total: 1,
             sync_requester_total: 1,
         };
@@ -339,6 +350,48 @@ mod wire_format_tests {
             target_id: peer(2),
             found: vec![[7u8; 32], [9u8; 32]],
             pending: vec![[11u8; 32]],
+        };
+        let mut buf = Vec::new();
+        ciborium::into_writer(&original, &mut buf).expect("encode");
+        let recovered: Message = ciborium::de::from_reader(buf.as_slice()).expect("decode");
+        assert_eq!(original, recovered);
+    }
+
+    /// `SyncResponse.found` byte payloads must survive a CBOR round-trip with
+    /// their content intact.
+    #[test]
+    fn sync_response_round_trips_found_bytes() {
+        let original = Message::SyncResponse {
+            sender_id: peer(1),
+            target_id: peer(2),
+            requested: vec![[7u8; 32]],
+            found: vec![
+                vec![0xDE, 0xAD, 0xBE, 0xEF].into(),
+                Vec::new().into(),
+                vec![1, 2, 3, 4, 5].into(),
+            ],
+            sync_responder_total: 9,
+            sync_requester_total: 4,
+        };
+        let mut buf = Vec::new();
+        ciborium::into_writer(&original, &mut buf).expect("encode");
+        let recovered: Message = ciborium::de::from_reader(buf.as_slice()).expect("decode");
+        assert_eq!(original, recovered);
+    }
+
+    /// `SyncOps.ops` byte payloads must survive a CBOR round-trip intact.
+    #[test]
+    fn sync_ops_round_trips_op_bytes() {
+        let original = Message::SyncOps {
+            sender_id: peer(1),
+            target_id: peer(2),
+            ops: vec![
+                vec![1, 2, 3].into(),
+                vec![4, 5, 6, 7].into(),
+                Vec::new().into(),
+            ],
+            sync_responder_total: 2,
+            sync_requester_total: 3,
         };
         let mut buf = Vec::new();
         ciborium::into_writer(&original, &mut buf).expect("encode");

--- a/subduction_keyhive/src/message.rs
+++ b/subduction_keyhive/src/message.rs
@@ -12,22 +12,13 @@ pub type EventHash = [u8; 32];
 /// Bincode-serialized `StaticEvent<T>`.
 pub type EventBytes = Vec<u8>;
 
-/// [`EventBytes`] wrapped as a CBOR byte string (major type 2).
-pub type CborBytes = Vec<u8>;
-
-/// Reference-counted serialized-event bytes.
-///
-/// The periodic cache stores one copy of each event's bytes and hands every
-/// peer-pair response an `Arc` clone rather than copying the bytes, so
-/// concurrent responses share a single copy.
-pub type SharedBytes = Arc<[u8]>;
-
-/// A cached event's two serialized forms shared via `Arc`: the bincode
-/// [`EventBytes`] and its CBOR byte-string framing ([`CborBytes`]).
-pub type EventPair = (SharedBytes, SharedBytes);
-
 /// Hash-keyed map of serialized events for a peer or peer pair.
-pub type AgentHashMap = BTreeMap<EventHash, EventPair>;
+///
+/// Values are `Arc`-shared bincode event bytes: the periodic cache stores one
+/// copy of each event and hands every peer-pair response an `Arc` clone, so
+/// cloning a whole response is a set of refcount bumps, not a byte-for-byte
+/// copy of every event.
+pub type AgentHashMap = BTreeMap<EventHash, Arc<[u8]>>;
 
 /// The keyhive sync protocol messages.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -87,7 +78,7 @@ pub enum Message {
         ///
         /// These are operations we have that the initiator is missing.
         #[cfg_attr(feature = "serde", serde(with = "crate::serde_compat::vec_byte_buf"))]
-        found: Vec<SharedBytes>,
+        found: Vec<Arc<[u8]>>,
 
         /// Total operation count for the responder (intersection + pending).
         ///
@@ -113,7 +104,7 @@ pub enum Message {
 
         /// The serialized operations being sent.
         #[cfg_attr(feature = "serde", serde(with = "crate::serde_compat::vec_byte_buf"))]
-        ops: Vec<SharedBytes>,
+        ops: Vec<Arc<[u8]>>,
 
         /// Total operation count for the responder (from the sync response).
         ///

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -60,7 +60,7 @@ use crate::{
     collections::{Map, Set},
     connection::KeyhiveConnection,
     error::{ProtocolError, SigningError, StorageError, VerificationError},
-    message::{AgentHashMap, CborBytes, EventBytes, EventHash, Message},
+    message::{AgentHashMap, EventHash, EventPair, Message, SharedBytes},
     peer_id::KeyhivePeerId,
     signed_message::SignedMessage,
     storage::{KeyhiveStorage, StorageHash},
@@ -227,13 +227,14 @@ where
 
     /// Serialized events reachable by `peer_id`.
     ///
+    /// Values are [`Arc`]-shared.
+    ///
     /// # Errors
     /// Returns [`ProtocolError`] on serialization failure.
     pub async fn get_events_for_agent(
         &self,
         peer_id: &KeyhivePeerId,
-    ) -> Result<Option<BTreeMap<EventHash, (EventBytes, CborBytes)>>, ProtocolError<Conn::SendError>>
-    {
+    ) -> Result<Option<AgentHashMap>, ProtocolError<Conn::SendError>> {
         let id = peer_id
             .to_identifier()
             .map_err(ProtocolError::InvalidIdentifier)?;
@@ -246,24 +247,6 @@ where
         };
 
         collect_serialized_events(events).map(Some)
-    }
-
-    /// Serialized events reachable by the public agent.
-    ///
-    /// # Errors
-    /// Returns [`ProtocolError`] on serialization failure.
-    pub async fn get_events_for_public_agent(
-        &self,
-    ) -> Result<BTreeMap<EventHash, (EventBytes, CborBytes)>, ProtocolError<Conn::SendError>> {
-        let events = {
-            let keyhive = self.keyhive.lock().await;
-            let Some(agent) = keyhive.get_agent(Public.id()).await else {
-                return Ok(BTreeMap::new());
-            };
-            sync_events_for_agent(&keyhive, &agent).await
-        };
-
-        collect_serialized_events(events)
     }
 
     /// Bulk snapshot of every agent's reachable events, deduplicated.
@@ -287,7 +270,7 @@ where
             (all_membership, all_prekey, all_cgka)
         };
 
-        let mut event_data: BTreeMap<EventHash, (EventBytes, CborBytes)> = BTreeMap::new();
+        let mut event_data: BTreeMap<EventHash, EventPair> = BTreeMap::new();
 
         // Phase 1: serialize every distinct op once, skipping hashes
         // the caller already has cached.
@@ -426,7 +409,7 @@ where
             let cached = self.cached_events_for_pair_with_peer(target_id).await;
             let computed;
             let pair = if let Some(ref c) = cached {
-                Some(c)
+                Some(&**c)
             } else {
                 match self.get_events_for_peer_pair(target_id).await {
                     Ok(p) => {
@@ -573,11 +556,11 @@ where
 
         match &message {
             Message::SyncRequest { .. } => {
-                self.handle_sync_request(message, cached_sender_pair.as_ref())
+                self.handle_sync_request(message, cached_sender_pair.as_deref())
                     .await
             }
             Message::SyncResponse { .. } => {
-                self.handle_sync_response(message, cached_sender_pair.as_ref())
+                self.handle_sync_response(message, cached_sender_pair.as_deref())
                     .await
             }
             Message::SyncOps { .. } => self.handle_sync_ops(message).await,
@@ -671,21 +654,20 @@ where
         // Build sets for comparison.
         let peer_found_set: Set<EventHash> = peer_found.iter().copied().collect();
         let peer_pending_set: Set<EventHash> = peer_pending.iter().copied().collect();
-        let local_set: Set<EventHash> = local_events.keys().copied().collect();
         let our_pending_set: Set<EventHash> = our_pending_hashes.iter().copied().collect();
 
         // Ops to send = local - (peer_found U peer_pending)
-        let mut found_ops: Vec<EventBytes> = Vec::new();
+        let mut found_ops: Vec<SharedBytes> = Vec::new();
         for (h, (event_bytes, _)) in local_events {
             if !peer_found_set.contains(h) && !peer_pending_set.contains(h) {
-                found_ops.push(event_bytes.clone());
+                found_ops.push(event_bytes.dupe());
             }
         }
 
         // Ops to request = peer_found - (local U our_pending)
         let requested: Vec<EventHash> = peer_found
             .into_iter()
-            .filter(|h| !local_set.contains(h) && !our_pending_set.contains(h))
+            .filter(|h| !local_events.contains_key(h) && !our_pending_set.contains(h))
             .collect();
 
         tracing::debug!(
@@ -1030,7 +1012,7 @@ where
         sender_id: &KeyhivePeerId,
         requested: &[EventHash],
         cached_pair: Option<&AgentHashMap>,
-    ) -> Result<Vec<EventBytes>, ProtocolError<Conn::SendError>> {
+    ) -> Result<Vec<SharedBytes>, ProtocolError<Conn::SendError>> {
         let computed;
         let pair = if let Some(c) = cached_pair {
             c
@@ -1045,7 +1027,7 @@ where
         let mut result = Vec::with_capacity(requested.len().min(pair.len()));
         for h in requested {
             if let Some((bytes, _)) = pair.get(h) {
-                result.push(bytes.clone());
+                result.push(bytes.dupe());
             }
         }
         Ok(result)
@@ -1055,12 +1037,13 @@ where
     ///
     /// If some events remain pending (missing dependencies), attempts recovery
     /// by loading from storage and retrying.
-    async fn ingest_events(
+    async fn ingest_events<B: AsRef<[u8]>>(
         &self,
-        event_bytes_list: &[EventBytes],
+        event_bytes_list: &[B],
     ) -> Result<(), ProtocolError<Conn::SendError>> {
         let mut events: Vec<StaticEvent<CRef>> = Vec::with_capacity(event_bytes_list.len());
-        for (idx, bytes) in event_bytes_list.iter().enumerate() {
+        for (idx, item) in event_bytes_list.iter().enumerate() {
+            let bytes = item.as_ref();
             match bincode_deserialize::<StaticEvent<CRef>>(bytes) {
                 Ok(ev) => events.push(ev),
                 Err(e) => {
@@ -1122,7 +1105,8 @@ where
         } else {
             for event_bytes in event_bytes_list {
                 if let Err(e) =
-                    storage_ops::save_event_bytes(&self.storage, event_bytes.clone()).await
+                    storage_ops::save_event_bytes(&self.storage, event_bytes.as_ref().to_vec())
+                        .await
                 {
                     tracing::warn!(error = %e, "failed to persist event to storage");
                 }
@@ -1133,9 +1117,9 @@ where
     }
 
     /// Attempt to recover by ingesting from storage and retrying.
-    async fn try_storage_recovery(
+    async fn try_storage_recovery<B: AsRef<[u8]>>(
         &self,
-        event_bytes_list: &[EventBytes],
+        event_bytes_list: &[B],
     ) -> Result<(), StorageError> {
         {
             let keyhive = self.keyhive.lock().await;
@@ -1144,7 +1128,7 @@ where
 
         let events: Vec<StaticEvent<CRef>> = event_bytes_list
             .iter()
-            .filter_map(|bytes| match bincode_deserialize(bytes) {
+            .filter_map(|bytes| match bincode_deserialize(bytes.as_ref()) {
                 Ok(ev) => Some(ev),
                 Err(e) => {
                     tracing::warn!(error = %e, "storage recovery: failed to deserialize event");
@@ -1222,7 +1206,10 @@ where
     }
 
     /// Look up cached events for us paired with the provided peer
-    async fn cached_events_for_pair_with_peer(&self, peer: &KeyhivePeerId) -> Option<AgentHashMap> {
+    async fn cached_events_for_pair_with_peer(
+        &self,
+        peer: &KeyhivePeerId,
+    ) -> Option<Arc<AgentHashMap>> {
         let cache = self.cache.lock().await;
         let local = self.peer_id();
         let map = cache.events_for_peer_pair(&local, peer);
@@ -1311,7 +1298,7 @@ where
 ///
 /// Hashes present in `skip_serialization` are recorded but not serialized.
 fn hash_and_insert_events<Async, Signer, CRef, Listener, E>(
-    event_data: &mut BTreeMap<EventHash, (EventBytes, CborBytes)>,
+    event_data: &mut BTreeMap<EventHash, EventPair>,
     events: impl Iterator<Item = Event<Async, Signer, CRef, Listener>>,
     skip_serialization: &BTreeSet<EventHash>,
 ) -> Result<Vec<EventHash>, ProtocolError<E>>
@@ -1340,24 +1327,27 @@ where
 /// Serialize a map of digested events into a hash-keyed byte map.
 fn collect_serialized_events<CRef: ContentRef, E: core::error::Error + 'static>(
     events: Map<Digest<StaticEvent<CRef>>, StaticEvent<CRef>>,
-) -> Result<BTreeMap<EventHash, (EventBytes, CborBytes)>, ProtocolError<E>> {
-    let mut out = BTreeMap::new();
+) -> Result<AgentHashMap, ProtocolError<E>> {
+    let mut out = AgentHashMap::new();
     for (digest, event) in events {
         let h = digest_to_bytes(&digest);
-        let (event_bytes, cbor_bytes) = serialize_event_pair(&event)?;
-        out.insert(h, (event_bytes, cbor_bytes));
+        out.insert(h, serialize_event_pair(&event)?);
     }
     Ok(out)
 }
 
 /// Serialize a `StaticEvent` to bincode bytes and a CBOR byte-string wrapper.
+///
+/// Both forms are `Arc`-shared (an [`EventPair`]) so the periodic cache and
+/// every served response reference one copy instead of each deep-copying the
+/// bytes.
 fn serialize_event_pair<CRef: ContentRef, E: core::error::Error + 'static>(
     event: &StaticEvent<CRef>,
-) -> Result<(EventBytes, CborBytes), ProtocolError<E>> {
+) -> Result<EventPair, ProtocolError<E>> {
     let bytes =
         bincode_serialize(event).map_err(|e| ProtocolError::Serialization(e.to_string()))?;
     let cbor = wrap_as_cbor_byte_string(&bytes);
-    Ok((bytes, cbor))
+    Ok((Arc::from(bytes), Arc::from(cbor)))
 }
 
 /// Collect hashes reachable from `agent_id` through `index` into `hash_set`.
@@ -1448,6 +1438,7 @@ const fn digest_to_bytes<U: serde::Serialize>(digest: &Digest<U>) -> [u8; 32] {
 mod tests {
     use super::*;
     use crate::{
+        message::EventBytes,
         storage::MemoryKeyhiveStorage,
         test_utils::{
             SimpleKeyhive, TestProtocol, TwoPeerHarness, create_channel_pair,
@@ -1980,7 +1971,7 @@ mod tests {
             .await
             .unwrap()
             .expect("bob should resolve to an agent");
-        let event_bytes: Vec<EventBytes> = pair.values().map(|(b, _)| b.clone()).collect();
+        let event_bytes: Vec<SharedBytes> = pair.values().map(|(b, _)| b.dupe()).collect();
         assert!(
             event_bytes.len() > 2,
             "need >2 events to exceed threshold of 2 (got {})",
@@ -2030,7 +2021,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let event_bytes: Vec<EventBytes> = pair.values().map(|(b, _)| b.clone()).collect();
+        let event_bytes: Vec<SharedBytes> = pair.values().map(|(b, _)| b.dupe()).collect();
         assert!(!event_bytes.is_empty());
 
         protocol.ingest_events(&event_bytes).await.unwrap();
@@ -2104,7 +2095,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let dependent: Vec<EventBytes> = other_proto
+        let dependent: Vec<SharedBytes> = other_proto
             .get_events_for_agent(&other_id)
             .await
             .unwrap()
@@ -2196,7 +2187,10 @@ mod tests {
         let synthetic_cbor = wrap_as_cbor_byte_string(&synthetic_bytes);
 
         let mut cached_pair = AgentHashMap::new();
-        cached_pair.insert(synthetic_hash, (synthetic_bytes.clone(), synthetic_cbor));
+        cached_pair.insert(
+            synthetic_hash,
+            (synthetic_bytes.clone().into(), synthetic_cbor.into()),
+        );
 
         // SyncResponse from Bob asking Alice for the synthetic hash.
         // Bob's `requested` always lists hashes Alice advertised, so
@@ -2240,7 +2234,8 @@ mod tests {
             "alice should have served exactly one op (the synthetic one)"
         );
         assert_eq!(
-            ops[0], synthetic_bytes,
+            ops[0].as_ref(),
+            synthetic_bytes.as_slice(),
             "served bytes should match the cached pair entry, \
              not anything from a live keyhive walk"
         );

--- a/subduction_keyhive/src/protocol.rs
+++ b/subduction_keyhive/src/protocol.rs
@@ -60,7 +60,7 @@ use crate::{
     collections::{Map, Set},
     connection::KeyhiveConnection,
     error::{ProtocolError, SigningError, StorageError, VerificationError},
-    message::{AgentHashMap, EventHash, EventPair, Message, SharedBytes},
+    message::{AgentHashMap, EventHash, Message},
     peer_id::KeyhivePeerId,
     signed_message::SignedMessage,
     storage::{KeyhiveStorage, StorageHash},
@@ -270,7 +270,7 @@ where
             (all_membership, all_prekey, all_cgka)
         };
 
-        let mut event_data: BTreeMap<EventHash, EventPair> = BTreeMap::new();
+        let mut event_data: BTreeMap<EventHash, Arc<[u8]>> = BTreeMap::new();
 
         // Phase 1: serialize every distinct op once, skipping hashes
         // the caller already has cached.
@@ -290,7 +290,7 @@ where
                 {
                     let event: Event<Async, Signer, CRef, Listener> = op.clone().into();
                     let static_event = StaticEvent::from(event);
-                    e.insert(serialize_event_pair(&static_event)?);
+                    e.insert(serialize_event(&static_event)?);
                 }
             }
             membership_source_hashes.insert(*source_id, hashes);
@@ -408,8 +408,8 @@ where
 
             let cached = self.cached_events_for_pair_with_peer(target_id).await;
             let computed;
-            let pair = if let Some(ref c) = cached {
-                Some(&**c)
+            let pair = if let Some(c) = cached.as_deref() {
+                Some(c)
             } else {
                 match self.get_events_for_peer_pair(target_id).await {
                     Ok(p) => {
@@ -657,8 +657,8 @@ where
         let our_pending_set: Set<EventHash> = our_pending_hashes.iter().copied().collect();
 
         // Ops to send = local - (peer_found U peer_pending)
-        let mut found_ops: Vec<SharedBytes> = Vec::new();
-        for (h, (event_bytes, _)) in local_events {
+        let mut found_ops: Vec<Arc<[u8]>> = Vec::new();
+        for (h, event_bytes) in local_events {
             if !peer_found_set.contains(h) && !peer_pending_set.contains(h) {
                 found_ops.push(event_bytes.dupe());
             }
@@ -976,7 +976,7 @@ where
         let mut result = AgentHashMap::new();
         for (digest, event) in public_events {
             let h = digest_to_bytes(&digest);
-            let pair = serialize_event_pair(&event)?;
+            let pair = serialize_event(&event)?;
             result.insert(h, pair);
         }
 
@@ -984,7 +984,7 @@ where
             if their_events.contains_key(&digest) {
                 let h = digest_to_bytes(&digest);
                 if let Entry::Vacant(entry) = result.entry(h) {
-                    let pair = serialize_event_pair(&event)?;
+                    let pair = serialize_event(&event)?;
                     entry.insert(pair);
                 }
             }
@@ -1012,7 +1012,7 @@ where
         sender_id: &KeyhivePeerId,
         requested: &[EventHash],
         cached_pair: Option<&AgentHashMap>,
-    ) -> Result<Vec<SharedBytes>, ProtocolError<Conn::SendError>> {
+    ) -> Result<Vec<Arc<[u8]>>, ProtocolError<Conn::SendError>> {
         let computed;
         let pair = if let Some(c) = cached_pair {
             c
@@ -1026,7 +1026,7 @@ where
 
         let mut result = Vec::with_capacity(requested.len().min(pair.len()));
         for h in requested {
-            if let Some((bytes, _)) = pair.get(h) {
+            if let Some(bytes) = pair.get(h) {
                 result.push(bytes.dupe());
             }
         }
@@ -1298,7 +1298,7 @@ where
 ///
 /// Hashes present in `skip_serialization` are recorded but not serialized.
 fn hash_and_insert_events<Async, Signer, CRef, Listener, E>(
-    event_data: &mut BTreeMap<EventHash, EventPair>,
+    event_data: &mut BTreeMap<EventHash, Arc<[u8]>>,
     events: impl Iterator<Item = Event<Async, Signer, CRef, Listener>>,
     skip_serialization: &BTreeSet<EventHash>,
 ) -> Result<Vec<EventHash>, ProtocolError<E>>
@@ -1318,7 +1318,7 @@ where
             && let Entry::Vacant(e) = event_data.entry(h)
         {
             let static_event = StaticEvent::from(event);
-            e.insert(serialize_event_pair(&static_event)?);
+            e.insert(serialize_event(&static_event)?);
         }
     }
     Ok(hashes)
@@ -1331,23 +1331,21 @@ fn collect_serialized_events<CRef: ContentRef, E: core::error::Error + 'static>(
     let mut out = AgentHashMap::new();
     for (digest, event) in events {
         let h = digest_to_bytes(&digest);
-        out.insert(h, serialize_event_pair(&event)?);
+        out.insert(h, serialize_event(&event)?);
     }
     Ok(out)
 }
 
-/// Serialize a `StaticEvent` to bincode bytes and a CBOR byte-string wrapper.
+/// Serialize a `StaticEvent` to bincode bytes, `Arc`-shared.
 ///
-/// Both forms are `Arc`-shared (an [`EventPair`]) so the periodic cache and
-/// every served response reference one copy instead of each deep-copying the
-/// bytes.
-fn serialize_event_pair<CRef: ContentRef, E: core::error::Error + 'static>(
+/// The bytes are `Arc`-shared so the periodic cache and every served response
+/// reference one copy instead of each deep-copying the bytes.
+fn serialize_event<CRef: ContentRef, E: core::error::Error + 'static>(
     event: &StaticEvent<CRef>,
-) -> Result<EventPair, ProtocolError<E>> {
+) -> Result<Arc<[u8]>, ProtocolError<E>> {
     let bytes =
         bincode_serialize(event).map_err(|e| ProtocolError::Serialization(e.to_string()))?;
-    let cbor = wrap_as_cbor_byte_string(&bytes);
-    Ok((Arc::from(bytes), Arc::from(cbor)))
+    Ok(Arc::from(bytes))
 }
 
 /// Collect hashes reachable from `agent_id` through `index` into `hash_set`.
@@ -1372,48 +1370,6 @@ fn cbor_serialize<V: serde::Serialize>(value: &V) -> Result<Vec<u8>, StorageErro
     ciborium::into_writer(value, &mut buf)
         .map_err(|e| StorageError::Serialization(e.to_string()))?;
     Ok(buf)
-}
-
-/// Wrap raw bytes in a CBOR byte-string (major type 2) header.
-///
-/// Lets the cache hand pre-encoded fragments straight to a hand-rolled
-/// wire path without re-running ciborium's array serializer.
-#[allow(clippy::cast_possible_truncation)] // match arms guarantee range
-fn wrap_as_cbor_byte_string(bytes: &[u8]) -> Vec<u8> {
-    let len = bytes.len();
-    let mut out = match len {
-        0..=23 => {
-            let mut v = Vec::with_capacity(1 + len);
-            v.push(0x40 | len as u8);
-            v
-        }
-        24..=255 => {
-            let mut v = Vec::with_capacity(2 + len);
-            v.push(0x58);
-            v.push(len as u8);
-            v
-        }
-        256..=65535 => {
-            let mut v = Vec::with_capacity(3 + len);
-            v.push(0x59);
-            v.extend_from_slice(&(len as u16).to_be_bytes());
-            v
-        }
-        65536..=4_294_967_295 => {
-            let mut v = Vec::with_capacity(5 + len);
-            v.push(0x5A);
-            v.extend_from_slice(&(len as u32).to_be_bytes());
-            v
-        }
-        _ => {
-            let mut v = Vec::with_capacity(9 + len);
-            v.push(0x5B);
-            v.extend_from_slice(&(len as u64).to_be_bytes());
-            v
-        }
-    };
-    out.extend_from_slice(bytes);
-    out
 }
 
 /// Deserialize a value from CBOR bytes.
@@ -1971,7 +1927,7 @@ mod tests {
             .await
             .unwrap()
             .expect("bob should resolve to an agent");
-        let event_bytes: Vec<SharedBytes> = pair.values().map(|(b, _)| b.dupe()).collect();
+        let event_bytes: Vec<Arc<[u8]>> = pair.values().map(Dupe::dupe).collect();
         assert!(
             event_bytes.len() > 2,
             "need >2 events to exceed threshold of 2 (got {})",
@@ -2021,7 +1977,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        let event_bytes: Vec<SharedBytes> = pair.values().map(|(b, _)| b.dupe()).collect();
+        let event_bytes: Vec<Arc<[u8]>> = pair.values().map(Dupe::dupe).collect();
         assert!(!event_bytes.is_empty());
 
         protocol.ingest_events(&event_bytes).await.unwrap();
@@ -2095,14 +2051,14 @@ mod tests {
             )
             .await
             .unwrap();
-        let dependent: Vec<SharedBytes> = other_proto
+        let dependent: Vec<Arc<[u8]>> = other_proto
             .get_events_for_agent(&other_id)
             .await
             .unwrap()
             .expect("other resolves to an agent")
             .into_iter()
             .filter(|(hash, _)| !before_add.contains(hash))
-            .map(|(_, (bytes, _))| bytes)
+            .map(|(_, bytes)| bytes)
             .collect();
         assert!(
             !dependent.is_empty(),
@@ -2184,13 +2140,9 @@ mod tests {
 
         let synthetic_hash: EventHash = [0xAB; 32];
         let synthetic_bytes: EventBytes = vec![0xDE, 0xAD, 0xBE, 0xEF];
-        let synthetic_cbor = wrap_as_cbor_byte_string(&synthetic_bytes);
 
         let mut cached_pair = AgentHashMap::new();
-        cached_pair.insert(
-            synthetic_hash,
-            (synthetic_bytes.clone().into(), synthetic_cbor.into()),
-        );
+        cached_pair.insert(synthetic_hash, synthetic_bytes.clone().into());
 
         // SyncResponse from Bob asking Alice for the synthetic hash.
         // Bob's `requested` always lists hashes Alice advertised, so
@@ -2946,21 +2898,10 @@ mod tests {
             "alice's agent should have membership/cgka ops after the group was created"
         );
 
-        // Event bytes round-trip via bincode (matching keyhive-wasm); the
-        // pre-encoded form wraps them in a CBOR byte-string header for the
-        // outer envelope.
-        for (event_bytes, cbor_bytes) in alice_hashes.values() {
+        // Event bytes round-trip via bincode (matching keyhive-wasm).
+        for event_bytes in alice_hashes.values() {
             bincode_deserialize::<StaticEvent<[u8; 32]>>(event_bytes)
                 .expect("event_bytes round-trips");
-            assert!(
-                cbor_bytes.len() > event_bytes.len(),
-                "cbor_bytes carries at least a 1-byte byte-string header"
-            );
-            // Major-type-2 (byte-string) marker check.
-            assert!(
-                cbor_bytes[0] & 0xE0 == 0x40,
-                "cbor_bytes[0] should be a CBOR byte-string major type"
-            );
         }
 
         // Symmetric: querying for a peer keyhive doesn't know about returns None.
@@ -3417,7 +3358,7 @@ mod tests {
         let mut events: alloc::collections::BTreeMap<[u8; 32], StaticEvent<[u8; 32]>> =
             alloc::collections::BTreeMap::new();
         for h in public_hashes {
-            if let Some((bytes, _)) = snapshot.event_data.get(h) {
+            if let Some(bytes) = snapshot.event_data.get(h) {
                 events.insert(*h, bincode_deserialize(bytes).unwrap());
             }
         }
@@ -3568,7 +3509,7 @@ mod tests {
         let mut events: alloc::collections::BTreeMap<[u8; 32], StaticEvent<[u8; 32]>> =
             alloc::collections::BTreeMap::new();
         for h in public_hashes {
-            if let Some((bytes, _)) = snapshot.event_data.get(h) {
+            if let Some(bytes) = snapshot.event_data.get(h) {
                 events.insert(*h, bincode_deserialize(bytes).unwrap());
             }
         }
@@ -3776,7 +3717,7 @@ mod tests {
         let mut events: alloc::collections::BTreeMap<[u8; 32], StaticEvent<[u8; 32]>> =
             alloc::collections::BTreeMap::new();
         for h in public_hashes {
-            if let Some((bytes, _)) = snapshot.event_data.get(h) {
+            if let Some(bytes) = snapshot.event_data.get(h) {
                 events.insert(*h, bincode_deserialize(bytes).unwrap());
             }
         }
@@ -3926,7 +3867,7 @@ mod tests {
         let mut events: alloc::collections::BTreeMap<[u8; 32], StaticEvent<[u8; 32]>> =
             alloc::collections::BTreeMap::new();
         for h in public_hashes {
-            if let Some((bytes, _)) = snapshot.event_data.get(h) {
+            if let Some(bytes) = snapshot.event_data.get(h) {
                 events.insert(*h, bincode_deserialize(bytes).unwrap());
             }
         }
@@ -3969,88 +3910,6 @@ mod tests {
             "expected at least one CgkaOperation in the public event set after \
              the add/revoke delegation chain, but found none"
         );
-    }
-
-    // ── wrap_as_cbor_byte_string boundary tests ──────────────────────────
-
-    /// Helper: decode a CBOR byte string using ciborium and return the inner bytes.
-    fn ciborium_decode_byte_string(cbor: &[u8]) -> Vec<u8> {
-        let value: ciborium::Value = ciborium::from_reader(cbor).expect("ciborium decode");
-        match value {
-            ciborium::Value::Bytes(b) => b,
-            other => panic!("expected CBOR Bytes, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn wrap_cbor_len_0() {
-        let input = vec![];
-        let cbor = wrap_as_cbor_byte_string(&input);
-        assert_eq!(cbor[0], 0x40, "len 0: initial byte should be 0x40");
-        assert_eq!(cbor.len(), 1);
-        assert_eq!(ciborium_decode_byte_string(&cbor), input);
-    }
-
-    #[test]
-    fn wrap_cbor_len_23() {
-        let input = vec![0xAB; 23];
-        let cbor = wrap_as_cbor_byte_string(&input);
-        assert_eq!(cbor[0], 0x40 | 23, "len 23: initial byte should be 0x57");
-        assert_eq!(cbor.len(), 1 + 23);
-        assert_eq!(ciborium_decode_byte_string(&cbor), input);
-    }
-
-    #[test]
-    fn wrap_cbor_len_24() {
-        let input = vec![0xCD; 24];
-        let cbor = wrap_as_cbor_byte_string(&input);
-        assert_eq!(cbor[0], 0x58, "len 24: initial byte should be 0x58");
-        assert_eq!(cbor[1], 24);
-        assert_eq!(cbor.len(), 2 + 24);
-        assert_eq!(ciborium_decode_byte_string(&cbor), input);
-    }
-
-    #[test]
-    fn wrap_cbor_len_255() {
-        let input = vec![0xEF; 255];
-        let cbor = wrap_as_cbor_byte_string(&input);
-        assert_eq!(cbor[0], 0x58, "len 255: initial byte should be 0x58");
-        assert_eq!(cbor[1], 255);
-        assert_eq!(cbor.len(), 2 + 255);
-        assert_eq!(ciborium_decode_byte_string(&cbor), input);
-    }
-
-    #[test]
-    fn wrap_cbor_len_256() {
-        let input = vec![0x11; 256];
-        let cbor = wrap_as_cbor_byte_string(&input);
-        assert_eq!(cbor[0], 0x59, "len 256: initial byte should be 0x59");
-        let encoded_len = u16::from_be_bytes([cbor[1], cbor[2]]);
-        assert_eq!(encoded_len, 256);
-        assert_eq!(cbor.len(), 3 + 256);
-        assert_eq!(ciborium_decode_byte_string(&cbor), input);
-    }
-
-    #[test]
-    fn wrap_cbor_len_65535() {
-        let input = vec![0x22; 65535];
-        let cbor = wrap_as_cbor_byte_string(&input);
-        assert_eq!(cbor[0], 0x59, "len 65535: initial byte should be 0x59");
-        let encoded_len = u16::from_be_bytes([cbor[1], cbor[2]]);
-        assert_eq!(encoded_len, 65535);
-        assert_eq!(cbor.len(), 3 + 65535);
-        assert_eq!(ciborium_decode_byte_string(&cbor), input);
-    }
-
-    #[test]
-    fn wrap_cbor_len_65536() {
-        let input = vec![0x33; 65536];
-        let cbor = wrap_as_cbor_byte_string(&input);
-        assert_eq!(cbor[0], 0x5A, "len 65536: initial byte should be 0x5A");
-        let encoded_len = u32::from_be_bytes([cbor[1], cbor[2], cbor[3], cbor[4]]);
-        assert_eq!(encoded_len, 65536);
-        assert_eq!(cbor.len(), 5 + 65536);
-        assert_eq!(ciborium_decode_byte_string(&cbor), input);
     }
 }
 

--- a/subduction_keyhive/src/serde_compat.rs
+++ b/subduction_keyhive/src/serde_compat.rs
@@ -31,15 +31,22 @@ pub(crate) mod vec_byte_array_32 {
     }
 }
 
-/// `Vec<Vec<u8>>` with each element as a CBOR byte string.
+/// `Vec<SharedBytes>` with each element as a CBOR byte string.
+///
+/// Elements are the `Arc`-shared [`SharedBytes`](crate::message::SharedBytes) so
+/// a response can share one copy of each event's bytes across concurrent uses.
+/// Each element encodes as a plain CBOR byte string (major type 2), the same
+/// wire form as a `Vec<u8>` element.
 pub(crate) mod vec_byte_buf {
     use alloc::vec::Vec;
 
     use serde::{Deserialize, Deserializer, Serializer, ser::SerializeSeq};
     use serde_bytes::ByteBuf;
 
+    use crate::message::SharedBytes;
+
     pub(crate) fn serialize<S: Serializer>(
-        v: &[Vec<u8>],
+        v: &[SharedBytes],
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(v.len()))?;
@@ -49,8 +56,13 @@ pub(crate) mod vec_byte_buf {
         seq.end()
     }
 
-    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vec<Vec<u8>>, D::Error> {
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        de: D,
+    ) -> Result<Vec<SharedBytes>, D::Error> {
         let wrapped: Vec<ByteBuf> = Vec::deserialize(de)?;
-        Ok(wrapped.into_iter().map(ByteBuf::into_vec).collect())
+        Ok(wrapped
+            .into_iter()
+            .map(|b| SharedBytes::from(b.into_vec()))
+            .collect())
     }
 }

--- a/subduction_keyhive/src/serde_compat.rs
+++ b/subduction_keyhive/src/serde_compat.rs
@@ -31,22 +31,19 @@ pub(crate) mod vec_byte_array_32 {
     }
 }
 
-/// `Vec<SharedBytes>` with each element as a CBOR byte string.
+/// `Vec<Arc<[u8]>>` with each element as a CBOR byte string.
 ///
-/// Elements are the `Arc`-shared [`SharedBytes`](crate::message::SharedBytes) so
-/// a response can share one copy of each event's bytes across concurrent uses.
-/// Each element encodes as a plain CBOR byte string (major type 2), the same
-/// wire form as a `Vec<u8>` element.
+/// Elements are `Arc`-shared so a response can share one copy of each event's
+/// bytes across concurrent uses. Each element encodes as a plain CBOR byte
+/// string (major type 2), the same wire form as a `Vec<u8>` element.
 pub(crate) mod vec_byte_buf {
-    use alloc::vec::Vec;
+    use alloc::{sync::Arc, vec::Vec};
 
     use serde::{Deserialize, Deserializer, Serializer, ser::SerializeSeq};
     use serde_bytes::ByteBuf;
 
-    use crate::message::SharedBytes;
-
     pub(crate) fn serialize<S: Serializer>(
-        v: &[SharedBytes],
+        v: &[Arc<[u8]>],
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(v.len()))?;
@@ -58,11 +55,11 @@ pub(crate) mod vec_byte_buf {
 
     pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
         de: D,
-    ) -> Result<Vec<SharedBytes>, D::Error> {
+    ) -> Result<Vec<Arc<[u8]>>, D::Error> {
         let wrapped: Vec<ByteBuf> = Vec::deserialize(de)?;
         Ok(wrapped
             .into_iter()
-            .map(|b| SharedBytes::from(b.into_vec()))
+            .map(|b| Arc::from(b.into_vec()))
             .collect())
     }
 }


### PR DESCRIPTION
Store the periodic event cache's serialized events as `Arc<[u8]>` and hand every peer-pair sync response `Arc` dupes instead of deep-copying the byte set. 

During cold start of a new peer, we normally sync exactly the entire public set of keyhive ops from the server to the peer. When there are many concurrent peers cold-starting at the same time, we don't want to copy those bytes unnecessarily. The cache now builds that map once per refresh and shares it by `Arc`.

  ### Testing
  * New tests cover the `Arc`-sharing semantics of `events_for_peer_pair` (shared on the public-only path, a fresh map on the private path) and the byte round-trips.
  * Adds a criterion bench (`periodic_cache`) for the refresh build cost and an opt-in dhat heap membench (`cache/membench.rs`, behind a new `dhat-heap` feature) that measures the working set for the periodic keyhive op cache. 
