### PR TITLE
`redb` batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-channel"
@@ -212,7 +212,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -283,12 +283,12 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "automerge"
-version = "0.9.0"
-source = "git+https://github.com/automerge/automerge?branch=fragments#a57688012b93c29d5ceb1d26735608955c40a4ca"
+version = "0.10.0"
+source = "git+https://github.com/automerge/automerge?branch=fragments#b158c7bfbc1c31b2675a7c6367e4f43686a01609"
 dependencies = [
  "cfg-if",
  "flate2",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hex",
  "hexane",
  "itertools 0.14.0",
@@ -337,7 +337,7 @@ dependencies = [
  "blake3",
  "console_error_panic_hook",
  "getrandom 0.3.4",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "sedimentree_core",
  "sedimentree_wasm",
@@ -516,16 +516,16 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 2.1.2",
  "shlex 1.3.0",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -536,9 +536,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake3"
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -644,7 +644,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -715,9 +715,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -727,9 +727,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -885,7 +885,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -977,8 +977,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
  "tonic-prost",
  "tracing-core",
@@ -997,8 +997,8 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "serde",
  "serde_json",
  "thread_local",
@@ -1273,7 +1273,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1297,7 +1297,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1308,7 +1308,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1334,7 +1334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1372,9 +1372,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derivative"
@@ -1395,7 +1392,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1406,7 +1403,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1427,7 +1424,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1437,7 +1434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1466,7 +1463,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1480,7 +1477,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1522,7 +1519,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
@@ -1533,7 +1530,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -1547,7 +1544,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1584,7 +1581,7 @@ checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1672,7 +1669,7 @@ checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1692,7 +1689,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1864,7 +1861,7 @@ checksum = "6658fc211f4fa8521b72c00efe6626be82dd9d5bde5042137bcb90b02caee84d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1949,7 +1946,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2041,17 +2038,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -2091,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2202,7 +2197,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/automerge/automerge?branch=fragments#a57688012b93c29d5ceb1d26735608955c40a4ca"
+source = "git+https://github.com/automerge/automerge?branch=fragments#b158c7bfbc1c31b2675a7c6367e4f43686a01609"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -2288,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2544,12 +2539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac9a3c8278f43b4cd8463380f4a25653ac843e5b177e1d3eaf849cc9ba10d4d"
+checksum = "de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581"
 dependencies = [
  "attohttpc",
  "bytes",
@@ -2616,8 +2605,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2685,7 +2672,7 @@ dependencies = [
  "derive_more 2.1.1",
  "ed25519-dalek 3.0.0-pre.6",
  "futures-util",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hickory-resolver",
  "http",
  "ipnet",
@@ -2736,7 +2723,7 @@ dependencies = [
  "derive_more 2.1.1",
  "digest 0.11.3",
  "ed25519-dalek 3.0.0-pre.6",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "n0-error",
  "rand 0.10.1",
  "serde",
@@ -2785,7 +2772,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2799,7 +2786,7 @@ dependencies = [
  "cfg_aliases",
  "data-encoding",
  "derive_more 2.1.1",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hickory-resolver",
  "http",
  "http-body-util",
@@ -2862,6 +2849,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2902,7 +2898,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2921,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3003,15 +2999,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "libc"
@@ -3069,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loki-api"
@@ -3140,15 +3130,15 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3313,7 +3303,7 @@ checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3408,7 +3398,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -3420,7 +3410,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -3517,7 +3507,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3580,7 +3570,7 @@ dependencies = [
  "bytes",
  "derive_more 2.1.1",
  "enum-assoc",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "identity-hash",
  "lru-slab",
  "rand 0.10.1",
@@ -3682,7 +3672,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3709,7 +3699,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "dispatch2",
  "libc",
@@ -3728,7 +3718,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3739,7 +3729,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "libc",
  "objc2",
@@ -3786,11 +3776,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3806,7 +3796,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3817,9 +3807,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3929,7 +3919,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4095,7 +4085,7 @@ checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4163,16 +4153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a65843dfefbafd3c879c683306959a6de478443ffe9c9adf02f5976432402d7"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4206,7 +4186,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "procfs-core",
  "rustix",
 ]
@@ -4217,7 +4197,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hex",
 ]
 
@@ -4233,12 +4213,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -4251,20 +4231,20 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4278,11 +4258,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4320,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4340,9 +4320,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4375,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4432,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -4504,7 +4484,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4542,14 +4522,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4570,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -4723,7 +4703,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4732,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4855,7 +4835,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5003,7 +4983,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5155,7 +5135,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5178,9 +5158,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smol_str"
@@ -5222,7 +5202,7 @@ checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5299,7 +5279,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5662,9 +5642,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5688,7 +5668,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5697,7 +5677,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5725,7 +5705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5763,7 +5743,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5774,7 +5754,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5794,12 +5774,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "js-sys",
  "libc",
  "num-conv",
@@ -5812,15 +5791,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5887,7 +5866,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5957,7 +5936,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "http",
  "httparse",
  "rand 0.10.1",
@@ -6053,7 +6032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -6082,7 +6061,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -6126,7 +6105,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6310,11 +6289,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -6412,20 +6391,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6470,7 +6440,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -6513,7 +6483,7 @@ checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6521,28 +6491,6 @@ name = "wasm-bindgen-test-shared"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
 
 [[package]]
 name = "wasm-streams"
@@ -6577,20 +6525,8 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -6615,18 +6551,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6721,7 +6657,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6732,7 +6668,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6965,97 +6901,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wmi"
@@ -7126,9 +6974,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7143,28 +6991,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7184,28 +7032,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7238,7 +7086,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -473,8 +473,9 @@ impl<
             .await
             .map_err(IoError::Storage)?;
 
-        self.minimize_tree(id).await;
-
+        // No eager minimize: `heads_for` below minimizes the resident tree in
+        // place (dirty-gated), as does every other reader, so minimizing here
+        // would be redundant work on the per-commit hot path.
         if was_new {
             let heads = self.heads_for(id).await;
 
@@ -666,8 +667,8 @@ impl<
             .await
             .map_err(IoError::Storage)?;
 
-        self.minimize_tree(id).await;
-
+        // No eager minimize: `heads_for` below minimizes in place; see
+        // `recv_commit`.
         if was_new {
             let heads = self.heads_for(id).await;
 
@@ -885,11 +886,13 @@ impl<
             // Slow path (cache miss): full storage scan, which also warms
             // the cache so subsequent requests for this tree take the
             // fast path.
-            let verified_commits = fetcher
-                .load_loose_commits()
-                .await
-                .map_err(IoError::Storage)?;
-            let verified_fragments = fetcher.load_fragments().await.map_err(IoError::Storage)?;
+            // Cache miss warms the whole tree, so load both tables at once.
+            // redb allows concurrent readers (MVCC), so the two scans overlap
+            // on the blocking pool instead of running back-to-back.
+            let (verified_commits, verified_fragments) =
+                futures::future::try_join(fetcher.load_loose_commits(), fetcher.load_fragments())
+                    .await
+                    .map_err(IoError::Storage)?;
 
             // Byzantine duplicates (multiple payloads per id) resolve
             // first-loaded-wins — the same policy for commits and

--- a/subduction_core/src/handler/sync.rs
+++ b/subduction_core/src/handler/sync.rs
@@ -473,9 +473,6 @@ impl<
             .await
             .map_err(IoError::Storage)?;
 
-        // No eager minimize: `heads_for` below minimizes the resident tree in
-        // place (dirty-gated), as does every other reader, so minimizing here
-        // would be redundant work on the per-commit hot path.
         if was_new {
             let heads = self.heads_for(id).await;
 
@@ -667,8 +664,6 @@ impl<
             .await
             .map_err(IoError::Storage)?;
 
-        // No eager minimize: `heads_for` below minimizes in place; see
-        // `recv_commit`.
         if was_new {
             let heads = self.heads_for(id).await;
 

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -113,7 +113,7 @@ use sedimentree_core::{
     blob::{Blob, verified::VerifiedBlobMeta},
     codec::{decode::Decode, encode::Encode},
     collections::{
-        Entry, Map, Set,
+        Map, Set,
         nonempty_ext::{NonEmptyExt, RemoveResult},
     },
     crypto::{digest::Digest, fingerprint::FingerprintSeed},
@@ -2159,89 +2159,23 @@ where
                     let commits_to_receive = missing_commits.len();
                     let fragments_to_receive = missing_fragments.len();
 
-                    // Cache putters by author to avoid redundant policy checks.
-                    let mut putter_cache: Map<PeerId, Putter<Async, Store>> = Map::new();
-
-                    for (signed_commit, blob) in missing_commits {
-                        let verified = match signed_commit.try_verify() {
-                            Ok(v) => v,
-                            Err(e) => {
-                                tracing::warn!(error = %e, "sync commit signature verification failed");
-                                continue;
-                            }
-                        };
-                        let verified_meta = match VerifiedMeta::new(verified, blob) {
-                            Ok(vm) => vm,
-                            Err(e) => {
-                                tracing::warn!(error = %e, "sync commit blob mismatch");
-                                continue;
-                            }
-                        };
-                        let author = verified_meta.verified_author();
-                        let author_id = PeerId::from(*author.verifying_key());
-                        let putter = match putter_cache.entry(author_id) {
-                            Entry::Occupied(e) => e.into_mut(),
-                            Entry::Vacant(e) => {
-                                match self.storage.get_putter::<Async>(*to_ask, author, id).await {
-                                    Ok(p) => e.insert(p),
-                                    Err(err) => {
-                                        tracing::warn!(
-                                            peer = %to_ask,
-                                            author = ?author,
-                                            tree = ?id,
-                                            error = %err,
-                                            "policy rejected sync commit"
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-                        };
-                        self.insert_commit_locally(putter, verified_meta)
-                            .await
-                            .map_err(IoError::Storage)?;
-                    }
-
-                    for (signed_fragment, blob) in missing_fragments {
-                        let verified = match signed_fragment.try_verify() {
-                            Ok(v) => v,
-                            Err(e) => {
-                                tracing::warn!(error = %e, "sync fragment signature verification failed");
-                                continue;
-                            }
-                        };
-                        let verified_meta = match VerifiedMeta::new(verified, blob) {
-                            Ok(vm) => vm,
-                            Err(e) => {
-                                tracing::warn!(error = %e, "sync fragment blob mismatch");
-                                continue;
-                            }
-                        };
-                        let author = verified_meta.verified_author();
-                        let author_id = PeerId::from(*author.verifying_key());
-                        let putter = match putter_cache.entry(author_id) {
-                            Entry::Occupied(e) => e.into_mut(),
-                            Entry::Vacant(e) => {
-                                match self.storage.get_putter::<Async>(*to_ask, author, id).await {
-                                    Ok(p) => e.insert(p),
-                                    Err(err) => {
-                                        tracing::warn!(
-                                            peer = %to_ask,
-                                            author = ?author,
-                                            tree = ?id,
-                                            error = %err,
-                                            "policy rejected sync fragment"
-                                        );
-                                        continue;
-                                    }
-                                }
-                            }
-                        };
-                        self.insert_fragment_locally(putter, verified_meta)
-                            .await
-                            .map_err(IoError::Storage)?;
-                    }
-
+                    // Ingest the diff in one batched pass: `recv_batch_sync_response`
+                    // groups items by author and writes each author's batch in a
+                    // single `save_batch` (one fsync), instead of one fsync per
+                    // commit. `requesting` is handled separately below, so the
+                    // copy handed to the ingester is left empty.
+                    ingest::recv_batch_sync_response(
+                        &self.sedimentrees,
+                        &self.storage,
+                        to_ask,
+                        id,
+                        SyncDiff {
+                            missing_commits,
+                            missing_fragments,
+                            requesting: RequestedData::default(),
+                        },
+                    )
+                    .await?;
                     self.minimize_tree(id).await;
 
                     // Update received stats (count what was offered, not verified)
@@ -2294,7 +2228,12 @@ where
 
         #[cfg(feature = "metrics")]
         {
-            crate::metrics::sync_duration(sync_start.elapsed().as_secs_f64());
+            // Duration is for successful round-trips only; all-failed syncs are
+            // counted via `sync_call_failure` below. Recording them here would
+            // skew the histogram toward the timeout instead of real latency.
+            if had_success {
+                crate::metrics::sync_duration(sync_start.elapsed().as_secs_f64());
+            }
             crate::metrics::sync_data_exchanged(
                 stats.commits_received,
                 stats.fragments_received,
@@ -2454,89 +2393,22 @@ where
                                     "sync_with_all_peers: response received"
                                 );
 
-                                // Cache putters by author to avoid redundant policy checks.
-                                let mut putter_cache: Map<PeerId, Putter<Async, Store>> = Map::new();
-
-                                for (signed_commit, blob) in missing_commits {
-                                    let verified = match signed_commit.try_verify() {
-                                        Ok(v) => v,
-                                        Err(e) => {
-                                            tracing::warn!(error = %e, "full sync commit signature verification failed");
-                                            continue;
-                                        }
-                                    };
-                                    let verified_meta = match VerifiedMeta::new(verified, blob) {
-                                        Ok(vm) => vm,
-                                        Err(e) => {
-                                            tracing::warn!(error = %e, "full sync commit blob mismatch");
-                                            continue;
-                                        }
-                                    };
-                                    let author = verified_meta.verified_author();
-                                    let author_id = PeerId::from(*author.verifying_key());
-                                    let putter = match putter_cache.entry(author_id) {
-                                        Entry::Occupied(e) => e.into_mut(),
-                                        Entry::Vacant(e) => {
-                                            match self.storage.get_putter::<Async>(*peer_id, author, id).await {
-                                                Ok(p) => e.insert(p),
-                                                Err(err) => {
-                                                    tracing::warn!(
-                                                        peer = %peer_id,
-                                                        author = ?author,
-                                                        tree = ?id,
-                                                        error = %err,
-                                                        "policy rejected full sync commit"
-                                                    );
-                                                    continue;
-                                                }
-                                            }
-                                        }
-                                    };
-                                    self.insert_commit_locally(putter, verified_meta)
-                                        .await
-                                        .map_err(IoError::Storage)?;
-                                }
-
-                                for (signed_fragment, blob) in missing_fragments {
-                                    let verified = match signed_fragment.try_verify() {
-                                        Ok(v) => v,
-                                        Err(e) => {
-                                            tracing::warn!(error = %e, "full sync fragment signature verification failed");
-                                            continue;
-                                        }
-                                    };
-                                    let verified_meta = match VerifiedMeta::new(verified, blob) {
-                                        Ok(vm) => vm,
-                                        Err(e) => {
-                                            tracing::warn!(error = %e, "full sync fragment blob mismatch");
-                                            continue;
-                                        }
-                                    };
-                                    let author = verified_meta.verified_author();
-                                    let author_id = PeerId::from(*author.verifying_key());
-                                    let putter = match putter_cache.entry(author_id) {
-                                        Entry::Occupied(e) => e.into_mut(),
-                                        Entry::Vacant(e) => {
-                                            match self.storage.get_putter::<Async>(*peer_id, author, id).await {
-                                                Ok(p) => e.insert(p),
-                                                Err(err) => {
-                                                    tracing::warn!(
-                                                        peer = %peer_id,
-                                                        author = ?author,
-                                                        tree = ?id,
-                                                        error = %err,
-                                                        "policy rejected full sync fragment"
-                                                    );
-                                                    continue;
-                                                }
-                                            }
-                                        }
-                                    };
-                                    self.insert_fragment_locally(putter, verified_meta)
-                                        .await
-                                        .map_err(IoError::Storage)?;
-                                }
-
+                                // Ingest the diff in one batched pass (see
+                                // `sync_with_peer`): one `save_batch` per author
+                                // instead of one fsync per commit. `requesting`
+                                // is handled separately below.
+                                ingest::recv_batch_sync_response(
+                                    &self.sedimentrees,
+                                    &self.storage,
+                                    peer_id,
+                                    id,
+                                    SyncDiff {
+                                        missing_commits,
+                                        missing_fragments,
+                                        requesting: RequestedData::default(),
+                                    },
+                                )
+                                .await?;
                                 self.minimize_tree(id).await;
 
                                 // Update received stats

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -2159,11 +2159,10 @@ where
                     let commits_to_receive = missing_commits.len();
                     let fragments_to_receive = missing_fragments.len();
 
-                    // Ingest the diff in one batched pass: `recv_batch_sync_response`
-                    // groups items by author and writes each author's batch in a
-                    // single `save_batch` (one fsync), instead of one fsync per
-                    // commit. `requesting` is handled separately below, so the
-                    // copy handed to the ingester is left empty.
+                    // Ingest in one batched pass: `recv_batch_sync_response` groups
+                    // items by author and writes each batch in a single `save_batch`.
+                    // `requesting` is handled separately below, so the ingester's
+                    // copy is left empty.
                     ingest::recv_batch_sync_response(
                         &self.sedimentrees,
                         &self.storage,
@@ -2393,10 +2392,8 @@ where
                                     "sync_with_all_peers: response received"
                                 );
 
-                                // Ingest the diff in one batched pass (see
-                                // `sync_with_peer`): one `save_batch` per author
-                                // instead of one fsync per commit. `requesting`
-                                // is handled separately below.
+                                // Ingest in one batched pass; see `sync_with_peer`.
+                                // `requesting` is handled separately below.
                                 ingest::recv_batch_sync_response(
                                     &self.sedimentrees,
                                     &self.storage,

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -256,10 +256,8 @@ pub(crate) async fn insert_commit_locally<
         .await?
         .unwrap_or(true);
 
-    // Persist before the in-RAM mutation (storage is the source of truth;
-    // the map is a cache that re-hydrates from it). `save_commit` registers
-    // the sedimentree id atomically with the commit (Storage contract), so a
-    // separate `save_sedimentree_id` write would be pure redundant fsync.
+    // Persist before the in-RAM mutation: storage is the source of truth; the
+    // map is a cache that re-hydrates from it.
     putter.save_commit(verified_meta).await?;
 
     // Apply to the in-RAM tree, hydrating on a miss in case it was evicted
@@ -306,8 +304,7 @@ pub(crate) async fn insert_fragment_locally<
         .await?
         .unwrap_or(true);
 
-    // `save_fragment` registers the sedimentree id atomically with the
-    // fragment (Storage contract); no separate `save_sedimentree_id` needed.
+    // Persist before the in-RAM mutation; see `insert_commit_locally`.
     putter.save_fragment(verified_meta).await?;
 
     sedimentrees

--- a/subduction_core/src/subduction/ingest.rs
+++ b/subduction_core/src/subduction/ingest.rs
@@ -241,8 +241,6 @@ pub(crate) async fn insert_commit_locally<
 
     tracing::debug!(digest = ?Digest::hash(&commit), "inserting commit locally");
 
-    putter.save_sedimentree_id().await?;
-
     // Newness ("was this commit not already known?") is judged against the
     // tree state *before* persisting. Read it from the resident cache, or
     // hydrate-on-miss — both reflect pre-save state (we save below). This is
@@ -259,7 +257,9 @@ pub(crate) async fn insert_commit_locally<
         .unwrap_or(true);
 
     // Persist before the in-RAM mutation (storage is the source of truth;
-    // the map is a cache that re-hydrates from it).
+    // the map is a cache that re-hydrates from it). `save_commit` registers
+    // the sedimentree id atomically with the commit (Storage contract), so a
+    // separate `save_sedimentree_id` write would be pure redundant fsync.
     putter.save_commit(verified_meta).await?;
 
     // Apply to the in-RAM tree, hydrating on a miss in case it was evicted
@@ -295,8 +295,6 @@ pub(crate) async fn insert_fragment_locally<
     let fragment = verified_meta.payload().clone();
     let head = fragment.head();
 
-    putter.save_sedimentree_id().await?;
-
     // Newness from pre-save tree state (resident or hydrated); see
     // `insert_commit_locally`.
     let was_added = sedimentrees
@@ -308,6 +306,8 @@ pub(crate) async fn insert_fragment_locally<
         .await?
         .unwrap_or(true);
 
+    // `save_fragment` registers the sedimentree id atomically with the
+    // fragment (Storage contract); no separate `save_sedimentree_id` needed.
     putter.save_fragment(verified_meta).await?;
 
     sedimentrees

--- a/subduction_http_longpoll/src/transport.rs
+++ b/subduction_http_longpoll/src/transport.rs
@@ -37,7 +37,7 @@ struct Outbound {
 }
 
 impl Outbound {
-    // `const` only without `metrics` (`Instant::now()` isn't const); not worth a cfg split.
+    // Const-eligible only without `metrics` (`Instant::now()` isn't const).
     #[allow(clippy::missing_const_for_fn)]
     fn new(bytes: Vec<u8>) -> Self {
         Self {

--- a/subduction_redb_storage/src/error.rs
+++ b/subduction_redb_storage/src/error.rs
@@ -35,6 +35,12 @@ pub enum RedbStorageError {
     /// A blocking storage task panicked or was cancelled.
     #[error("blocking storage task failed: {0}")]
     Join(#[from] tokio::task::JoinError),
+
+    /// The group-commit writer is unavailable: its queue closed or its reply
+    /// was dropped. Only reachable during shutdown or if the writer task
+    /// panicked (the offending item's own error already surfaced there).
+    #[error("redb group-commit writer is unavailable")]
+    WriterClosed,
 }
 
 /// A filesystem operation on an external blob file (or the on-disk store

--- a/subduction_redb_storage/src/insert.rs
+++ b/subduction_redb_storage/src/insert.rs
@@ -79,9 +79,23 @@ pub(crate) fn stage_external_blobs_sync(
     inline_threshold: usize,
 ) -> Result<(), RedbStorageError> {
     for item in items {
-        if item.blob.len() > inline_threshold {
-            write_blob_file_sync(blobs_dir, &item.blob_digest, &item.blob)?;
-        }
+        stage_external_blob_sync(item, blobs_dir, inline_threshold)?;
+    }
+    Ok(())
+}
+
+/// Stage a single item's external blob file (no-op for inline blobs).
+///
+/// The one-item counterpart of [`stage_external_blobs_sync`], used by the
+/// group-commit writer which holds its pending items as individual jobs
+/// rather than a contiguous slice. Must be called from a blocking context.
+pub(crate) fn stage_external_blob_sync(
+    item: &PendingInsert,
+    blobs_dir: &Path,
+    inline_threshold: usize,
+) -> Result<(), RedbStorageError> {
+    if item.blob.len() > inline_threshold {
+        write_blob_file_sync(blobs_dir, &item.blob_digest, &item.blob)?;
     }
     Ok(())
 }

--- a/subduction_redb_storage/src/lib.rs
+++ b/subduction_redb_storage/src/lib.rs
@@ -86,15 +86,23 @@ mod inspect;
 mod key;
 mod scan;
 mod storage;
+mod writer;
 
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use redb::{Database, TableDefinition};
+use sedimentree_core::id::SedimentreeId;
+use tokio::sync::{mpsc, oneshot};
 
-use crate::{blob_store::fsync_dir_sync, error::FileContext};
+use crate::{
+    blob_store::fsync_dir_sync,
+    error::FileContext,
+    insert::PendingInsert,
+    writer::{WriteJob, WriteKind},
+};
 
 pub use error::{FileError, FileOp, RedbStorageError};
 pub use inspect::{HeadEntry, HeadKind, HeadLocation, StoreStats, TreeHeads, TreeStats};
@@ -135,6 +143,10 @@ pub struct RedbStorage {
     db: Arc<Database>,
     blobs_dir: Arc<PathBuf>,
     inline_threshold: usize,
+    /// Group-commit writer queue, spawned lazily on first write (the
+    /// constructor is sync and may run outside a runtime; writes never do).
+    /// Shared across clones so all handles feed one writer.
+    writer: Arc<OnceLock<mpsc::Sender<WriteJob>>>,
 }
 
 impl RedbStorage {
@@ -204,6 +216,7 @@ impl RedbStorage {
             db: Arc::new(db),
             blobs_dir: Arc::new(blobs_dir),
             inline_threshold,
+            writer: Arc::new(OnceLock::new()),
         })
     }
 
@@ -215,6 +228,70 @@ impl RedbStorage {
     ) -> Result<T, RedbStorageError> {
         let db = Arc::clone(&self.db);
         let blobs_dir = Arc::clone(&self.blobs_dir);
+        // Counts the op as blocking-pool-resident from enqueue until completion
+        // (drops on return, including cancellation) — a proxy for pool pressure.
+        #[cfg(feature = "metrics")]
+        let _blocking = BlockingGuard::new();
         tokio::task::spawn_blocking(move || f(&db, &blobs_dir)).await?
+    }
+
+    /// The group-commit writer's queue, spawning the writer task on first use.
+    ///
+    /// Lazy because the constructor is sync and may run outside a Tokio runtime
+    /// (e.g. benches build the store, then drive ops inside `block_on`), whereas
+    /// every write runs inside one. `OnceLock` makes the first writer win and
+    /// the rest share its sender.
+    fn writer(&self) -> &mpsc::Sender<WriteJob> {
+        self.writer.get_or_init(|| {
+            writer::spawn(&self.db, Arc::clone(&self.blobs_dir), self.inline_threshold)
+        })
+    }
+
+    /// Enqueue one verified write and await its durability.
+    ///
+    /// The writer coalesces this with any concurrent writes into a single
+    /// fsync'd transaction (registering the tree id atomically) and signals back
+    /// only after `commit()` returns — so durability-on-return is preserved.
+    pub(crate) async fn enqueue_write(
+        &self,
+        tree: SedimentreeId,
+        insert: PendingInsert,
+        kind: WriteKind,
+    ) -> Result<(), RedbStorageError> {
+        let (responder, rx) = oneshot::channel();
+        self.writer()
+            .send(WriteJob {
+                tree,
+                insert,
+                kind,
+                responder,
+            })
+            .await
+            .map_err(|_| RedbStorageError::WriterClosed)?;
+
+        match rx.await {
+            Ok(result) => result,
+            Err(_) => Err(RedbStorageError::WriterClosed),
+        }
+    }
+}
+
+/// RAII guard that raises the `storage_blocking_inflight` gauge while a storage
+/// op is queued/running on the blocking pool, lowering it on drop.
+#[cfg(feature = "metrics")]
+pub(crate) struct BlockingGuard;
+
+#[cfg(feature = "metrics")]
+impl BlockingGuard {
+    pub(crate) fn new() -> Self {
+        subduction_core::metrics::storage_blocking_inc();
+        Self
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl Drop for BlockingGuard {
+    fn drop(&mut self) {
+        subduction_core::metrics::storage_blocking_dec();
     }
 }

--- a/subduction_redb_storage/src/storage.rs
+++ b/subduction_redb_storage/src/storage.rs
@@ -25,6 +25,7 @@ use crate::{
     insert::{insert_compound, pending_commit, pending_fragment, stage_external_blobs_sync},
     key::{item_range, tree_range},
     scan::{delete_range, resolve_items, scan_decoded, scan_ids, scan_payloads},
+    writer::WriteKind,
 };
 
 #[future_form(Sendable, Local)]
@@ -114,25 +115,12 @@ impl<Async: FutureForm> Storage<Async> for RedbStorage {
     ) -> Async::Future<'_, Result<(), Self::Error>> {
         Async::from_future(async move {
             tracing::trace!(?sedimentree_id, "RedbStorage::save_loose_commit");
-            let pending = pending_commit(sedimentree_id, verified);
-            let threshold = self.inline_threshold;
-            self.with_db(move |db, blobs_dir| {
-                // External blob (if any) staged before the write txn so its
-                // file I/O doesn't hold the database-wide writer slot.
-                stage_external_blobs_sync(core::slice::from_ref(&pending), blobs_dir, threshold)?;
-
-                let txn = db.begin_write()?;
-                {
-                    // Contract: persisting an item registers its
-                    // sedimentree id, atomically with the item itself.
-                    txn.open_table(TREES)?
-                        .insert(sedimentree_id.as_bytes(), ())?;
-                    insert_compound(&mut txn.open_table(COMMITS)?, &pending, threshold)?;
-                }
-                txn.commit()?;
-                Ok(())
-            })
-            .await
+            let insert = pending_commit(sedimentree_id, verified);
+            // Group-commit: the writer task coalesces this with any concurrent
+            // single-item writes into one fsync'd transaction. It registers the
+            // tree id atomically with the commit (Storage contract).
+            self.enqueue_write(sedimentree_id, insert, WriteKind::Commit)
+                .await
         })
     }
 
@@ -271,25 +259,11 @@ impl<Async: FutureForm> Storage<Async> for RedbStorage {
     ) -> Async::Future<'_, Result<(), Self::Error>> {
         Async::from_future(async move {
             tracing::trace!(?sedimentree_id, "RedbStorage::save_fragment");
-            let pending = pending_fragment(sedimentree_id, verified);
-            let threshold = self.inline_threshold;
-            self.with_db(move |db, blobs_dir| {
-                // External blob (if any) staged before the write txn so its
-                // file I/O doesn't hold the database-wide writer slot.
-                stage_external_blobs_sync(core::slice::from_ref(&pending), blobs_dir, threshold)?;
-
-                let txn = db.begin_write()?;
-                {
-                    // Contract: persisting an item registers its
-                    // sedimentree id, atomically with the item itself.
-                    txn.open_table(TREES)?
-                        .insert(sedimentree_id.as_bytes(), ())?;
-                    insert_compound(&mut txn.open_table(FRAGMENTS)?, &pending, threshold)?;
-                }
-                txn.commit()?;
-                Ok(())
-            })
-            .await
+            let insert = pending_fragment(sedimentree_id, verified);
+            // Group-commit: coalesced with concurrent writes into one fsync'd
+            // transaction; registers the tree id atomically with the fragment.
+            self.enqueue_write(sedimentree_id, insert, WriteKind::Fragment)
+                .await
         })
     }
 

--- a/subduction_redb_storage/src/writer.rs
+++ b/subduction_redb_storage/src/writer.rs
@@ -1,0 +1,239 @@
+//! Group-commit writer: coalesces concurrent single-item writes into one
+//! redb transaction (one fsync per drain), preserving per-call durability.
+//!
+//! redb has a single database-wide writer and fsyncs on every commit, so a
+//! burst of N concurrent [`save_loose_commit`]/[`save_fragment`] calls would
+//! serialize into N fsync'd transactions — the last waits behind every fsync
+//! ahead of it.
+//!
+//! Routing those writes through a single task that drains the queue and writes
+//! the whole drain in **one** transaction turns N fsyncs into one. There is no
+//! added latency: a lone write drains immediately (batch of one), while writes
+//! that arrive *during* a commit ride the next drain — the batching window is
+//! exactly however long the previous fsync took, self-tuning to the load.
+//!
+//! Durability is unchanged ([`redb::Durability::Immediate`]): a waiter is
+//! signalled only after `commit()` returns, and the whole drain is one atomic
+//! transaction, so a crash never leaves a partial batch.
+//!
+//! [`save_loose_commit`]: subduction_core::storage::traits::Storage::save_loose_commit
+//! [`save_fragment`]: subduction_core::storage::traits::Storage::save_fragment
+
+mod ack;
+
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Weak},
+};
+
+use redb::Database;
+use sedimentree_core::id::SedimentreeId;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::{
+    COMMITS, FRAGMENTS, RedbStorageError, TREES,
+    insert::{PendingInsert, insert_compound, stage_external_blob_sync},
+};
+
+use self::ack::Ack;
+
+/// Bounded write queue depth. When full, callers await on `send` — backpressure
+/// that bounds both queued memory and the largest possible single drain.
+pub(crate) const WRITER_QUEUE_CAPACITY: usize = 1024;
+
+/// Which table a pending insert targets.
+#[derive(Clone, Copy)]
+pub(crate) enum WriteKind {
+    Commit,
+    Fragment,
+}
+
+/// One enqueued write awaiting durability, with the channel to signal its
+/// caller once the containing transaction commits (or, on batch failure, once
+/// its isolated retry resolves).
+pub(crate) struct WriteJob {
+    pub(crate) tree: SedimentreeId,
+    pub(crate) insert: PendingInsert,
+    pub(crate) kind: WriteKind,
+    pub(crate) responder: oneshot::Sender<Result<(), RedbStorageError>>,
+}
+
+/// Spawn the group-commit writer task and return its queue sender.
+///
+/// Must be called from within a Tokio runtime (writes always are; the redb
+/// backend already runs every op on the blocking pool).
+///
+/// The task holds only a [`Weak`] handle to the database, upgrading per drain,
+/// so the last [`RedbStorage`](crate::RedbStorage) drop releases the file lock
+/// immediately rather than waiting for the task to notice its queue closed.
+pub(crate) fn spawn(
+    db: &Arc<Database>,
+    blobs_dir: Arc<PathBuf>,
+    inline_threshold: usize,
+) -> mpsc::Sender<WriteJob> {
+    let (tx, rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
+    tokio::runtime::Handle::current().spawn(run(
+        rx,
+        Arc::downgrade(db),
+        blobs_dir,
+        inline_threshold,
+    ));
+    tx
+}
+
+/// Drain-and-commit loop. Exits when every sender is dropped (storage closed)
+/// or the database has been released, after flushing whatever is already
+/// queued.
+async fn run(
+    mut rx: mpsc::Receiver<WriteJob>,
+    db: Weak<Database>,
+    blobs_dir: Arc<PathBuf>,
+    inline_threshold: usize,
+) {
+    while let Some(first) = rx.recv().await {
+        let mut jobs = vec![first];
+        // Coalesce everything already queued (bounded by the channel capacity).
+        // Whatever arrives after this point rides the next drain.
+        while let Ok(job) = rx.try_recv() {
+            jobs.push(job);
+        }
+
+        // Upgrade only for the write: a live caller awaiting its ack keeps the
+        // storage (hence the database) alive, so this succeeds whenever there's
+        // real work. It fails only if every caller cancelled and the storage was
+        // dropped — then the database is gone and there's nothing to write.
+        let Some(db) = db.upgrade() else {
+            for job in jobs {
+                drop(job.responder.send(Err(RedbStorageError::WriterClosed)));
+            }
+            return;
+        };
+
+        let blobs_dir = Arc::clone(&blobs_dir);
+        let blocking = tokio::task::spawn_blocking(move || {
+            write_drain(&db, &blobs_dir, inline_threshold, jobs)
+        });
+
+        match blocking.await {
+            // The blocking closure has returned, so the strong `Arc<Database>`
+            // it captured is already dropped. Acking only now guarantees a
+            // caller that drops its storage the instant it's signalled still
+            // releases redb's file lock: this drain no longer holds a handle.
+            Ok(acks) => {
+                for ack in acks {
+                    ack.send();
+                }
+            }
+
+            Err(join_err) => {
+                // The blocking task panicked: its `WriteJob`s (and their
+                // responders) were dropped, so callers already observe
+                // `WriterClosed` via the closed oneshot. Keep the writer alive.
+                tracing::error!(error = %join_err, "redb group-commit writer task panicked");
+            }
+        }
+    }
+}
+
+/// Write a whole drain in one transaction, returning each waiter's channel
+/// paired with its result for the caller to deliver *after* this function's
+/// strong [`Database`] handle is dropped (see [`Ack`]).
+///
+/// On a batch failure, fall back to writing each item in its own transaction so
+/// one poison item can't fail unrelated writes — and each caller gets its own
+/// real error (`RedbStorageError` is not `Clone`, so a shared result can't be
+/// fanned out).
+///
+/// Runs on the blocking pool.
+fn write_drain(
+    db: &Database,
+    blobs_dir: &Path,
+    inline_threshold: usize,
+    jobs: Vec<WriteJob>,
+) -> Vec<Ack> {
+    #[cfg(feature = "metrics")]
+    let _blocking = crate::BlockingGuard::new();
+
+    match flush_all(db, blobs_dir, inline_threshold, &jobs) {
+        Ok(()) => jobs
+            .into_iter()
+            .map(|job| Ack::new(job.responder, Ok(())))
+            .collect(),
+
+        Err(_batch_err) => jobs
+            .into_iter()
+            .map(|job| {
+                let result = flush_one(db, blobs_dir, inline_threshold, &job);
+                Ack::new(job.responder, result)
+            })
+            .collect(),
+    }
+}
+
+/// Stage every item's blob, then insert the whole drain in one transaction.
+fn flush_all(
+    db: &Database,
+    blobs_dir: &Path,
+    inline_threshold: usize,
+    jobs: &[WriteJob],
+) -> Result<(), RedbStorageError> {
+    // Blob files are staged before the write txn opens: file I/O must not hold
+    // the database-wide writer slot (see `insert::stage_external_blobs_sync`).
+    for job in jobs {
+        stage_external_blob_sync(&job.insert, blobs_dir, inline_threshold)?;
+    }
+
+    let txn = db.begin_write()?;
+    {
+        // Register every tree id (idempotent; duplicate ids within one txn are
+        // harmless). Per the Storage contract, persisting items registers their
+        // sedimentree ids atomically with the items.
+        let mut trees = txn.open_table(TREES)?;
+        for job in jobs {
+            trees.insert(job.tree.as_bytes(), ())?;
+        }
+    }
+    {
+        let mut commits = txn.open_table(COMMITS)?;
+        let mut fragments = txn.open_table(FRAGMENTS)?;
+        for job in jobs {
+            match job.kind {
+                WriteKind::Commit => insert_compound(&mut commits, &job.insert, inline_threshold)?,
+                WriteKind::Fragment => {
+                    insert_compound(&mut fragments, &job.insert, inline_threshold)?;
+                }
+            }
+        }
+    }
+    txn.commit()?;
+    Ok(())
+}
+
+/// Write a single job in its own transaction (the batch-failure fallback).
+fn flush_one(
+    db: &Database,
+    blobs_dir: &Path,
+    inline_threshold: usize,
+    job: &WriteJob,
+) -> Result<(), RedbStorageError> {
+    stage_external_blob_sync(&job.insert, blobs_dir, inline_threshold)?;
+
+    let txn = db.begin_write()?;
+    {
+        txn.open_table(TREES)?.insert(job.tree.as_bytes(), ())?;
+        match job.kind {
+            WriteKind::Commit => {
+                insert_compound(&mut txn.open_table(COMMITS)?, &job.insert, inline_threshold)?;
+            }
+            WriteKind::Fragment => {
+                insert_compound(
+                    &mut txn.open_table(FRAGMENTS)?,
+                    &job.insert,
+                    inline_threshold,
+                )?;
+            }
+        }
+    }
+    txn.commit()?;
+    Ok(())
+}

--- a/subduction_redb_storage/src/writer/ack.rs
+++ b/subduction_redb_storage/src/writer/ack.rs
@@ -1,0 +1,32 @@
+//! Per-caller durability acknowledgement for the group-commit writer.
+
+use tokio::sync::oneshot;
+
+use crate::RedbStorageError;
+
+/// A caller's durability channel paired with the result to deliver.
+///
+/// The drain returns these rather than sending them inline so the writer's
+/// strong `Arc<Database>` is dropped *before* any caller is signalled —
+/// otherwise a caller that drops its `RedbStorage` the instant it's acked could
+/// still find redb's exclusive file lock held by this in-flight drain.
+pub(super) struct Ack {
+    responder: oneshot::Sender<Result<(), RedbStorageError>>,
+    result: Result<(), RedbStorageError>,
+}
+
+impl Ack {
+    /// Pair a caller's `responder` with the `result` to hand back to it.
+    pub(super) const fn new(
+        responder: oneshot::Sender<Result<(), RedbStorageError>>,
+        result: Result<(), RedbStorageError>,
+    ) -> Self {
+        Self { responder, result }
+    }
+
+    /// Signal the waiting caller. A dropped receiver just means the caller
+    /// cancelled, so the failed send is ignored.
+    pub(super) fn send(self) {
+        drop(self.responder.send(self.result));
+    }
+}

--- a/subduction_redb_storage/tests/roundtrip.rs
+++ b/subduction_redb_storage/tests/roundtrip.rs
@@ -50,6 +50,88 @@ async fn seal_fragment(
     .await
 }
 
+/// Many concurrent writes are coalesced by the group-commit writer into shared
+/// transactions, yet every one is durable and correctly attributed to its tree.
+/// Exercises the writer's batching, per-tree id registration across a single
+/// multi-tree transaction, the commit/fragment table split, and result fan-out
+/// under contention.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_writes_coalesce_and_stay_durable() -> testresult::TestResult {
+    const TREES: u8 = 4;
+    const COMMITS_PER_TREE: u8 = 10;
+    const FRAGMENTS_PER_TREE: u8 = 3;
+
+    let dir = tempfile::tempdir()?;
+    let storage = RedbStorage::new(dir.path())?;
+    let signer = test_signer();
+    let ids: Vec<SedimentreeId> = (0..TREES)
+        .map(|t| SedimentreeId::new([t + 1; 32]))
+        .collect();
+
+    // Pre-seal everything (signing is async), then fire all saves at once so
+    // many land in each writer drain. No explicit `save_sedimentree_id`: the
+    // coalesced writes must register every tree id themselves.
+    let mut set = tokio::task::JoinSet::new();
+    for (t, &id) in (0u8..).zip(&ids) {
+        for c in 0..COMMITS_PER_TREE {
+            let verified = seal_commit(
+                &signer,
+                id,
+                CommitId::new([t * COMMITS_PER_TREE + c; 32]),
+                vec![t, c],
+            )
+            .await;
+            let storage = storage.clone();
+            set.spawn(async move {
+                Storage::<Sendable>::save_loose_commit(&storage, id, verified).await
+            });
+        }
+        for f in 0..FRAGMENTS_PER_TREE {
+            let verified = seal_fragment(
+                &signer,
+                id,
+                CommitId::new([100 + t * FRAGMENTS_PER_TREE + f; 32]),
+                vec![t, f],
+            )
+            .await;
+            let storage = storage.clone();
+            set.spawn(
+                async move { Storage::<Sendable>::save_fragment(&storage, id, verified).await },
+            );
+        }
+    }
+
+    while let Some(joined) = set.join_next().await {
+        joined??;
+    }
+
+    // Every item is durable, attributed to the right tree, and every tree id is
+    // enumerable — proving the coalesced transactions registered ids correctly.
+    let all_ids = Storage::<Sendable>::load_all_sedimentree_ids(&storage).await?;
+    assert_eq!(
+        all_ids.len(),
+        usize::from(TREES),
+        "every tree id must be registered"
+    );
+    for &id in &ids {
+        assert!(all_ids.contains(&id), "missing tree {id:?}");
+        let commits = Storage::<Sendable>::load_loose_commits(&storage, id).await?;
+        assert_eq!(
+            commits.len(),
+            usize::from(COMMITS_PER_TREE),
+            "tree {id:?} lost commits"
+        );
+        let fragments = Storage::<Sendable>::load_fragments(&storage, id).await?;
+        assert_eq!(
+            fragments.len(),
+            usize::from(FRAGMENTS_PER_TREE),
+            "tree {id:?} lost fragments"
+        );
+    }
+
+    Ok(())
+}
+
 /// Save a commit, reload via bulk + point lookups, verify byte identity.
 #[tokio::test]
 async fn save_load_roundtrip() -> testresult::TestResult {

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -43,7 +43,7 @@ struct Outbound {
 }
 
 impl Outbound {
-    // `const` only without `metrics` (`Instant::now()` isn't const); not worth a cfg split.
+    // Const-eligible only without `metrics` (`Instant::now()` isn't const).
     #[allow(clippy::missing_const_for_fn)]
     fn new(msg: tungstenite::Message) -> Self {
         Self {


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

- Fewer round trips to redb!

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
