### PR TITLE
Use opt-level=3 for the dependencies, too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,30 +153,18 @@ pedantic = { level = "deny", priority = -1 }
 [profile.release]
 codegen-units = 1
 lto = "fat"
-opt-level = "z"
+opt-level = 3
 panic = "abort"
 strip = "symbols"
 
-# The workspace-wide opt-level="z" is tuned for Wasm bundle size.
-# Override to opt-level=3 only for crates that are NOT shared with the
-# Wasm target, so Wasm bundles stay small while the native CLI is fast.
-[profile.release.package.subduction_cli]
-opt-level = 3
-
-[profile.release.package.subduction_http_longpoll]
-opt-level = 3
-
-[profile.release.package.subduction_iroh]
-opt-level = 3
-
-[profile.release.package.subduction_websocket]
-opt-level = 3
-
-[profile.release.package.sedimentree_fs_storage]
-opt-level = 3
-
-[profile.release.package.tokio]
-opt-level = 3
+# opt-level = 3 (speed) for the whole release profile, native CLI and Wasm
+# alike. This is a compute-bound system on both ends (Ed25519 verify, BLAKE3,
+# B-tree storage, Automerge merges), and "z" often emits slower code than "s"/2
+# for a size win that gzip/brotli and wasm-opt mostly recover anyway.
+#
+# If a Wasm bundle's size becomes the binding constraint, drop that one crate
+# (or the `*_wasm` binding crate) to opt-level = 2 / "s" rather than reverting
+# the whole profile to "z".
 
 # Wasm crates: preserve Wasm name section for readable stack traces in
 # production. Only strips DWARF debug info, not function names (~5-15%
@@ -207,9 +195,8 @@ opt-level = 2
 [profile.test.package.sedimentree_core]
 opt-level = 2
 
-# Benchmarks inherit from release, but the workspace release profile is tuned
-# for Wasm (opt-level="z", strip="symbols"). Override for accurate benchmarks
-# with debug info sufficient for flamegraphs.
+# Benchmarks inherit from release (opt-level=3, lto="fat", strip="symbols").
+# Override only the debug-info knobs needed for accurate flamegraphs.
 [profile.bench]
 codegen-units = 1
 debug = true        # Full debug symbols for flamegraphs/profiling
@@ -228,7 +215,7 @@ strip = false       # Keep symbols for profiling tools
 #
 # | knob             | wasm-debug | release | why different             |
 # |------------------|------------|---------|---------------------------|
-# | opt-level        | 1          | "z"     | preserve locals/stepping  |
+# | opt-level        | 1          | 3       | preserve locals/stepping  |
 # | lto              | "thin"     | "fat"   | keep stack frames clear   |
 # | codegen-units    | 16         | 1       | faster rebuild cycle      |
 # | debug            | "limited"  | (off)   | DWARF for step-through    |


### PR DESCRIPTION
Both ends are compute-bound (Ed25519 verify, BLAKE3, B-tree storage, Automerge merges), where opt-level=\"z\" often emits slower code for a size win that gzip/brotli and wasm-opt mostly recover. Apply opt-level=3 to the whole release profile and drop the per-crate opt-level=3 overrides.

<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

- In particular, configure hot path crypto deps
- Also switch to opt=3 for wasm; tradeoff is a couple more KB for faster hot path crypto. We can change it later if needed but there's bigger size wins than opt level it seems

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
