### PR TITLE
Fire and forget subscriptions

### DIFF
--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -3969,14 +3969,19 @@ where
             let result = handler.handle(&conn, msg).await;
             if result.is_ok()
                 && let Some((sed_id, originator)) = propagate
-                && subduction
-                    .storage
-                    .policy()
-                    .authorize_fetch(originator, sed_id)
-                    .await
-                    .is_ok()
             {
-                subduction.propagate_subscription(sed_id, originator).await;
+                let sd = Arc::clone(&subduction);
+                let _propagation = subduction.spawner.spawn(Async::from_future(async move {
+                    if sd
+                        .storage
+                        .policy()
+                        .authorize_fetch(originator, sed_id)
+                        .await
+                        .is_ok()
+                    {
+                        sd.propagate_subscription(sed_id, originator).await;
+                    };
+                }));
             }
 
             completion.complete(conn, result);

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -3980,7 +3980,7 @@ where
                         .is_ok()
                     {
                         sd.propagate_subscription(sed_id, originator).await;
-                    };
+                    }
                 }));
             }
 


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

While looking at timings, this is a quick win with slow peers

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
