### PR TITLE
Per-peer rate limiting (instead of global limit)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1781117444,
-        "narHash": "sha256-jzhqUdwjqkFVAHClmjoK1ROmFLJzs8rSHm8Y+OZqBSM=",
+        "lastModified": 1781793837,
+        "narHash": "sha256-T9/Q/A5B/Q1hC65fdwCz0aKVN7u1MDXGQXMKgoMQ1Hw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9fbf8d5b7ea867085c92fdbe0581bd77f8081cf",
+        "rev": "05eced6879632fc2f62fec56f2e33269157984ef",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780902259,
-        "narHash": "sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ=",
+        "lastModified": 1781216227,
+        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd0ff2d3eac24699c3664d5966b9ef36f388e2ca",
+        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
         "type": "github"
       },
       "original": {
@@ -132,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781061510,
-        "narHash": "sha256-tVuGHgt/TsWu1rUAqEL+eWRIJJHtiPE2+yQ63b+/WTU=",
+        "lastModified": 1781839264,
+        "narHash": "sha256-B0RwmQxE9TqI9XAdgHKGHavdcuhqM2nMoW/PVh8X14A=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d286e9691bb03045febbf8304a658eab1487d1b5",
+        "rev": "ee87764910f5d67d18694a7eb94bc0d7ae9f4655",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     "wasm-bodge-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777388480,
-        "narHash": "sha256-kMiTQnU/NVIhRnwp/YEW3lU9r0O/rkLSPOeBTznXHoc=",
+        "lastModified": 1781614223,
+        "narHash": "sha256-KZipWAFr9Dg6JyVNULRr/o33llxjd68Rphh/THKLK4s=",
         "owner": "alexjg",
         "repo": "wasm-bodge",
-        "rev": "58e0d9b2c3b749d81df7813e380432d04a904f23",
+        "rev": "2700e4b60ccfd346bdace2b3af78141a1a9511e8",
         "type": "github"
       },
       "original": {

--- a/subduction_cli/monitoring/grafana/provisioning/dashboards/subduction.json
+++ b/subduction_cli/monitoring/grafana/provisioning/dashboards/subduction.json
@@ -51,15 +51,14 @@
     {
       "type": "stat",
       "title": "Dispatch In-Flight",
-      "description": "Messages currently being dispatched vs the semaphore ceiling. Approaching max means inbound processing is saturating.",
+      "description": "Messages currently being dispatched across all peers.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 5, "w": 5, "x": 4, "y": 1 },
       "id": 2,
       "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 512 }, { "color": "red", "value": 900 }] }, "unit": "none" }, "overrides": [] },
       "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "value_and_name" },
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "subduction_dispatch_inflight", "legendFormat": "in-flight", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "subduction_dispatch_inflight_max", "legendFormat": "max", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "subduction_dispatch_inflight", "legendFormat": "in-flight", "refId": "A" }
       ]
     },
     {
@@ -103,15 +102,14 @@
     },
     {
       "type": "timeseries",
-      "title": "Dispatch In-Flight vs Max",
+      "title": "Dispatch In-Flight Over Time",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 7, "w": 8, "x": 0, "y": 7 },
       "id": 10,
