### PR TITLE
Decode slices, not owned bytes

### DIFF
--- a/sedimentree_core/src/loose_commit.rs
+++ b/sedimentree_core/src/loose_commit.rs
@@ -306,11 +306,8 @@ mod proptests {
     }
 
     /// Decoded struct's `fields_size()` matches the consumed byte count
-    /// returned by `try_decode_fields`.
-    ///
-    /// This is the invariant that the old `Signed::try_decode` assumed
-    /// but never verified — if these disagree, `bytes.truncate()` corrupts
-    /// the signed data.
+    /// returned by `try_decode_fields`. `Signed` decoding relies on these
+    /// agreeing to locate the signature; a mismatch would corrupt it.
     #[test]
     #[allow(clippy::panic)]
     fn decoded_fields_size_matches_consumed() {

--- a/sedimentree_fs_storage/benches/load_loose_commits.rs
+++ b/sedimentree_fs_storage/benches/load_loose_commits.rs
@@ -169,7 +169,7 @@ fn read_all_pairs_sync(commits_dir: &Path) -> Vec<(Vec<u8>, Vec<u8>)> {
 /// Decode a pre-read `.meta` + `.blob` pair, mirroring the decode phase of
 /// `load_loose_commits`.
 fn decode_pair(meta: Vec<u8>, blob: Vec<u8>) -> VerifiedMeta<LooseCommit> {
-    let signed = Signed::try_decode(meta).expect("decode Signed<LooseCommit>");
+    let signed = Signed::try_decode(&meta).expect("decode Signed<LooseCommit>");
     VerifiedMeta::try_from_trusted(signed, Blob::new(blob)).expect("reconstruct VerifiedMeta")
 }
 

--- a/sedimentree_fs_storage/benches/load_loose_commits.rs
+++ b/sedimentree_fs_storage/benches/load_loose_commits.rs
@@ -168,8 +168,8 @@ fn read_all_pairs_sync(commits_dir: &Path) -> Vec<(Vec<u8>, Vec<u8>)> {
 
 /// Decode a pre-read `.meta` + `.blob` pair, mirroring the decode phase of
 /// `load_loose_commits`.
-fn decode_pair(meta: Vec<u8>, blob: Vec<u8>) -> VerifiedMeta<LooseCommit> {
-    let signed = Signed::try_decode(&meta).expect("decode Signed<LooseCommit>");
+fn decode_pair(meta: &[u8], blob: Vec<u8>) -> VerifiedMeta<LooseCommit> {
+    let signed = Signed::try_decode(meta).expect("decode Signed<LooseCommit>");
     VerifiedMeta::try_from_trusted(signed, Blob::new(blob)).expect("reconstruct VerifiedMeta")
 }
 
@@ -256,7 +256,7 @@ fn bench_phases(c: &mut Criterion) {
             |pairs| {
                 pairs
                     .into_iter()
-                    .map(|(meta, blob)| decode_pair(meta, blob))
+                    .map(|(meta, blob)| decode_pair(&meta, blob))
                     .collect::<Vec<_>>()
             },
             BatchSize::SmallInput,

--- a/sedimentree_fs_storage/src/lib.rs
+++ b/sedimentree_fs_storage/src/lib.rs
@@ -605,7 +605,7 @@ where
 {
     let mut out = Vec::with_capacity(raw.len());
     for (name, signed_data) in raw {
-        match Signed::<T>::try_decode(signed_data).and_then(|s| s.try_decode_trusted_payload()) {
+        match Signed::<T>::try_decode(&signed_data).and_then(|s| s.try_decode_trusted_payload()) {
             Ok(payload) => out.push(payload),
             Err(e) => tracing::warn!(dir = %name, "skipping corrupt stored {what}: {e}"),
         }
@@ -1072,7 +1072,7 @@ impl Storage<Sendable> for FsStorage {
 
             match Self::read_first_meta_blob_pair(&id_dir).await? {
                 Some((signed_data, blob_data)) => {
-                    let signed = Signed::try_decode(signed_data)?;
+                    let signed = Signed::try_decode(&signed_data)?;
                     let blob = Blob::new(blob_data);
                     Ok(Some(VerifiedMeta::try_from_trusted(signed, blob)?))
                 }
@@ -1119,7 +1119,7 @@ impl Storage<Sendable> for FsStorage {
 
             let mut results = Vec::with_capacity(raw.len());
             for (name, signed_data, blob_data) in raw {
-                let signed = match Signed::try_decode(signed_data) {
+                let signed = match Signed::try_decode(&signed_data) {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::warn!(
@@ -1218,7 +1218,7 @@ impl Storage<Sendable> for FsStorage {
 
             match Self::read_first_meta_blob_pair(&id_dir).await? {
                 Some((signed_data, blob_data)) => {
-                    let signed = match Signed::try_decode(signed_data) {
+                    let signed = match Signed::try_decode(&signed_data) {
                         Ok(s) => s,
                         Err(e) => {
                             tracing::error!(
@@ -1280,7 +1280,7 @@ impl Storage<Sendable> for FsStorage {
 
             let mut results = Vec::with_capacity(raw.len());
             for (name, signed_data, blob_data) in raw {
-                let signed = match Signed::try_decode(signed_data) {
+                let signed = match Signed::try_decode(&signed_data) {
                     Ok(s) => s,
                     Err(e) => {
                         tracing::warn!(

--- a/sedimentree_wasm/src/signed.rs
+++ b/sedimentree_wasm/src/signed.rs
@@ -78,7 +78,7 @@ impl WasmSignedLooseCommit {
     ///
     /// Returns an error if the bytes are not a valid signed loose commit.
     pub fn try_from_vec(bytes: Vec<u8>) -> Result<Self, DecodeError> {
-        Ok(Self(Signed::<LooseCommit>::try_decode(bytes)?))
+        Ok(Self(Signed::<LooseCommit>::try_decode(&bytes)?))
     }
 
     /// Get the raw bytes of the signed loose commit.
@@ -105,7 +105,7 @@ impl WasmSignedFragment {
     pub fn try_decode(bytes: &Uint8Array) -> Result<WasmSignedFragment, JsValue> {
         let data = bytes.to_vec();
         let signed =
-            Signed::<Fragment>::try_decode(data).map_err(|e| JsValue::from_str(&e.to_string()))?;
+            Signed::<Fragment>::try_decode(&data).map_err(|e| JsValue::from_str(&e.to_string()))?;
         Ok(Self(signed))
     }
 
@@ -156,7 +156,7 @@ impl WasmSignedFragment {
     ///
     /// Returns an error if the bytes are not a valid signed fragment.
     pub fn try_from_vec(bytes: Vec<u8>) -> Result<Self, DecodeError> {
-        Ok(Self(Signed::<Fragment>::try_decode(bytes)?))
+        Ok(Self(Signed::<Fragment>::try_decode(&bytes)?))
     }
 
     /// Get the raw bytes of the signed fragment.

--- a/sedimentree_wasm/src/signed.rs
+++ b/sedimentree_wasm/src/signed.rs
@@ -77,8 +77,8 @@ impl WasmSignedLooseCommit {
     /// # Errors
     ///
     /// Returns an error if the bytes are not a valid signed loose commit.
-    pub fn try_from_vec(bytes: Vec<u8>) -> Result<Self, DecodeError> {
-        Ok(Self(Signed::<LooseCommit>::try_decode(&bytes)?))
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Ok(Self(Signed::<LooseCommit>::try_decode(bytes)?))
     }
 
     /// Get the raw bytes of the signed loose commit.
@@ -155,8 +155,8 @@ impl WasmSignedFragment {
     /// # Errors
     ///
     /// Returns an error if the bytes are not a valid signed fragment.
-    pub fn try_from_vec(bytes: Vec<u8>) -> Result<Self, DecodeError> {
-        Ok(Self(Signed::<Fragment>::try_decode(&bytes)?))
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Ok(Self(Signed::<Fragment>::try_decode(bytes)?))
     }
 
     /// Get the raw bytes of the signed fragment.

--- a/sedimentree_wasm/src/signed.rs
+++ b/sedimentree_wasm/src/signed.rs
@@ -1,6 +1,6 @@
 //! Wasm wrappers for signed types.
 
-use alloc::{string::ToString, vec::Vec};
+use alloc::string::ToString;
 
 use js_sys::Uint8Array;
 use sedimentree_core::{codec::error::DecodeError, fragment::Fragment, loose_commit::LooseCommit};

--- a/sedimentree_wasm/src/signed.rs
+++ b/sedimentree_wasm/src/signed.rs
@@ -26,7 +26,7 @@ impl WasmSignedLooseCommit {
     #[wasm_bindgen(js_name = tryDecode)]
     pub fn try_decode(bytes: &Uint8Array) -> Result<WasmSignedLooseCommit, JsValue> {
         let data = bytes.to_vec();
-        let signed = Signed::<LooseCommit>::try_decode(data)
+        let signed = Signed::<LooseCommit>::try_decode(&data)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
         Ok(Self(signed))
     }

--- a/sedimentree_wasm/src/storage/idb.rs
+++ b/sedimentree_wasm/src/storage/idb.rs
@@ -385,7 +385,7 @@ impl WasmIndexedDbStorage {
             .map_err(WasmLoadCommitError::ReflectError)?;
 
         let signed_bytes = Uint8Array::new(&signed_val).to_vec();
-        let signed = WasmSignedLooseCommit::try_from_vec(signed_bytes)?;
+        let signed = WasmSignedLooseCommit::try_from_bytes(&signed_bytes)?;
         let blob = Uint8Array::new(&blob_val);
 
         Ok(Some(WasmCommitWithBlob::new(signed, blob)))
@@ -444,7 +444,7 @@ impl WasmIndexedDbStorage {
             let signed_bytes = Uint8Array::new(&signed_val).to_vec();
             let blob = Uint8Array::new(&blob_val);
 
-            let signed = WasmSignedLooseCommit::try_from_vec(signed_bytes)?;
+            let signed = WasmSignedLooseCommit::try_from_bytes(&signed_bytes)?;
 
             result.push(WasmCommitWithBlob::new(signed, blob));
         }
@@ -581,7 +581,7 @@ impl WasmIndexedDbStorage {
         let signed_bytes = Uint8Array::new(&signed_val).to_vec();
         let blob = Uint8Array::new(&blob_val);
 
-        let signed = WasmSignedFragment::try_from_vec(signed_bytes)?;
+        let signed = WasmSignedFragment::try_from_bytes(&signed_bytes)?;
 
         Ok(Some(WasmFragmentWithBlob::new(signed, blob)))
     }
@@ -639,7 +639,7 @@ impl WasmIndexedDbStorage {
             let signed_bytes = Uint8Array::new(&signed_val).to_vec();
             let blob = Uint8Array::new(&blob_val);
 
-            let signed = WasmSignedFragment::try_from_vec(signed_bytes)?;
+            let signed = WasmSignedFragment::try_from_bytes(&signed_bytes)?;
 
             result.push(WasmFragmentWithBlob::new(signed, blob));
         }

--- a/subduction_core/src/connection/message.rs
+++ b/subduction_core/src/connection/message.rs
@@ -809,18 +809,15 @@ fn decode_loose_commit(payload: &[u8]) -> Result<SyncMessage, DecodeError> {
     let id = SedimentreeId::new(read_array::<32>(payload, &mut offset)?);
     let sender_heads = decode_remote_heads(payload, &mut offset)?;
 
-    let commit = Signed::<LooseCommit>::try_decode(
-        payload
-            .get(offset..)
-            .ok_or(BufferTooShort {
-                reading: ReadingType::Slice { len: 0 },
-                offset,
-                need: 1,
-                have: 0,
-            })?
-            .to_vec(),
+    let (commit, consumed) = Signed::<LooseCommit>::try_decode_prefix(
+        payload.get(offset..).ok_or(BufferTooShort {
+            reading: ReadingType::Slice { len: 0 },
+            offset,
+            need: 1,
+            have: 0,
+        })?,
     )?;
-    offset += commit.as_bytes().len();
+    offset += consumed;
 
     let blob_size = read_bijou64_as_usize(payload, &mut offset)?;
 
@@ -850,18 +847,15 @@ fn decode_fragment(payload: &[u8]) -> Result<SyncMessage, DecodeError> {
     let id = SedimentreeId::new(read_array::<32>(payload, &mut offset)?);
     let sender_heads = decode_remote_heads(payload, &mut offset)?;
 
-    let fragment = Signed::<Fragment>::try_decode(
-        payload
-            .get(offset..)
-            .ok_or(BufferTooShort {
-                reading: ReadingType::Slice { len: 0 },
-                offset,
-                need: 1,
-                have: 0,
-            })?
-            .to_vec(),
+    let (fragment, consumed) = Signed::<Fragment>::try_decode_prefix(
+        payload.get(offset..).ok_or(BufferTooShort {
+            reading: ReadingType::Slice { len: 0 },
+            offset,
+            need: 1,
+            have: 0,
+        })?,
     )?;
-    offset += fragment.as_bytes().len();
+    offset += consumed;
 
     let blob_size = read_bijou64_as_usize(payload, &mut offset)?;
 
@@ -974,18 +968,15 @@ fn decode_sync_diff(payload: &[u8], offset: &mut usize) -> Result<SyncDiff, Deco
 
     let mut missing_commits = Vec::with_capacity(commit_count);
     for _ in 0..commit_count {
-        let commit = Signed::<LooseCommit>::try_decode(
-            payload
-                .get(*offset..)
-                .ok_or(BufferTooShort {
-                    reading: ReadingType::Slice { len: 0 },
-                    offset: *offset,
-                    need: 1,
-                    have: 0,
-                })?
-                .to_vec(),
+        let (commit, consumed) = Signed::<LooseCommit>::try_decode_prefix(
+            payload.get(*offset..).ok_or(BufferTooShort {
+                reading: ReadingType::Slice { len: 0 },
+                offset: *offset,
+                need: 1,
+                have: 0,
+            })?,
         )?;
-        *offset += commit.as_bytes().len();
+        *offset += consumed;
 
         let blob_size = read_bijou64_as_usize(payload, offset)?;
         let blob = Blob::new(
@@ -1006,18 +997,15 @@ fn decode_sync_diff(payload: &[u8], offset: &mut usize) -> Result<SyncDiff, Deco
 
     let mut missing_fragments = Vec::with_capacity(fragment_count);
     for _ in 0..fragment_count {
-        let fragment = Signed::<Fragment>::try_decode(
-            payload
-                .get(*offset..)
-                .ok_or(BufferTooShort {
-                    reading: ReadingType::Slice { len: 0 },
-                    offset: *offset,
-                    need: 1,
-                    have: 0,
-                })?
-                .to_vec(),
+        let (fragment, consumed) = Signed::<Fragment>::try_decode_prefix(
+            payload.get(*offset..).ok_or(BufferTooShort {
+                reading: ReadingType::Slice { len: 0 },
+                offset: *offset,
+                need: 1,
+                have: 0,
+            })?,
         )?;
-        *offset += fragment.as_bytes().len();
+        *offset += consumed;
 
         let blob_size = read_bijou64_as_usize(payload, offset)?;
         let blob = Blob::new(

--- a/subduction_core/src/connection/message.rs
+++ b/subduction_core/src/connection/message.rs
@@ -809,14 +809,13 @@ fn decode_loose_commit(payload: &[u8]) -> Result<SyncMessage, DecodeError> {
     let id = SedimentreeId::new(read_array::<32>(payload, &mut offset)?);
     let sender_heads = decode_remote_heads(payload, &mut offset)?;
 
-    let (commit, consumed) = Signed::<LooseCommit>::try_decode_prefix(
-        payload.get(offset..).ok_or(BufferTooShort {
+    let (commit, consumed) =
+        Signed::<LooseCommit>::try_decode_prefix(payload.get(offset..).ok_or(BufferTooShort {
             reading: ReadingType::Slice { len: 0 },
             offset,
             need: 1,
             have: 0,
-        })?,
-    )?;
+        })?)?;
     offset += consumed;
 
     let blob_size = read_bijou64_as_usize(payload, &mut offset)?;
@@ -847,14 +846,13 @@ fn decode_fragment(payload: &[u8]) -> Result<SyncMessage, DecodeError> {
     let id = SedimentreeId::new(read_array::<32>(payload, &mut offset)?);
     let sender_heads = decode_remote_heads(payload, &mut offset)?;
 
-    let (fragment, consumed) = Signed::<Fragment>::try_decode_prefix(
-        payload.get(offset..).ok_or(BufferTooShort {
+    let (fragment, consumed) =
+        Signed::<Fragment>::try_decode_prefix(payload.get(offset..).ok_or(BufferTooShort {
             reading: ReadingType::Slice { len: 0 },
             offset,
             need: 1,
             have: 0,
-        })?,
-    )?;
+        })?)?;
     offset += consumed;
 
     let blob_size = read_bijou64_as_usize(payload, &mut offset)?;

--- a/subduction_core/src/handshake.rs
+++ b/subduction_core/src/handshake.rs
@@ -281,11 +281,11 @@ impl HandshakeMessage {
         match tag {
             handshake_tags::CHALLENGE => {
                 // Full bytes are Signed<Challenge> — discriminant validated by try_decode.
-                let signed = Signed::<Challenge>::try_decode(bytes.to_vec())?;
+                let signed = Signed::<Challenge>::try_decode(bytes)?;
                 Ok(HandshakeMessage::SignedChallenge(signed))
             }
             handshake_tags::RESPONSE => {
-                let signed = Signed::<Response>::try_decode(bytes.to_vec())?;
+                let signed = Signed::<Response>::try_decode(bytes)?;
                 Ok(HandshakeMessage::SignedResponse(signed))
             }
             handshake_tags::REJECTION => {

--- a/subduction_core/tests/codec_proptest.rs
+++ b/subduction_core/tests/codec_proptest.rs
@@ -136,7 +136,7 @@ fn challenge_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<Challenge>::try_decode(&bytes);
+            let _result = Signed::<Challenge>::try_decode(bytes);
         });
 }
 
@@ -309,7 +309,7 @@ fn response_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<Response>::try_decode(&bytes);
+            let _result = Signed::<Response>::try_decode(bytes);
         });
 }
 

--- a/subduction_core/tests/codec_proptest.rs
+++ b/subduction_core/tests/codec_proptest.rs
@@ -136,7 +136,7 @@ fn challenge_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<Challenge>::try_decode(bytes);
+            let _result = Signed::<Challenge>::try_decode(&bytes);
         });
 }
 
@@ -309,7 +309,7 @@ fn response_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<Response>::try_decode(bytes);
+            let _result = Signed::<Response>::try_decode(&bytes);
         });
 }
 

--- a/subduction_core/tests/codec_proptest.rs
+++ b/subduction_core/tests/codec_proptest.rs
@@ -125,7 +125,7 @@ fn challenge_signed_round_trip() {
         .with_arbitrary::<(Challenge, [u8; 32])>()
         .for_each(|(challenge, key_bytes)| {
             let bytes = seal_sync(*key_bytes, challenge);
-            let signed = Signed::<Challenge>::try_decode(bytes).expect("decode");
+            let signed = Signed::<Challenge>::try_decode(&bytes).expect("decode");
             let verified = signed.try_verify().expect("verify");
             assert_eq!(verified.payload(), challenge);
         });
@@ -136,7 +136,7 @@ fn challenge_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<Challenge>::try_decode(bytes.clone());
+            let _result = Signed::<Challenge>::try_decode(bytes);
         });
 }
 
@@ -181,7 +181,7 @@ fn challenge_rejects_response_bytes() {
             let bytes = seal_sync(*key_bytes, response);
             // Sanity: byte 4 should be Response::DISCRIMINANT (0x01).
             assert_eq!(bytes[SCHEMA_SIZE], 0x01);
-            let result = Signed::<Challenge>::try_decode(bytes);
+            let result = Signed::<Challenge>::try_decode(&bytes);
             assert!(
                 matches!(
                     result,
@@ -207,7 +207,7 @@ fn challenge_rejects_response_bytes_padded_via_discriminant() {
                 bytes.push(0u8);
             }
             assert_eq!(bytes[SCHEMA_SIZE], 0x01);
-            let result = Signed::<Challenge>::try_decode(bytes);
+            let result = Signed::<Challenge>::try_decode(&bytes);
             assert!(
                 matches!(
                     result,
@@ -226,7 +226,7 @@ fn challenge_signed_truncation_does_not_panic() {
             let mut bytes = seal_sync(*key_bytes, challenge);
             let new_len = bytes.len().saturating_sub(*drop_count as usize);
             bytes.truncate(new_len);
-            let _result = Signed::<Challenge>::try_decode(bytes);
+            let _result = Signed::<Challenge>::try_decode(&bytes);
         });
 }
 
@@ -243,7 +243,7 @@ fn challenge_signed_bit_flip_breaks_verification() {
             let bit_idx = bit_idx_seed % 8;
             bytes[byte_idx] ^= 1 << bit_idx;
 
-            if let Ok(signed) = Signed::<Challenge>::try_decode(bytes) {
+            if let Ok(signed) = Signed::<Challenge>::try_decode(&bytes) {
                 let verify = signed.try_verify();
                 assert!(verify.is_err(), "tampered bytes must not verify");
             }
@@ -298,7 +298,7 @@ fn response_signed_round_trip() {
         .with_arbitrary::<(Response, [u8; 32])>()
         .for_each(|(response, key_bytes)| {
             let bytes = seal_sync(*key_bytes, response);
-            let signed = Signed::<Response>::try_decode(bytes).expect("decode");
+            let signed = Signed::<Response>::try_decode(&bytes).expect("decode");
             let verified = signed.try_verify().expect("verify");
             assert_eq!(verified.payload(), response);
         });
@@ -309,7 +309,7 @@ fn response_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<Response>::try_decode(bytes.clone());
+            let _result = Signed::<Response>::try_decode(bytes);
         });
 }
 
@@ -323,7 +323,7 @@ fn response_rejects_challenge_bytes_via_discriminant() {
         .for_each(|(challenge, key_bytes)| {
             let bytes = seal_sync(*key_bytes, challenge);
             assert_eq!(bytes[SCHEMA_SIZE], 0x00);
-            let result = Signed::<Response>::try_decode(bytes);
+            let result = Signed::<Response>::try_decode(&bytes);
             assert!(
                 matches!(
                     result,

--- a/subduction_core/tests/sync_codec_memory.rs
+++ b/subduction_core/tests/sync_codec_memory.rs
@@ -1,0 +1,120 @@
+//! Regression test: decoding a `BatchSyncResponse` carrying N missing
+//! commits must use memory **linear** in N, not quadratic.
+//!
+//! Background: `decode_sync_diff` decodes each commit via
+//! `Signed::try_decode(payload.get(*offset..)?.to_vec())` — it copies the
+//! *entire remaining payload* per commit, and `Signed::try_decode` finalizes
+//! its buffer with `Vec::truncate` (which shrinks length but **not**
+//! capacity). So each of the N decoded `Signed` values retains a `Vec` whose
+//! capacity is the whole remaining payload at its decode point. Summed over
+//! N commits that is `Σ (N-k) ≈ ½·N²` bytes held at once — ~12 GiB for an
+//! 8.7k-commit document, which overflows wasm's 4 GiB linear-memory heap and
+//! crashes sync with `RuntimeError: unreachable`.
+//!
+//! This test fails (red) on the quadratic code and passes once each decoded
+//! `Signed` retains only its own bytes. It is deterministic — it inspects the
+//! decoded buffers' `capacity()` directly rather than sampling process RSS.
+
+#![allow(clippy::expect_used, clippy::panic, clippy::cast_precision_loss)]
+
+use std::collections::BTreeSet;
+
+use future_form::Sendable;
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+};
+use subduction_core::{
+    connection::{
+        message::{
+            BatchSyncResponse, RequestId, RequestedData, SyncDiff, SyncMessage, SyncResult,
+        },
+        test_utils::test_signer,
+    },
+    peer::id::PeerId,
+    remote_heads::RemoteHeads,
+};
+use subduction_crypto::signed::Signed;
+
+/// Build one signed loose commit + its blob.
+async fn make_commit(id: SedimentreeId) -> (Signed<LooseCommit>, Blob) {
+    let blob = Blob::new(vec![0xAB; 32]);
+    let blob_meta = BlobMeta::new(&blob);
+    let commit = LooseCommit::new(id, CommitId::new([0x11; 32]), BTreeSet::new(), blob_meta);
+    let verified = Signed::seal::<Sendable, _>(&test_signer(), commit).await;
+    (verified.into_signed(), blob)
+}
+
+/// A `BatchSyncResponse` with `N` missing commits must decode into buffers
+/// whose total retained capacity is linear in the wire size, not quadratic.
+#[tokio::test]
+async fn batch_sync_response_decode_memory_is_linear() {
+    const N: u32 = 1_000;
+
+    let sed_id = SedimentreeId::new([1u8; 32]);
+
+    // The decode's per-commit memory cost is independent of commit content,
+    // so we seal one commit and clone it N times (each clone is right-sized,
+    // ~200 B) instead of sealing N — keeps the test sub-second. Identical
+    // entries are fine: the wire codec does not deduplicate.
+    let commit = make_commit(sed_id).await;
+    let missing_commits = vec![commit; N as usize];
+
+    let response = BatchSyncResponse {
+        req_id: RequestId {
+            requestor: PeerId::new([9u8; 32]),
+            nonce: 0xDEAD_BEEF,
+        },
+        id: sed_id,
+        result: SyncResult::Ok(SyncDiff {
+            missing_commits,
+            missing_fragments: Vec::new(),
+            requesting: RequestedData::default(),
+        }),
+        responder_heads: RemoteHeads {
+            counter: 0,
+            heads: Vec::new(),
+        },
+    };
+
+    let bytes = SyncMessage::from(response).encode();
+
+    let decoded = SyncMessage::try_decode(&bytes).expect("decode BatchSyncResponse");
+    let SyncMessage::BatchSyncResponse(BatchSyncResponse {
+        result: SyncResult::Ok(diff),
+        ..
+    }) = decoded
+    else {
+        panic!("expected Ok(BatchSyncResponse)");
+    };
+
+    assert_eq!(diff.missing_commits.len(), N as usize, "all commits decoded");
+
+    // Total memory retained by the decoded commit buffers. The bug makes each
+    // commit retain ~the whole remaining payload, so this sums to O(N²); the
+    // fix makes each retain only its own bytes, so it sums to ~the wire size.
+    let total_capacity: usize = diff
+        .missing_commits
+        .into_iter()
+        .map(|(signed, _blob)| signed.into_bytes().capacity())
+        .sum();
+
+    let wire = bytes.len();
+    let bound = wire * 4;
+    let ratio = total_capacity as f64 / wire as f64;
+
+    eprintln!(
+        "N={N}: decoded total_capacity = {total_capacity} B, wire = {wire} B, ratio {ratio:.2}x \
+         (quadratic would be ~{:.0}x)",
+        f64::from(N + 1) / 2.0
+    );
+
+    assert!(
+        total_capacity <= bound,
+        "decoded commit buffers retain memory quadratic in N: \
+         total_capacity = {total_capacity} B, wire = {wire} B (ratio {ratio:.0}x), \
+         linear bound = {bound} B. Each decoded Signed must retain only its own \
+         bytes, not the whole remaining payload."
+    );
+}

--- a/subduction_core/tests/sync_codec_memory.rs
+++ b/subduction_core/tests/sync_codec_memory.rs
@@ -1,19 +1,9 @@
-//! Regression test: decoding a `BatchSyncResponse` carrying N missing
-//! commits must use memory **linear** in N, not quadratic.
+//! Decoding a `BatchSyncResponse` carrying N missing commits must use memory
+//! linear in N: each decoded `Signed` retains only its own bytes, keeping
+//! batch decode within wasm's bounded linear-memory heap.
 //!
-//! Background: `decode_sync_diff` decodes each commit via
-//! `Signed::try_decode(payload.get(*offset..)?.to_vec())` — it copies the
-//! *entire remaining payload* per commit, and `Signed::try_decode` finalizes
-//! its buffer with `Vec::truncate` (which shrinks length but **not**
-//! capacity). So each of the N decoded `Signed` values retains a `Vec` whose
-//! capacity is the whole remaining payload at its decode point. Summed over
-//! N commits that is `Σ (N-k) ≈ ½·N²` bytes held at once — ~12 GiB for an
-//! 8.7k-commit document, which overflows wasm's 4 GiB linear-memory heap and
-//! crashes sync with `RuntimeError: unreachable`.
-//!
-//! This test fails (red) on the quadratic code and passes once each decoded
-//! `Signed` retains only its own bytes. It is deterministic — it inspects the
-//! decoded buffers' `capacity()` directly rather than sampling process RSS.
+//! The check is deterministic: it inspects the decoded buffers' `capacity()`
+//! directly rather than sampling process RSS.
 
 #![allow(clippy::expect_used, clippy::panic, clippy::cast_precision_loss)]
 
@@ -27,9 +17,7 @@ use sedimentree_core::{
 };
 use subduction_core::{
     connection::{
-        message::{
-            BatchSyncResponse, RequestId, RequestedData, SyncDiff, SyncMessage, SyncResult,
-        },
+        message::{BatchSyncResponse, RequestId, RequestedData, SyncDiff, SyncMessage, SyncResult},
         test_utils::test_signer,
     },
     peer::id::PeerId,
@@ -89,11 +77,14 @@ async fn batch_sync_response_decode_memory_is_linear() {
         panic!("expected Ok(BatchSyncResponse)");
     };
 
-    assert_eq!(diff.missing_commits.len(), N as usize, "all commits decoded");
+    assert_eq!(
+        diff.missing_commits.len(),
+        N as usize,
+        "all commits decoded"
+    );
 
-    // Total memory retained by the decoded commit buffers. The bug makes each
-    // commit retain ~the whole remaining payload, so this sums to O(N²); the
-    // fix makes each retain only its own bytes, so it sums to ~the wire size.
+    // Total memory retained by the decoded commit buffers. With each commit
+    // retaining only its own bytes, this sums to ~the wire size.
     let total_capacity: usize = diff
         .missing_commits
         .into_iter()
@@ -105,16 +96,14 @@ async fn batch_sync_response_decode_memory_is_linear() {
     let ratio = total_capacity as f64 / wire as f64;
 
     eprintln!(
-        "N={N}: decoded total_capacity = {total_capacity} B, wire = {wire} B, ratio {ratio:.2}x \
-         (quadratic would be ~{:.0}x)",
-        f64::from(N + 1) / 2.0
+        "N={N}: decoded total_capacity = {total_capacity} B, wire = {wire} B, \
+         ratio {ratio:.2}x (linear bound {bound} B)"
     );
 
     assert!(
         total_capacity <= bound,
-        "decoded commit buffers retain memory quadratic in N: \
-         total_capacity = {total_capacity} B, wire = {wire} B (ratio {ratio:.0}x), \
-         linear bound = {bound} B. Each decoded Signed must retain only its own \
-         bytes, not the whole remaining payload."
+        "decoded commit buffers retain {total_capacity} B for {wire} B of wire \
+         (ratio {ratio:.0}x), exceeding the linear bound of {bound} B. Each decoded \
+         Signed must retain only its own bytes."
     );
 }

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -186,7 +186,54 @@ impl<T: Schema + EncodeFields + DecodeFields> Signed<T> {
     /// - The schema header doesn't match `T::SCHEMA`
     /// - The verifying key is invalid
     /// - The payload cannot be decoded
-    pub fn try_decode(mut bytes: Vec<u8>) -> Result<Self, DecodeError> {
+    pub fn try_decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Self::try_decode_prefix(bytes).map(|(signed, _)| signed)
+    }
+
+    /// Decode one signed message from the front of `bytes`, returning the
+    /// decoded value and the number of bytes it consumed (`actual_size`).
+    ///
+    /// The consumed length lets callers decode a sequence of messages packed
+    /// back-to-back (e.g. the commits and fragments in a batch sync response).
+    ///
+    /// Validates the header but does NOT verify the signature; use
+    /// [`try_verify`](Self::try_verify) for that.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`try_decode`](Self::try_decode).
+    pub fn try_decode_prefix(bytes: &[u8]) -> Result<(Self, usize), DecodeError> {
+        let (issuer, signature, actual_size) = Self::decode_header(bytes)?;
+
+        // Copy out this message's bytes, leaving the rest of `bytes` for the
+        // caller to continue decoding.
+        let message = bytes
+            .get(..actual_size)
+            .ok_or(DecodeError::MessageTooShort {
+                type_name: core::any::type_name::<T>(),
+                need: actual_size,
+                have: bytes.len(),
+            })?
+            .to_vec();
+
+        Ok((
+            Self {
+                issuer,
+                signature,
+                bytes: message,
+                _marker: PhantomData,
+            },
+            actual_size,
+        ))
+    }
+
+    /// Validate the wire header and compute the signed message's total size.
+    ///
+    /// Validates the schema and optional discriminant, extracts the issuer key
+    /// and signature, and decodes the fields to determine `actual_size` (schema
+    /// + discriminant + issuer + fields + signature). Does not verify the
+    /// signature.
+    fn decode_header(bytes: &[u8]) -> Result<(VerifyingKey, Signature, usize), DecodeError> {
         // Check minimum size
         if bytes.len() < T::MIN_SIGNED_SIZE {
             return Err(DecodeError::MessageTooShort {
@@ -201,10 +248,10 @@ impl<T: Schema + EncodeFields + DecodeFields> Signed<T> {
             .get(0..SCHEMA_SIZE)
             .and_then(|s| s.try_into().ok())
             .ok_or(DecodeError::MessageTooShort {
-            type_name: core::any::type_name::<T>(),
-            need: SCHEMA_SIZE,
-            have: bytes.len(),
-        })?;
+                type_name: core::any::type_name::<T>(),
+                need: SCHEMA_SIZE,
+                have: bytes.len(),
+            })?;
         if schema != T::SCHEMA {
             return Err(InvalidSchema {
                 expected: T::SCHEMA,
@@ -280,15 +327,7 @@ impl<T: Schema + EncodeFields + DecodeFields> Signed<T> {
             })?;
         let signature = Signature::from_bytes(&sig_bytes);
 
-        // Truncate to only include the actual signed message bytes
-        bytes.truncate(actual_size);
-
-        Ok(Self {
-            issuer,
-            signature,
-            bytes,
-            _marker: PhantomData,
-        })
+        Ok((issuer, signature, actual_size))
     }
 
     /// Consume and return the wire bytes.

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -563,7 +563,7 @@ mod tests {
         let bytes = sealed.as_bytes().to_vec();
 
         // Parse from wire bytes
-        let parsed = Signed::<TestPayload>::try_decode(bytes)?;
+        let parsed = Signed::<TestPayload>::try_decode(&bytes)?;
 
         // Verify the signature and decode
         let verified = parsed.try_verify()?;
@@ -610,7 +610,7 @@ mod tests {
         // Tamper with the payload (change the value)
         bytes[36] ^= 0xFF;
 
-        let parsed = Signed::<TestPayload>::try_decode(bytes)?;
+        let parsed = Signed::<TestPayload>::try_decode(&bytes)?;
         let result = parsed.try_verify();
 
         assert!(result.is_err(), "tampered bytes should fail verification");
@@ -643,7 +643,7 @@ mod tests {
                 original_bytes.extend_from_slice(&signature.to_bytes());
 
                 // Round-trip through try_decode
-                let decoded = Signed::<TestPayload>::try_decode(original_bytes.clone())
+                let decoded = Signed::<TestPayload>::try_decode(&original_bytes)
                     .expect("decode should succeed for sealed bytes");
 
                 assert_eq!(
@@ -679,7 +679,7 @@ mod tests {
                 bytes.extend_from_slice(&signature.to_bytes());
 
                 let decoded =
-                    Signed::<TestPayload>::try_decode(bytes).expect("decode should succeed");
+                    Signed::<TestPayload>::try_decode(&bytes).expect("decode should succeed");
 
                 let verified = decoded
                     .try_verify()
@@ -769,8 +769,7 @@ mod regression {
     #[test]
     fn into_bytes_returns_full_wire_bytes() {
         let canonical = seal_payload([7u8; 32], 0xDEAD_BEEF);
-        let signed =
-            Signed::<Payload>::try_decode(canonical.clone()).expect("decode of canonical bytes");
+        let signed = Signed::<Payload>::try_decode(&canonical).expect("decode of canonical bytes");
 
         let via_as_bytes: Vec<u8> = signed.as_bytes().to_vec();
         let via_into_bytes: Vec<u8> = signed.into_bytes();
@@ -882,7 +881,7 @@ mod regression {
         bytes.extend_from_slice(&UnderSpecifiedTagged::SCHEMA);
         assert_eq!(bytes.len(), SCHEMA_SIZE);
 
-        let result = Signed::<UnderSpecifiedTagged>::try_decode(bytes);
+        let result = Signed::<UnderSpecifiedTagged>::try_decode(&bytes);
         match result {
             Err(DecodeError::MessageTooShort { need, have, .. }) => {
                 assert_eq!(
@@ -908,7 +907,7 @@ mod regression {
         bytes.extend_from_slice(&UnderSpecifiedPlain::SCHEMA);
         assert_eq!(bytes.len(), SCHEMA_SIZE);
 
-        let result = Signed::<UnderSpecifiedPlain>::try_decode(bytes);
+        let result = Signed::<UnderSpecifiedPlain>::try_decode(&bytes);
         match result {
             Err(DecodeError::MessageTooShort { need, have, .. }) => {
                 assert_eq!(
@@ -945,7 +944,7 @@ mod regression {
         bytes.extend_from_slice(&[0u8; VERIFYING_KEY_SIZE]);
         assert_eq!(bytes.len(), SCHEMA_SIZE + VERIFYING_KEY_SIZE);
 
-        let result = Signed::<UnderSpecifiedPlain>::try_decode(bytes);
+        let result = Signed::<UnderSpecifiedPlain>::try_decode(&bytes);
         assert!(
             result.is_err(),
             "decode of bytes with empty fields region must fail"
@@ -959,12 +958,12 @@ mod regression {
     /// be `!=`.
     #[test]
     fn partial_eq_distinguishes_different_signed_values() {
-        let a = Signed::<Payload>::try_decode(seal_payload([1u8; 32], 100)).expect("decode a");
+        let a = Signed::<Payload>::try_decode(&seal_payload([1u8; 32], 100)).expect("decode a");
         let a_again =
-            Signed::<Payload>::try_decode(seal_payload([1u8; 32], 100)).expect("decode a_again");
-        let b = Signed::<Payload>::try_decode(seal_payload([1u8; 32], 200))
+            Signed::<Payload>::try_decode(&seal_payload([1u8; 32], 100)).expect("decode a_again");
+        let b = Signed::<Payload>::try_decode(&seal_payload([1u8; 32], 200))
             .expect("decode b (different value)");
-        let c = Signed::<Payload>::try_decode(seal_payload([2u8; 32], 100))
+        let c = Signed::<Payload>::try_decode(&seal_payload([2u8; 32], 100))
             .expect("decode c (different signer)");
 
         assert_eq!(a, a, "self-equality must hold");
@@ -993,7 +992,7 @@ mod regression {
         let mut with_trailing = canonical.clone();
         with_trailing.extend_from_slice(&[0xFF; 256]);
 
-        let signed = Signed::<Payload>::try_decode(with_trailing)
+        let signed = Signed::<Payload>::try_decode(&with_trailing)
             .expect("decode must succeed when extra bytes trail the canonical encoding");
         assert_eq!(
             signed.as_bytes().len(),
@@ -1019,8 +1018,8 @@ mod regression {
         use core::hash::{BuildHasher as _, Hasher as _};
         use std::collections::hash_map::RandomState;
 
-        let a = Signed::<Payload>::try_decode(seal_payload([5u8; 32], 100)).expect("decode a");
-        let b = Signed::<Payload>::try_decode(seal_payload([5u8; 32], 200)).expect("decode b");
+        let a = Signed::<Payload>::try_decode(&seal_payload([5u8; 32], 100)).expect("decode a");
+        let b = Signed::<Payload>::try_decode(&seal_payload([5u8; 32], 200)).expect("decode b");
 
         let builder = RandomState::new();
         let mut ha = builder.build_hasher();
@@ -1039,8 +1038,8 @@ mod regression {
     /// values, since `Ord` defines a total order.
     #[test]
     fn partial_cmp_is_total() {
-        let a = Signed::<Payload>::try_decode(seal_payload([6u8; 32], 1)).expect("decode a");
-        let b = Signed::<Payload>::try_decode(seal_payload([6u8; 32], 2)).expect("decode b");
+        let a = Signed::<Payload>::try_decode(&seal_payload([6u8; 32], 1)).expect("decode a");
+        let b = Signed::<Payload>::try_decode(&seal_payload([6u8; 32], 2)).expect("decode b");
 
         assert!(
             a.partial_cmp(&a).is_some(),

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -248,10 +248,10 @@ impl<T: Schema + EncodeFields + DecodeFields> Signed<T> {
             .get(0..SCHEMA_SIZE)
             .and_then(|s| s.try_into().ok())
             .ok_or(DecodeError::MessageTooShort {
-                type_name: core::any::type_name::<T>(),
-                need: SCHEMA_SIZE,
-                have: bytes.len(),
-            })?;
+            type_name: core::any::type_name::<T>(),
+            need: SCHEMA_SIZE,
+            have: bytes.len(),
+        })?;
         if schema != T::SCHEMA {
             return Err(InvalidSchema {
                 expected: T::SCHEMA,

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -230,8 +230,8 @@ impl<T: Schema + EncodeFields + DecodeFields> Signed<T> {
     /// Validate the wire header and compute the signed message's total size.
     ///
     /// Validates the schema and optional discriminant, extracts the issuer key
-    /// and signature, and decodes the fields to determine `actual_size` (schema
-    /// + discriminant + issuer + fields + signature). Does not verify the signature.
+    /// and signature, and decodes the fields to determine `actual_size` (schema,
+    /// discriminant, issuer, fields, and signature). Does not verify the signature.
     fn decode_header(bytes: &[u8]) -> Result<(VerifyingKey, Signature, usize), DecodeError> {
         // Check minimum size
         if bytes.len() < T::MIN_SIGNED_SIZE {
@@ -705,7 +705,7 @@ mod regression {
         schema::{self, Schema},
     };
 
-    use super::{Signed, MIN_SIGNED_SIZE, SCHEMA_SIZE, SIGNATURE_SIZE, VERIFYING_KEY_SIZE};
+    use super::{MIN_SIGNED_SIZE, SCHEMA_SIZE, SIGNATURE_SIZE, Signed, VERIFYING_KEY_SIZE};
 
     // ── Test payloads ─────────────────────────────────────────────────
 

--- a/subduction_crypto/src/signed.rs
+++ b/subduction_crypto/src/signed.rs
@@ -231,8 +231,7 @@ impl<T: Schema + EncodeFields + DecodeFields> Signed<T> {
     ///
     /// Validates the schema and optional discriminant, extracts the issuer key
     /// and signature, and decodes the fields to determine `actual_size` (schema
-    /// + discriminant + issuer + fields + signature). Does not verify the
-    /// signature.
+    /// + discriminant + issuer + fields + signature). Does not verify the signature.
     fn decode_header(bytes: &[u8]) -> Result<(VerifyingKey, Signature, usize), DecodeError> {
         // Check minimum size
         if bytes.len() < T::MIN_SIGNED_SIZE {
@@ -706,7 +705,7 @@ mod regression {
         schema::{self, Schema},
     };
 
-    use super::{MIN_SIGNED_SIZE, SCHEMA_SIZE, SIGNATURE_SIZE, Signed, VERIFYING_KEY_SIZE};
+    use super::{Signed, MIN_SIGNED_SIZE, SCHEMA_SIZE, SIGNATURE_SIZE, VERIFYING_KEY_SIZE};
 
     // ── Test payloads ─────────────────────────────────────────────────
 

--- a/subduction_crypto/src/verified_signature.rs
+++ b/subduction_crypto/src/verified_signature.rs
@@ -254,7 +254,7 @@ mod tests {
     }
 
     fn verified(key_bytes: [u8; 32], value: u64) -> VerifiedSignature<Payload> {
-        Signed::<Payload>::try_decode(seal_payload(key_bytes, value))
+        Signed::<Payload>::try_decode(&seal_payload(key_bytes, value))
             .expect("decode")
             .try_verify()
             .expect("verify")

--- a/subduction_crypto/tests/signed_proptest.rs
+++ b/subduction_crypto/tests/signed_proptest.rs
@@ -431,7 +431,7 @@ fn random_bytes_through_plain_signed_never_panics() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<PlainPayload>::try_decode(&bytes);
+            let _result = Signed::<PlainPayload>::try_decode(bytes);
         });
 }
 
@@ -440,7 +440,7 @@ fn random_bytes_through_tagged_signed_never_panics() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<TaggedPayload>::try_decode(&bytes);
+            let _result = Signed::<TaggedPayload>::try_decode(bytes);
         });
 }
 
@@ -449,7 +449,7 @@ fn random_bytes_through_variable_signed_never_panics() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<VariablePayload>::try_decode(&bytes);
+            let _result = Signed::<VariablePayload>::try_decode(bytes);
         });
 }
 

--- a/subduction_crypto/tests/signed_proptest.rs
+++ b/subduction_crypto/tests/signed_proptest.rs
@@ -247,7 +247,7 @@ fn plain_round_trip_seal_decode_verify() {
         .with_arbitrary::<(PlainPayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let bytes = seal_sync(*key_bytes, payload);
-            let signed = Signed::<PlainPayload>::try_decode(bytes).expect("decode");
+            let signed = Signed::<PlainPayload>::try_decode(&bytes).expect("decode");
             let verified = signed.try_verify().expect("verify");
             assert_eq!(verified.payload(), payload);
         });
@@ -259,7 +259,7 @@ fn tagged_round_trip_seal_decode_verify() {
         .with_arbitrary::<(TaggedPayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let bytes = seal_sync(*key_bytes, payload);
-            let signed = Signed::<TaggedPayload>::try_decode(bytes).expect("decode");
+            let signed = Signed::<TaggedPayload>::try_decode(&bytes).expect("decode");
             let verified = signed.try_verify().expect("verify");
             assert_eq!(verified.payload(), payload);
         });
@@ -271,7 +271,7 @@ fn variable_round_trip_seal_decode_verify() {
         .with_arbitrary::<(VariablePayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let bytes = seal_sync(*key_bytes, payload);
-            let signed = Signed::<VariablePayload>::try_decode(bytes).expect("decode");
+            let signed = Signed::<VariablePayload>::try_decode(&bytes).expect("decode");
             let verified = signed.try_verify().expect("verify");
             assert_eq!(verified.payload(), payload);
         });
@@ -291,7 +291,7 @@ fn plain_decode_preserves_canonical_bytes() {
         .with_arbitrary::<(PlainPayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let original = seal_sync(*key_bytes, payload);
-            let signed = Signed::<PlainPayload>::try_decode(original.clone()).expect("decode");
+            let signed = Signed::<PlainPayload>::try_decode(&original).expect("decode");
             assert_eq!(signed.as_bytes(), original.as_slice());
         });
 }
@@ -302,7 +302,7 @@ fn tagged_decode_preserves_canonical_bytes() {
         .with_arbitrary::<(TaggedPayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let original = seal_sync(*key_bytes, payload);
-            let signed = Signed::<TaggedPayload>::try_decode(original.clone()).expect("decode");
+            let signed = Signed::<TaggedPayload>::try_decode(&original).expect("decode");
             assert_eq!(signed.as_bytes(), original.as_slice());
         });
 }
@@ -313,7 +313,7 @@ fn variable_decode_preserves_canonical_bytes() {
         .with_arbitrary::<(VariablePayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let original = seal_sync(*key_bytes, payload);
-            let signed = Signed::<VariablePayload>::try_decode(original.clone()).expect("decode");
+            let signed = Signed::<VariablePayload>::try_decode(&original).expect("decode");
             assert_eq!(signed.as_bytes(), original.as_slice());
         });
 }
@@ -338,7 +338,7 @@ fn plain_decode_truncates_trailing_bytes() {
             with_trailing.extend_from_slice(trailing);
 
             let signed =
-                Signed::<PlainPayload>::try_decode(with_trailing).expect("decode with trailing");
+                Signed::<PlainPayload>::try_decode(&with_trailing).expect("decode with trailing");
             assert_eq!(
                 signed.as_bytes().len(),
                 canonical_len,
@@ -360,7 +360,7 @@ fn tagged_decode_truncates_trailing_bytes() {
             with_trailing.extend_from_slice(trailing);
 
             let signed =
-                Signed::<TaggedPayload>::try_decode(with_trailing).expect("decode with trailing");
+                Signed::<TaggedPayload>::try_decode(&with_trailing).expect("decode with trailing");
             assert_eq!(signed.as_bytes().len(), canonical_len);
             signed.try_verify().expect("verify after truncation");
         });
@@ -376,8 +376,8 @@ fn variable_decode_truncates_trailing_bytes() {
             let mut with_trailing = canonical.clone();
             with_trailing.extend_from_slice(trailing);
 
-            let signed =
-                Signed::<VariablePayload>::try_decode(with_trailing).expect("decode with trailing");
+            let signed = Signed::<VariablePayload>::try_decode(&with_trailing)
+                .expect("decode with trailing");
             assert_eq!(signed.as_bytes().len(), canonical_len);
             signed.try_verify().expect("verify after truncation");
         });
@@ -396,7 +396,7 @@ fn plain_decode_truncated_does_not_panic() {
             let mut bytes = seal_sync(*key_bytes, payload);
             let new_len = bytes.len().saturating_sub(*drop_count as usize);
             bytes.truncate(new_len);
-            let _result = Signed::<PlainPayload>::try_decode(bytes);
+            let _result = Signed::<PlainPayload>::try_decode(&bytes);
         });
 }
 
@@ -408,7 +408,7 @@ fn tagged_decode_truncated_does_not_panic() {
             let mut bytes = seal_sync(*key_bytes, payload);
             let new_len = bytes.len().saturating_sub(*drop_count as usize);
             bytes.truncate(new_len);
-            let _result = Signed::<TaggedPayload>::try_decode(bytes);
+            let _result = Signed::<TaggedPayload>::try_decode(&bytes);
         });
 }
 
@@ -420,7 +420,7 @@ fn variable_decode_truncated_does_not_panic() {
             let mut bytes = seal_sync(*key_bytes, payload);
             let new_len = bytes.len().saturating_sub(*drop_count as usize);
             bytes.truncate(new_len);
-            let _result = Signed::<VariablePayload>::try_decode(bytes);
+            let _result = Signed::<VariablePayload>::try_decode(&bytes);
         });
 }
 
@@ -431,7 +431,7 @@ fn random_bytes_through_plain_signed_never_panics() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<PlainPayload>::try_decode(bytes.clone());
+            let _result = Signed::<PlainPayload>::try_decode(&bytes);
         });
 }
 
@@ -440,7 +440,7 @@ fn random_bytes_through_tagged_signed_never_panics() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<TaggedPayload>::try_decode(bytes.clone());
+            let _result = Signed::<TaggedPayload>::try_decode(&bytes);
         });
 }
 
@@ -449,7 +449,7 @@ fn random_bytes_through_variable_signed_never_panics() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<VariablePayload>::try_decode(bytes.clone());
+            let _result = Signed::<VariablePayload>::try_decode(&bytes);
         });
 }
 
@@ -467,7 +467,7 @@ fn plain_schema_tamper_yields_invalid_schema() {
             }
             let mut bytes = seal_sync(*key_bytes, payload);
             bytes[..4].copy_from_slice(bad_schema);
-            let result = Signed::<PlainPayload>::try_decode(bytes);
+            let result = Signed::<PlainPayload>::try_decode(&bytes);
             assert!(
                 matches!(
                     result,
@@ -490,7 +490,7 @@ fn tagged_discriminant_tamper_yields_invalid_discriminant() {
             }
             let mut bytes = seal_sync(*key_bytes, payload);
             bytes[SCHEMA_SIZE] = *bad_disc;
-            let result = Signed::<TaggedPayload>::try_decode(bytes);
+            let result = Signed::<TaggedPayload>::try_decode(&bytes);
             assert!(
                 matches!(
                     result,
@@ -519,7 +519,7 @@ fn tag_swap_attack_is_rejected() {
 
             // Decoding as OtherTaggedPayload must reject due to
             // discriminant mismatch.
-            let result = Signed::<OtherTaggedPayload>::try_decode(bytes);
+            let result = Signed::<OtherTaggedPayload>::try_decode(&bytes);
             assert!(
                 matches!(
                     result,
@@ -552,7 +552,7 @@ fn plain_single_bit_flip_breaks_verification() {
 
             // Either decode fails or verify fails — never both succeed.
             // A decode failure is acceptable; we only assert on the Ok branch.
-            if let Ok(signed) = Signed::<PlainPayload>::try_decode(bytes) {
+            if let Ok(signed) = Signed::<PlainPayload>::try_decode(&bytes) {
                 let verify_result = signed.try_verify();
                 assert!(
                     verify_result.is_err(),
@@ -575,7 +575,7 @@ fn tagged_single_bit_flip_breaks_verification() {
             let bit_idx = bit_idx_seed % 8;
             bytes[byte_idx] ^= 1 << bit_idx;
 
-            if let Ok(signed) = Signed::<TaggedPayload>::try_decode(bytes) {
+            if let Ok(signed) = Signed::<TaggedPayload>::try_decode(&bytes) {
                 let verify_result = signed.try_verify();
                 assert!(verify_result.is_err(), "tampered bytes must not verify");
             }
@@ -595,7 +595,7 @@ fn variable_single_bit_flip_breaks_verification() {
             let bit_idx = bit_idx_seed % 8;
             bytes[byte_idx] ^= 1 << bit_idx;
 
-            if let Ok(signed) = Signed::<VariablePayload>::try_decode(bytes) {
+            if let Ok(signed) = Signed::<VariablePayload>::try_decode(&bytes) {
                 let verify_result = signed.try_verify();
                 assert!(verify_result.is_err(), "tampered bytes must not verify");
             }
@@ -613,7 +613,7 @@ fn wire_layout_slices_agree() {
         .with_arbitrary::<(PlainPayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let bytes = seal_sync(*key_bytes, payload);
-            let signed = Signed::<PlainPayload>::try_decode(bytes.clone()).expect("decode");
+            let signed = Signed::<PlainPayload>::try_decode(&bytes).expect("decode");
 
             assert_eq!(signed.as_bytes(), &bytes[..]);
 
@@ -639,7 +639,7 @@ fn wire_layout_slices_agree_tagged() {
         .with_arbitrary::<(TaggedPayload, [u8; 32])>()
         .for_each(|(payload, key_bytes)| {
             let bytes = seal_sync(*key_bytes, payload);
-            let signed = Signed::<TaggedPayload>::try_decode(bytes.clone()).expect("decode");
+            let signed = Signed::<TaggedPayload>::try_decode(&bytes).expect("decode");
 
             // For a tagged payload, fields starts after schema + disc
             // (1 byte) + issuer.

--- a/subduction_ephemeral/src/message.rs
+++ b/subduction_ephemeral/src/message.rs
@@ -331,7 +331,7 @@ fn decode_message(bytes: &[u8]) -> Result<EphemeralMessage, DecodeError> {
         tags::EPHEMERAL => {
             // The full bytes are a Signed<EphemeralPayload>.
             // The discriminant at byte 4 is validated by Signed::try_decode.
-            let signed = Signed::<EphemeralPayload>::try_decode(bytes.to_vec())?;
+            let signed = Signed::<EphemeralPayload>::try_decode(bytes)?;
             Ok(EphemeralMessage::Ephemeral(Box::new(signed)))
         }
         tags::SUBSCRIBE | tags::UNSUBSCRIBE | tags::SUBSCRIBE_REJECTED => {
@@ -605,7 +605,7 @@ mod tests {
         let sig_start = bytes.len() - 64;
         bytes[sig_start] ^= 0xFF;
 
-        let tampered = Signed::<EphemeralPayload>::try_decode(bytes);
+        let tampered = Signed::<EphemeralPayload>::try_decode(&bytes);
         if let Ok(s) = tampered {
             assert!(
                 s.try_verify().is_err(),

--- a/subduction_ephemeral/tests/amplification.rs
+++ b/subduction_ephemeral/tests/amplification.rs
@@ -617,7 +617,7 @@ async fn cross_edge_duplicate_with_corrupted_signature_is_dropped_silently() -> 
     let mut bytes = good_signed.into_bytes();
     let sig_start = bytes.len() - subduction_crypto::signed::SIGNATURE_SIZE;
     bytes[sig_start] ^= 0xFF;
-    let tampered_signed = Signed::<EphemeralPayload>::try_decode(bytes)
+    let tampered_signed = Signed::<EphemeralPayload>::try_decode(&bytes)
         .expect("flipping a signature byte must leave the wire structure valid");
     let tampered = EphemeralMessage::Ephemeral(Box::new(tampered_signed));
 

--- a/subduction_ephemeral/tests/codec_proptest.rs
+++ b/subduction_ephemeral/tests/codec_proptest.rs
@@ -194,7 +194,7 @@ fn ephemeral_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<EphemeralPayload>::try_decode(&bytes);
+            let _result = Signed::<EphemeralPayload>::try_decode(bytes);
         });
 }
 

--- a/subduction_ephemeral/tests/codec_proptest.rs
+++ b/subduction_ephemeral/tests/codec_proptest.rs
@@ -183,7 +183,7 @@ fn ephemeral_signed_round_trip() {
         .for_each(|(inputs, key_bytes)| {
             let payload = build_payload(inputs);
             let bytes = seal_sync(*key_bytes, &payload);
-            let signed = Signed::<EphemeralPayload>::try_decode(bytes).expect("decode");
+            let signed = Signed::<EphemeralPayload>::try_decode(&bytes).expect("decode");
             let verified = signed.try_verify().expect("verify");
             assert_eq!(verified.payload(), &payload);
         });
@@ -194,7 +194,7 @@ fn ephemeral_signed_decode_random_bytes_no_panic() {
     bolero::check!()
         .with_arbitrary::<Vec<u8>>()
         .for_each(|bytes| {
-            let _result = Signed::<EphemeralPayload>::try_decode(bytes.clone());
+            let _result = Signed::<EphemeralPayload>::try_decode(&bytes);
         });
 }
 
@@ -209,7 +209,7 @@ fn ephemeral_signed_truncates_trailing_bytes() {
             let mut with_trailing = canonical.clone();
             with_trailing.extend_from_slice(trailing);
 
-            let signed = Signed::<EphemeralPayload>::try_decode(with_trailing)
+            let signed = Signed::<EphemeralPayload>::try_decode(&with_trailing)
                 .expect("decode with trailing");
             assert_eq!(signed.as_bytes().len(), canonical_len);
             signed.try_verify().expect("verify after truncation");
@@ -225,7 +225,7 @@ fn ephemeral_signed_truncation_does_not_panic() {
             let mut bytes = seal_sync(*key_bytes, &payload);
             let new_len = bytes.len().saturating_sub(*drop_count as usize);
             bytes.truncate(new_len);
-            let _result = Signed::<EphemeralPayload>::try_decode(bytes);
+            let _result = Signed::<EphemeralPayload>::try_decode(&bytes);
         });
 }
 
@@ -243,7 +243,7 @@ fn ephemeral_signed_bit_flip_breaks_verification() {
             let bit_idx = bit_idx_seed % 8;
             bytes[byte_idx] ^= 1 << bit_idx;
 
-            if let Ok(signed) = Signed::<EphemeralPayload>::try_decode(bytes) {
+            if let Ok(signed) = Signed::<EphemeralPayload>::try_decode(&bytes) {
                 assert!(
                     signed.try_verify().is_err(),
                     "tampered Ephemeral bytes must not verify"

--- a/subduction_ephemeral/tests/ephemeral_handler.rs
+++ b/subduction_ephemeral/tests/ephemeral_handler.rs
@@ -890,7 +890,7 @@ async fn invalid_signature_is_dropped() -> TestResult {
 
     // Reconstruct a Signed<EphemeralPayload> from the tampered bytes.
     // try_decode may succeed (the bytes are structurally valid, just the sig is wrong).
-    let tampered = Signed::<EphemeralPayload>::try_decode(bytes);
+    let tampered = Signed::<EphemeralPayload>::try_decode(&bytes);
     let tampered_msg = match tampered {
         Ok(s) => EphemeralMessage::Ephemeral(Box::new(s)),
         Err(_) => {


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

- Reduce memory use on decode
- Was a problem on pathologically sized Sedimentrees

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