-      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 1, "showPoints": "never" }, "unit": "none" }, "overrides": [{ "matcher": { "id": "byName", "options": "max" }, "properties": [{ "id": "custom.lineStyle", "value": { "dash": [8, 4], "fill": "dash" } }, { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] }] },
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 1, "showPoints": "never" }, "unit": "none" }, "overrides": [] },
       "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "subduction_dispatch_inflight", "legendFormat": "in-flight", "refId": "A" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "subduction_dispatch_inflight_max", "legendFormat": "max", "refId": "B" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "subduction_dispatch_inflight", "legendFormat": "in-flight", "refId": "A" }
       ]
     },
     {
@@ -339,15 +337,15 @@
     },
     {
       "type": "timeseries",
-      "title": "Sedimentree Cache Hit Ratio (read paths)",
-      "description": "Fraction of READ-path sedimentree resolutions (heads lookups, foreground sync, get_commits) served from the in-memory LRU vs. hydrated from storage. A low ratio means hydration (and its minimization) is on the read hot path. NOTE: a pure write-through relay exercises these read paths rarely, so low sample counts here are expected and not a problem — watch it under foreground-sync load.",
+      "title": "Sedimentree Cache Miss Ratio (read paths)",
+      "description": "Fraction of READ-path sedimentree resolutions (heads lookups, foreground sync, get_commits) hydrated from storage rather than served from the in-memory LRU. A high ratio means hydration (and its minimization) is on the read hot path. NOTE: a pure write-through relay exercises these read paths rarely, so low sample counts here are expected and not a problem — watch it under foreground-sync load.",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 7, "w": 12, "x": 0, "y": 52 },
       "id": 43,
       "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1, "showPoints": "never" }, "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
       "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "(sum(rate(subduction_sedimentree_cache_hits_total[5m])) or vector(0)) / clamp_min((sum(rate(subduction_sedimentree_cache_hits_total[5m])) or vector(0)) + (sum(rate(subduction_sedimentree_cache_misses_total[5m])) or vector(0)), 1)", "legendFormat": "hit ratio", "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "(sum(rate(subduction_sedimentree_cache_misses_total[5m])) or vector(0)) / clamp_min((sum(rate(subduction_sedimentree_cache_hits_total[5m])) or vector(0)) + (sum(rate(subduction_sedimentree_cache_misses_total[5m])) or vector(0)), 1)", "legendFormat": "miss ratio", "refId": "A" }
       ]
     },
     {

--- a/subduction_core/src/connection/manager.rs
+++ b/subduction_core/src/connection/manager.rs
@@ -10,16 +10,60 @@
 //! - [`ConnectionId`]: Logical identifier that survives reconnects (returned to caller)
 //! - `TaskId`: Internal identifier for the spawned task (changes on reconnect)
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{
+    sync::{Arc, Weak},
+    vec::Vec,
+};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use async_lock::Mutex;
+use async_lock::{Mutex, Semaphore, SemaphoreGuardArc};
 use future_form::{FutureForm, Local, Sendable, future_form};
 use futures::stream::AbortHandle;
-use sedimentree_core::codec::{decode::Decode, encode::Encode};
+use sedimentree_core::{
+    codec::{decode::Decode, encode::Encode},
+    collections::Map,
+};
 
 use super::{Connection, id::ConnectionId};
 use crate::peer::id::PeerId;
+
+/// Maximum number of inbound handler-dispatch slots kept in flight **per peer**.
+///
+/// Each peer gets its own [`Semaphore`] with this many permits, shared across
+/// all of that peer's connections. A reader acquires a permit before admitting
+/// a request (see [`connection_loop`]) and holds it until the spawned handler
+/// completes, so a single peer can have at most this many handlers in flight
+/// (queued or running) at once.
+///
+/// When a peer hits the cap its reader stops pulling from the connection, so
+/// backpressure flows back to *that peer's* transport alone (its bounded
+/// inbound channel fills) — a slow or hostile peer can no longer starve
+/// dispatch for everyone else, which a single global cap allowed.
+pub(crate) const MAX_INFLIGHT_DISPATCH_PER_PEER: usize = 512;
+
+/// Get or create the per-peer dispatch [`Semaphore`], shared across all of a
+/// peer's connections.
+///
+/// The registry holds [`Weak`] references: a peer's semaphore stays alive only
+/// while one of its `connection_loop`s — or a still-running dispatch task
+/// holding a permit — keeps an `Arc`. Once the last holder drops, the `Weak`
+/// dangles and is pruned on the next miss, so the registry can't grow unbounded
+/// across peer churn. A reconnecting peer whose tasks are still draining
+/// re-shares the same semaphore, so its in-flight budget carries across the
+/// handoff.
+fn slots_for(peer: PeerId, registry: &mut Map<PeerId, Weak<Semaphore>>) -> Arc<Semaphore> {
+    if let Some(live) = registry.get(&peer).and_then(Weak::upgrade) {
+        return live;
+    }
+
+    // Miss: this peer has no live semaphore. Drop any other dangling entries
+    // before inserting so peers that departed for good can't accumulate.
+    registry.retain(|_, weak| weak.strong_count() > 0);
+
+    let slots = Arc::new(Semaphore::new(MAX_INFLIGHT_DISPATCH_PER_PEER));
+    registry.insert(peer, Arc::downgrade(&slots));
+    slots
+}
 
 /// Internal task identifier for abort handle tracking.
 ///
@@ -88,8 +132,13 @@ pub struct ConnectionManager<
     /// Inbound commands (add/remove connections).
     commands: async_channel::Receiver<Command<Conn>>,
 
-    /// Outbound messages from all connections (bounded — provides backpressure).
-    messages: async_channel::Sender<(Conn, WireMsg)>,
+    /// Outbound (non-response) messages from all connections (bounded —
+    /// provides backpressure).
+    ///
+    /// Each message carries a [`SemaphoreGuardArc`] from its peer's dispatch
+    /// semaphore, acquired in [`connection_loop`] and held until the spawned
+    /// handler completes, which caps in-flight dispatches per peer.
+    messages: async_channel::Sender<(Conn, WireMsg, SemaphoreGuardArc)>,
 
     /// Fast path for response messages (bounded at high capacity).
     ///
@@ -120,7 +169,7 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>>
     pub fn new(
         spawner: Spawner,
         commands: async_channel::Receiver<Command<Conn>>,
-        messages: async_channel::Sender<(Conn, WireMsg)>,
+        messages: async_channel::Sender<(Conn, WireMsg, SemaphoreGuardArc)>,
         responses: async_channel::Sender<(Conn, WireMsg)>,
         is_response: fn(&WireMsg) -> bool,
         closed: async_channel::Sender<(ConnectionId, Conn)>,
@@ -215,6 +264,11 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode> RunManager<Conn, WireMsg
         manager: ConnectionManager<Self, Conn, WireMsg, Spawner>,
     ) -> Self::Future<'static, ()> {
         Async::from_future(async move {
+            // Per-peer dispatch semaphores, shared across a peer's connections.
+            // Owned by this single command loop, so no extra synchronization is
+            // needed; spawned `connection_loop`s only hold an `Arc` clone.
+            let mut dispatch_registry: Map<PeerId, Weak<Semaphore>> = Map::new();
+
             while let Ok(cmd) = manager.commands.recv().await {
                 match cmd {
                     Command::Add(conn, peer_id) => {
@@ -230,6 +284,7 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode> RunManager<Conn, WireMsg
                         let is_response = manager.is_response;
                         let closed = manager.closed.clone();
                         let conn_clone = conn.clone();
+                        let dispatch_slots = slots_for(peer_id, &mut dispatch_registry);
 
                         let fut = Async::from_future(async move {
                             connection_loop(
@@ -238,6 +293,7 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode> RunManager<Conn, WireMsg
                                 messages,
                                 responses,
                                 is_response,
+                                dispatch_slots,
                             )
                             .await;
 
@@ -272,6 +328,7 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode> RunManager<Conn, WireMsg
                         let is_response = manager.is_response;
                         let closed = manager.closed.clone();
                         let conn_clone = conn.clone();
+                        let dispatch_slots = slots_for(peer_id, &mut dispatch_registry);
 
                         let fut = Async::from_future(async move {
                             connection_loop(
@@ -280,6 +337,7 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode> RunManager<Conn, WireMsg
                                 messages,
                                 responses,
                                 is_response,
+                                dispatch_slots,
                             )
                             .await;
 
@@ -337,22 +395,34 @@ async fn connection_loop<
 >(
     conn: Conn,
     peer_id: PeerId,
-    messages: async_channel::Sender<(Conn, WireMsg)>,
+    messages: async_channel::Sender<(Conn, WireMsg, SemaphoreGuardArc)>,
     responses: async_channel::Sender<(Conn, WireMsg)>,
     is_response: fn(&WireMsg) -> bool,
+    dispatch_slots: Arc<Semaphore>,
 ) {
     loop {
         match conn.recv().await {
             Ok(msg) => {
                 tracing::trace!(peer = %peer_id, "connection received message");
-                let sender = if is_response(&msg) {
-                    &responses
+                if is_response(&msg) {
+                    // Responses use the fast path and are never throttled: they
+                    // resolve a pending caller rather than spawning a handler.
+                    if responses.send((conn.clone(), msg)).await.is_err() {
+                        tracing::warn!(peer = %peer_id, "connection response channel closed");
+                        break;
+                    }
                 } else {
-                    &messages
-                };
-                if sender.send((conn.clone(), msg)).await.is_err() {
-                    tracing::warn!(peer = %peer_id, "connection message channel closed");
-                    break;
+                    // Acquire a per-peer dispatch slot BEFORE admitting the
+                    // request. At the cap this awaits, so the loop stops calling
+                    // `conn.recv()` and backpressure flows to *this* peer's
+                    // transport (its bounded inbound channel fills) without
+                    // affecting other peers. The permit rides the queue and is
+                    // released when the spawned handler completes.
+                    let permit = dispatch_slots.acquire_arc().await;
+                    if messages.send((conn.clone(), msg, permit)).await.is_err() {
+                        tracing::warn!(peer = %peer_id, "connection message channel closed");
+                        break;
+                    }
                 }
             }
             Err(e) => {

--- a/subduction_core/src/connection/manager.rs
+++ b/subduction_core/src/connection/manager.rs
@@ -27,18 +27,16 @@ use sedimentree_core::{
 use super::{Connection, id::ConnectionId};
 use crate::peer::id::PeerId;
 
-/// Maximum number of inbound handler-dispatch slots kept in flight **per peer**.
+/// Maximum number of inbound handler-dispatch slots kept in flight per peer.
 ///
 /// Each peer gets its own [`Semaphore`] with this many permits, shared across
 /// all of that peer's connections. A reader acquires a permit before admitting
 /// a request (see [`connection_loop`]) and holds it until the spawned handler
-/// completes, so a single peer can have at most this many handlers in flight
-/// (queued or running) at once.
+/// completes, capping a peer's concurrent (queued or running) handlers.
 ///
-/// When a peer hits the cap its reader stops pulling from the connection, so
-/// backpressure flows back to *that peer's* transport alone (its bounded
-/// inbound channel fills) — a slow or hostile peer can no longer starve
-/// dispatch for everyone else, which a single global cap allowed.
+/// At the cap the reader stops pulling from the connection, so a flooding or
+/// slow peer backpressures its own transport rather than consuming a shared
+/// dispatch budget.
 pub(crate) const MAX_INFLIGHT_DISPATCH_PER_PEER: usize = 512;
 
 /// Get or create the per-peer dispatch [`Semaphore`], shared across all of a
@@ -412,12 +410,10 @@ async fn connection_loop<
                         break;
                     }
                 } else {
-                    // Acquire a per-peer dispatch slot BEFORE admitting the
-                    // request. At the cap this awaits, so the loop stops calling
-                    // `conn.recv()` and backpressure flows to *this* peer's
-                    // transport (its bounded inbound channel fills) without
-                    // affecting other peers. The permit rides the queue and is
-                    // released when the spawned handler completes.
+                    // Acquire this peer's dispatch slot before forwarding. At
+                    // the cap this awaits, pausing `conn.recv()` for this peer
+                    // only; the permit rides the queue and releases when the
+                    // handler completes.
                     let permit = dispatch_slots.acquire_arc().await;
                     if messages.send((conn.clone(), msg, permit)).await.is_err() {
                         tracing::warn!(peer = %peer_id, "connection message channel closed");

--- a/subduction_core/src/metrics.rs
+++ b/subduction_core/src/metrics.rs
@@ -24,8 +24,6 @@ pub mod names {
     pub const DISPATCH_DURATION_SECONDS: &str = "subduction_dispatch_duration_seconds";
     /// Inbound messages currently being dispatched across all peers.
     pub const DISPATCH_INFLIGHT: &str = "subduction_dispatch_inflight";
-    /// Per-peer in-flight dispatch ceiling (the per-peer semaphore bound).
-    pub const DISPATCH_INFLIGHT_MAX: &str = "subduction_dispatch_inflight_max";
     /// Completed dispatch tasks, labeled by `outcome` (`ok`/`err`/`aborted`).
     pub const DISPATCH_COMPLETED_TOTAL: &str = "subduction_dispatch_completed_total";
     /// Total batch sync requests received.
@@ -173,13 +171,6 @@ pub fn dispatch_inflight_inc() {
 #[inline]
 pub fn dispatch_inflight_dec() {
     metrics::gauge!(names::DISPATCH_INFLIGHT).decrement(1.0);
-}
-
-/// Publish the per-peer in-flight dispatch ceiling (set once at listener start).
-#[inline]
-#[allow(clippy::cast_precision_loss)]
-pub fn set_dispatch_inflight_max(max: usize) {
-    metrics::gauge!(names::DISPATCH_INFLIGHT_MAX).set(max as f64);
 }
 
 /// Record a completed dispatch task, labeled by outcome.
@@ -395,10 +386,6 @@ pub fn describe_all() {
     metrics::describe_gauge!(
         names::DISPATCH_INFLIGHT,
         "Inbound messages currently being dispatched across all peers."
-    );
-    metrics::describe_gauge!(
-        names::DISPATCH_INFLIGHT_MAX,
-        "Per-peer in-flight dispatch ceiling (per-peer semaphore bound)."
     );
     metrics::describe_counter!(
         names::DISPATCH_COMPLETED_TOTAL,

--- a/subduction_core/src/metrics.rs
+++ b/subduction_core/src/metrics.rs
@@ -22,9 +22,9 @@ pub mod names {
     pub const MESSAGES_TOTAL: &str = "subduction_messages_total";
     /// Message dispatch duration in seconds.
     pub const DISPATCH_DURATION_SECONDS: &str = "subduction_dispatch_duration_seconds";
-    /// Inbound messages currently being dispatched (held semaphore permits).
+    /// Inbound messages currently being dispatched across all peers.
     pub const DISPATCH_INFLIGHT: &str = "subduction_dispatch_inflight";
-    /// Maximum concurrent in-flight dispatches (the semaphore bound).
+    /// Per-peer in-flight dispatch ceiling (the per-peer semaphore bound).
     pub const DISPATCH_INFLIGHT_MAX: &str = "subduction_dispatch_inflight_max";
     /// Completed dispatch tasks, labeled by `outcome` (`ok`/`err`/`aborted`).
     pub const DISPATCH_COMPLETED_TOTAL: &str = "subduction_dispatch_completed_total";
@@ -175,7 +175,7 @@ pub fn dispatch_inflight_dec() {
     metrics::gauge!(names::DISPATCH_INFLIGHT).decrement(1.0);
 }
 
-/// Publish the in-flight dispatch ceiling (set once at listener start).
+/// Publish the per-peer in-flight dispatch ceiling (set once at listener start).
 #[inline]
 #[allow(clippy::cast_precision_loss)]
 pub fn set_dispatch_inflight_max(max: usize) {
@@ -394,11 +394,11 @@ pub fn describe_all() {
     );
     metrics::describe_gauge!(
         names::DISPATCH_INFLIGHT,
-        "Inbound messages currently being dispatched (held semaphore permits)."
+        "Inbound messages currently being dispatched across all peers."
     );
     metrics::describe_gauge!(
         names::DISPATCH_INFLIGHT_MAX,
-        "Maximum concurrent in-flight dispatches (semaphore bound)."
+        "Per-peer in-flight dispatch ceiling (per-peer semaphore bound)."
     );
     metrics::describe_counter!(
         names::DISPATCH_COMPLETED_TOTAL,

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -92,7 +92,7 @@ use crate::{
 };
 use alloc::{collections::BTreeSet, sync::Arc, vec::Vec};
 use async_channel::{Sender, bounded};
-use async_lock::{Mutex, Semaphore, SemaphoreGuardArc};
+use async_lock::{Mutex, SemaphoreGuardArc};
 use core::{marker::PhantomData, time::Duration};
 use dispatch_completion::{DispatchCompletion, DispatchOutcome};
 use error::{
@@ -127,18 +127,6 @@ use spawn_guard::AbortOnDrop;
 use subduction_crypto::{
     signed::Signed, signer::Signer, verified_author::VerifiedAuthor, verified_meta::VerifiedMeta,
 };
-
-/// Maximum number of inbound handler-dispatch tasks the listener keeps in
-/// flight at once.
-///
-/// The listener spawns one task per inbound message; without a cap, a fast or
-/// hostile peer could make it drain the bounded `msg_queue` and spawn tasks
-/// faster than they complete, converting queue backpressure into unbounded
-/// runtime-task growth. While at the cap the listener stops accepting new
-/// messages and prioritises draining completions, so `msg_queue` backpressure
-/// flows back to the senders. Sized well above the queue's steady-state depth
-/// so it only engages under genuine overload.
-const MAX_INFLIGHT_DISPATCH: usize = 1024;
 
 /// The main synchronization manager for sedimentrees.
 #[derive(Debug, Clone)]
@@ -222,7 +210,8 @@ pub struct Subduction<
     send_counter: PeerCounter,
 
     manager_channel: Sender<Command<Authenticated<Conn, Async>>>,
-    msg_queue: async_channel::Receiver<(Authenticated<Conn, Async>, Hdl::Message)>,
+    msg_queue:
+        async_channel::Receiver<(Authenticated<Conn, Async>, Hdl::Message, SemaphoreGuardArc)>,
     response_queue: async_channel::Receiver<(Authenticated<Conn, Async>, Hdl::Message)>,
     connection_closed: async_channel::Receiver<(ConnectionId, Authenticated<Conn, Async>)>,
 
@@ -3167,10 +3156,14 @@ where
             async_channel::Receiver<DispatchOutcome<Conn, Async, Hdl::HandlerError>>,
         ) = async_channel::unbounded();
 
-        let dispatch_permits = Arc::new(Semaphore::new(MAX_INFLIGHT_DISPATCH));
-
+        // Per-peer dispatch admission lives in the connection manager: each
+        // peer has its own semaphore and a reader acquires a permit (carried on
+        // the `msg_queue` payload) before admitting a request. The listener no
+        // longer holds a global cap, so one peer can't starve the rest.
         #[cfg(feature = "metrics")]
-        crate::metrics::set_dispatch_inflight_max(MAX_INFLIGHT_DISPATCH);
+        crate::metrics::set_dispatch_inflight_max(
+            crate::connection::manager::MAX_INFLIGHT_DISPATCH_PER_PEER,
+        );
 
         loop {
             futures::select_biased! {
@@ -3247,13 +3240,11 @@ where
                     }
                 }
 
-                permitted = async {
-                    let permit = dispatch_permits.acquire_arc().await;
-                    let received = self.msg_queue.recv().await;
-                    (permit, received)
-                }.fuse() => {
-                    let (permit, msg_result) = permitted;
-                    if let Ok((conn, msg)) = msg_result {
+                received = self.msg_queue.recv().fuse() => {
+                    // The per-peer permit was acquired upstream in the
+                    // connection reader and rides the queue here; it's moved
+                    // into the dispatch task and released on completion.
+                    if let Ok((conn, msg, permit)) = received {
                         let peer_id = conn.peer_id();
                         // Don't Debug-format `msg` — it can embed commit/blob bytes.
                         tracing::trace!(peer = %peer_id, "listener received message");

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -3156,15 +3156,9 @@ where
             async_channel::Receiver<DispatchOutcome<Conn, Async, Hdl::HandlerError>>,
         ) = async_channel::unbounded();
 
-        // Per-peer dispatch admission lives in the connection manager: each
-        // peer has its own semaphore and a reader acquires a permit (carried on
-        // the `msg_queue` payload) before admitting a request. The listener no
-        // longer holds a global cap, so one peer can't starve the rest.
-        #[cfg(feature = "metrics")]
-        crate::metrics::set_dispatch_inflight_max(
-            crate::connection::manager::MAX_INFLIGHT_DISPATCH_PER_PEER,
-        );
-
+        // Dispatch admission is per-peer, enforced upstream in the connection
+        // manager (a reader acquires its peer's permit before forwarding); the
+        // listener just drains the queue and spawns.
         loop {
             futures::select_biased! {
                 done = done_rx.recv().fuse() => {

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -316,7 +316,7 @@ where
         tracing::info!("initializing Subduction instance");
 
         let (manager_sender, manager_receiver) = bounded(256);
-        let (queue_sender, queue_receiver) = async_channel::bounded(2048);
+        let (queue_sender, queue_receiver) = async_channel::bounded(4096);
         let (response_sender, response_receiver) = async_channel::bounded(8192);
         let (closed_sender, closed_receiver) = async_channel::bounded(32);
         let stored_spawner = spawner.clone();

--- a/subduction_core/src/subduction/dispatch_completion.rs
+++ b/subduction_core/src/subduction/dispatch_completion.rs
@@ -1,10 +1,10 @@
 //! Completion accounting for spawned inbound-dispatch tasks.
 //!
-//! The listener bounds in-flight dispatch tasks with a counter
-//! (`MAX_INFLIGHT_DISPATCH`): it increments on spawn and decrements when a task
-//! reports completion over an unbounded channel. If a task could finish without
-//! reporting — for instance by panicking before sending — the counter would
-//! ratchet up permanently and, once it hit the cap, wedge inbound processing.
+//! Each spawned task reports its outcome back to the listener over an unbounded
+//! channel. The listener uses the report to decrement the in-flight gauge and,
+//! on a handler error, to tear the connection down. A task that finished
+//! without reporting — for instance by panicking before sending — would leak
+//! its gauge increment and, worse, leave a failed connection un-condemned.
 //!
 //! [`DispatchCompletion`] guarantees a report on *every* exit path. The dispatch
 //! body records its outcome into the guard; the guard's [`Drop`] sends that

--- a/subduction_core/tests/dispatch_panic_recovery.rs
+++ b/subduction_core/tests/dispatch_panic_recovery.rs
@@ -1,17 +1,17 @@
 //! A panicking dispatch task must not wedge the listener.
 //!
-//! The listener bounds in-flight dispatch tasks with a counter and stops
-//! pulling new messages once it reaches `MAX_INFLIGHT_DISPATCH`. Each spawned
-//! task releases its slot through a completion guard that fires on drop — on the
-//! normal path *and* on unwind. So even a flood of panicking handler tasks
-//! cannot ratchet the in-flight count up permanently, and the listener keeps
-//! processing.
+//! Each peer's connection reader holds a per-peer dispatch semaphore
+//! (`MAX_INFLIGHT_DISPATCH_PER_PEER` permits) and acquires a permit before
+//! admitting a request; the permit rides the queue into the spawned handler
+//! task and is released when that task drops — on the normal path *and* on
+//! unwind. So even a flood of panicking handler tasks cannot permanently
+//! exhaust a peer's permits, and the reader keeps admitting work.
 //!
-//! This test drives more than `MAX_INFLIGHT_DISPATCH` panicking messages
-//! through a real listener, then a normal message, and asserts the normal one
-//! is still handled. Without the completion guard, the panics would never
-//! release their slots, the count would pin at the cap, and the final message
-//! would never be processed.
+//! This test drives more than `MAX_INFLIGHT_DISPATCH_PER_PEER` panicking
+//! messages from one peer through a real listener, then a normal message, and
+//! asserts the normal one is still handled. Without the permit's drop-release,
+//! the panics would never return their slots, the peer's semaphore would pin at
+//! the cap, and the final message would never be admitted.
 
 #![allow(clippy::expect_used, clippy::panic)]
 
@@ -102,8 +102,9 @@ async fn wait_for(limit: Duration, mut cond: impl FnMut() -> bool) -> bool {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn panicking_dispatch_tasks_do_not_wedge_the_listener() -> TestResult {
-    // Comfortably above the listener's `MAX_INFLIGHT_DISPATCH` (1024): without
-    // the completion guard, this many un-released slots would pin the gate.
+    // Comfortably above the per-peer cap `MAX_INFLIGHT_DISPATCH_PER_PEER` (512):
+    // without the permit's drop-release, this many un-returned slots would pin
+    // the peer's semaphore.
     const POISON_COUNT: usize = 1100;
 
     let handled = Arc::new(AtomicUsize::new(0));

--- a/subduction_core/tests/per_peer_dispatch_limit.rs
+++ b/subduction_core/tests/per_peer_dispatch_limit.rs
@@ -1,0 +1,210 @@
+//! Per-peer dispatch limiting: one peer saturating its in-flight budget must
+//! not starve another peer, and a saturated peer backpressures its *own*
+//! transport rather than the shared dispatch queue.
+//!
+//! A handler parks every message from a designated "slow" peer (holding its
+//! per-peer dispatch permit) until the test releases it, and counts messages
+//! from a "fast" peer. We flood the slow peer past its per-peer cap so its
+//! semaphore is fully held and its connection reader stops draining — observable
+//! as a backlog left in the slow peer's (unbounded) inbound channel — then
+//! assert the fast peer's message is still dispatched promptly.
+//!
+//! With the old single global cap, a peer holding the whole cap would block
+//! dispatch for everyone; the per-peer semaphore is what keeps the fast peer
+//! flowing here.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use core::time::Duration;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use future_form::Sendable;
+use sedimentree_core::{depth::CountLeadingZeroBytes, id::SedimentreeId};
+use subduction_core::{
+    authenticated::Authenticated,
+    connection::{
+        message::SyncMessage,
+        test_utils::{ChannelMockConnection, InstantTimeout, TokioSpawn, test_signer},
+    },
+    handler::sync::SyncHandler,
+    peer::id::PeerId,
+    policy::open::OpenPolicy,
+    remote_heads::{RemoteHeads, RemoteHeadsNotifier},
+    storage::memory::MemoryStorage,
+    subduction::builder::SubductionBuilder,
+};
+use testresult::TestResult;
+
+type Conn = ChannelMockConnection<SyncMessage>;
+type InnerHandler = SyncHandler<Sendable, MemoryStorage, Conn, OpenPolicy, CountLeadingZeroBytes>;
+
+/// Must match `MAX_INFLIGHT_DISPATCH_PER_PEER` in `connection::manager`. That
+/// constant is crate-private, so we pin it here; if it changes, the
+/// `entered_slow >= PER_PEER_CAP` wait below times out and flags the drift.
+const PER_PEER_CAP: usize = 512;
+
+/// Parks every message from `slow_peer` (holding its dispatch permit) until
+/// `release` is closed, and counts every message from any other peer. Always
+/// returns `Ok` so connections are never torn down.
+struct GatedHandler {
+    inner: Arc<InnerHandler>,
+    slow_peer: PeerId,
+    entered_slow: Arc<AtomicUsize>,
+    fast_handled: Arc<AtomicUsize>,
+    release: async_channel::Receiver<()>,
+}
+
+impl subduction_core::handler::Handler<Sendable, Conn> for GatedHandler {
+    type Message = SyncMessage;
+    type HandlerError =
+        <InnerHandler as subduction_core::handler::Handler<Sendable, Conn>>::HandlerError;
+
+    fn handle<'a>(
+        &'a self,
+        conn: &'a Authenticated<Conn, Sendable>,
+        _message: Self::Message,
+    ) -> <Sendable as future_form::FutureForm>::Future<'a, Result<(), Self::HandlerError>> {
+        let is_slow = conn.peer_id() == self.slow_peer;
+        <Sendable as future_form::FutureForm>::from_future(async move {
+            if is_slow {
+                // Mark the slot occupied, then park until released. The dispatch
+                // task holds this peer's permit for the whole time we're parked,
+                // so the slow peer's semaphore fills and stays full.
+                self.entered_slow.fetch_add(1, Ordering::SeqCst);
+                let _released = self.release.recv().await;
+            } else {
+                self.fast_handled.fetch_add(1, Ordering::SeqCst);
+            }
+
+            Ok(())
+        })
+    }
+
+    fn on_peer_disconnect(
+        &self,
+        peer: PeerId,
+    ) -> <Sendable as future_form::FutureForm>::Future<'_, ()> {
+        self.inner.on_peer_disconnect(peer)
+    }
+}
+
+impl RemoteHeadsNotifier for GatedHandler {
+    fn notify_remote_heads(&self, id: SedimentreeId, peer: PeerId, heads: RemoteHeads) {
+        self.inner.notify_remote_heads(id, peer, heads);
+    }
+}
+
+/// Poll `cond` until it holds or `limit` elapses; returns whether it held.
+async fn wait_for(limit: Duration, mut cond: impl FnMut() -> bool) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < limit {
+        if cond() {
+            return true;
+        }
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    cond()
+}
+
+fn heads_update(id: [u8; 32]) -> SyncMessage {
+    SyncMessage::HeadsUpdate {
+        id: SedimentreeId::new(id),
+        heads: RemoteHeads::default(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn saturated_peer_does_not_starve_another_peer() -> TestResult {
+    let slow_peer = PeerId::new([0xA1u8; 32]);
+    let fast_peer = PeerId::new([0xB2u8; 32]);
+
+    let entered_slow = Arc::new(AtomicUsize::new(0));
+    let fast_handled = Arc::new(AtomicUsize::new(0));
+    let (release_tx, release_rx) = async_channel::bounded::<()>(1);
+
+    let entered_for_handler = Arc::clone(&entered_slow);
+    let fast_for_handler = Arc::clone(&fast_handled);
+
+    let (sd, listener, manager, ()) = SubductionBuilder::new()
+        .signer(test_signer())
+        .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
+        .spawner(TokioSpawn)
+        .timer(InstantTimeout)
+        .build_composed::<Sendable, Conn, GatedHandler, ()>(|sync_handler| {
+            (
+                Arc::new(GatedHandler {
+                    inner: sync_handler,
+                    slow_peer,
+                    entered_slow: entered_for_handler,
+                    fast_handled: fast_for_handler,
+                    release: release_rx,
+                }),
+                (),
+            )
+        });
+
+    let listener_task = tokio::spawn(listener);
+    let manager_task = tokio::spawn(manager);
+
+    let (slow_conn, slow_handle) = ChannelMockConnection::new_with_handle(slow_peer);
+    let (fast_conn, fast_handle) = ChannelMockConnection::new_with_handle(fast_peer);
+    sd.add_connection(slow_conn.authenticated()).await?;
+    sd.add_connection(fast_conn.authenticated()).await?;
+
+    // Flood the slow peer past its per-peer cap. Its unbounded inbound channel
+    // absorbs the flood; the reader admits only `PER_PEER_CAP` before its
+    // semaphore is exhausted and it stops pulling.
+    const SLOW_FLOOD: usize = PER_PEER_CAP + 200;
+    for _ in 0..SLOW_FLOOD {
+        slow_handle.inbound_tx.send(heads_update([0xCCu8; 32])).await?;
+    }
+
+    // Wait until the slow peer holds its full per-peer budget in flight. The
+    // semaphore allows exactly `PER_PEER_CAP` concurrent handlers, so this
+    // plateaus at the cap — the next request is held at the reader's `acquire`.
+    let saturated = wait_for(Duration::from_secs(20), || {
+        entered_slow.load(Ordering::SeqCst) >= PER_PEER_CAP
+    })
+    .await;
+    assert!(
+        saturated,
+        "slow peer never reached its per-peer cap: entered_slow = {} (want {PER_PEER_CAP})",
+        entered_slow.load(Ordering::SeqCst)
+    );
+    assert_eq!(
+        entered_slow.load(Ordering::SeqCst),
+        PER_PEER_CAP,
+        "slow peer ran more than its per-peer cap of {PER_PEER_CAP} handlers concurrently"
+    );
+
+    // Backpressure: once the cap was hit the reader stopped draining, so the
+    // flood's remainder is still queued in the slow peer's inbound channel.
+    assert!(
+        slow_handle.inbound_tx.len() > 0,
+        "a saturated peer must backpressure its own inbound channel, not drain it"
+    );
+
+    // Isolation: a different peer's message is still dispatched promptly even
+    // though the slow peer is pinned at its cap.
+    fast_handle.inbound_tx.send(heads_update([7u8; 32])).await?;
+    let fast_progressed = wait_for(Duration::from_secs(5), || {
+        fast_handled.load(Ordering::SeqCst) >= 1
+    })
+    .await;
+    assert!(
+        fast_progressed,
+        "fast peer was starved by the saturated peer: fast_handled = {}",
+        fast_handled.load(Ordering::SeqCst)
+    );
+
+    // Release the parked slow handlers so teardown is clean.
+    release_tx.close();
+    listener_task.abort();
+    manager_task.abort();
+    Ok(())
+}

--- a/subduction_core/tests/per_peer_dispatch_limit.rs
+++ b/subduction_core/tests/per_peer_dispatch_limit.rs
@@ -8,10 +8,6 @@
 //! semaphore is fully held and its connection reader stops draining — observable
 //! as a backlog left in the slow peer's (unbounded) inbound channel — then
 //! assert the fast peer's message is still dispatched promptly.
-//!
-//! With the old single global cap, a peer holding the whole cap would block
-//! dispatch for everyone; the per-peer semaphore is what keeps the fast peer
-//! flowing here.
 
 #![allow(clippy::expect_used, clippy::panic)]
 

--- a/subduction_core/tests/per_peer_dispatch_limit.rs
+++ b/subduction_core/tests/per_peer_dispatch_limit.rs
@@ -162,7 +162,10 @@ async fn saturated_peer_does_not_starve_another_peer() -> TestResult {
     sd.add_connection(fast_conn.authenticated()).await?;
 
     for _ in 0..SLOW_FLOOD {
-        slow_handle.inbound_tx.send(heads_update([0xCCu8; 32])).await?;
+        slow_handle
+            .inbound_tx
+            .send(heads_update([0xCCu8; 32]))
+            .await?;
     }
 
     // Wait until the slow peer holds its full per-peer budget in flight. The

--- a/subduction_core/tests/per_peer_dispatch_limit.rs
+++ b/subduction_core/tests/per_peer_dispatch_limit.rs
@@ -120,6 +120,11 @@ fn heads_update(id: [u8; 32]) -> SyncMessage {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn saturated_peer_does_not_starve_another_peer() -> TestResult {
+    // Flood the slow peer past its per-peer cap. Its unbounded inbound channel
+    // absorbs the flood; the reader admits only `PER_PEER_CAP` before its
+    // semaphore is exhausted and it stops pulling.
+    const SLOW_FLOOD: usize = PER_PEER_CAP + 200;
+
     let slow_peer = PeerId::new([0xA1u8; 32]);
     let fast_peer = PeerId::new([0xB2u8; 32]);
 
@@ -156,10 +161,6 @@ async fn saturated_peer_does_not_starve_another_peer() -> TestResult {
     sd.add_connection(slow_conn.authenticated()).await?;
     sd.add_connection(fast_conn.authenticated()).await?;
 
-    // Flood the slow peer past its per-peer cap. Its unbounded inbound channel
-    // absorbs the flood; the reader admits only `PER_PEER_CAP` before its
-    // semaphore is exhausted and it stops pulling.
-    const SLOW_FLOOD: usize = PER_PEER_CAP + 200;
     for _ in 0..SLOW_FLOOD {
         slow_handle.inbound_tx.send(heads_update([0xCCu8; 32])).await?;
     }
@@ -185,7 +186,7 @@ async fn saturated_peer_does_not_starve_another_peer() -> TestResult {
     // Backpressure: once the cap was hit the reader stopped draining, so the
     // flood's remainder is still queued in the slow peer's inbound channel.
     assert!(
-        slow_handle.inbound_tx.len() > 0,
+        !slow_handle.inbound_tx.is_empty(),
         "a saturated peer must backpressure its own inbound channel, not drain it"
     );
 


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

-

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
