### PR TITLE
Set explicit `redb` limits, fix missed teardown

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,17 +9,19 @@
 ignore = [
     # ─── Vulnerabilities (temporary suppression) ───────────────────
     #
-    # Both pulled in by iroh-relay 0.98.0's exact pin
-    # `hickory-resolver = "=0.26.0-beta.4"`. Upstream fix exists at
-    # hickory-* >= 0.26.1. Revisit when iroh-relay relaxes the pin or
-    # bumps to >= 0.99.
+    # Both in quick-xml 0.26.0, pulled in by pprof 0.15's pin
+    # `inferno = "^0.11"`. inferno only parses/writes flamegraph SVGs in
+    # benches (dev-only, behind the off-by-default `pprof-profile`
+    # feature — no untrusted XML input, no production code path). The fix
+    # is quick-xml >= 0.41, which arrives via inferno 0.12; pprof 0.15 is
+    # already the latest release. Revisit when pprof bumps inferno.
 
-    # hickory-net NSEC3 closest-encloser proof unbounded loop on
-    # cross-zone responses (DoS).
-    "RUSTSEC-2026-0120",
-    # hickory-proto CPU exhaustion via O(n²) name compression during
-    # message encoding (DoS).
-    "RUSTSEC-2026-0119",
+    # quick-xml quadratic run time checking start tags for duplicate
+    # attribute names (DoS).
+    "RUSTSEC-2026-0194",
+    # quick-xml unbounded namespace-declaration allocation in `NsReader`
+    # (memory-exhaustion DoS).
+    "RUSTSEC-2026-0195",
 
     # ─── Unmaintained warnings (transitive, no fix on our side) ────
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -186,9 +186,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-channel"
@@ -284,7 +284,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 [[package]]
 name = "automerge"
 version = "0.10.0"
-source = "git+https://github.com/automerge/automerge?branch=fragments#b158c7bfbc1c31b2675a7c6367e4f43686a01609"
+source = "git+https://github.com/automerge/automerge?branch=fragments#72a8d0ba02af32f610cb0128e254a5f521287b74"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -294,8 +294,8 @@ dependencies = [
  "itertools 0.14.0",
  "js-sys",
  "leb128",
- "rand 0.10.1",
- "rustc-hash 2.1.2",
+ "rand 0.10.2",
+ "rustc-hash 2.1.3",
  "serde",
  "sha2 0.11.0",
  "smol_str",
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -361,14 +361,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -529,7 +530,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn 2.0.118",
 ]
@@ -721,9 +722,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -733,9 +734,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -783,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1166,18 +1167,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1185,18 +1186,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -2179,8 +2180,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexane"
-version = "0.2.1"
-source = "git+https://github.com/automerge/automerge?branch=fragments#b158c7bfbc1c31b2675a7c6367e4f43686a01609"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/automerge/automerge?branch=fragments#72a8d0ba02af32f610cb0128e254a5f521287b74"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -2206,7 +2207,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni 0.22.4",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2228,7 +2229,7 @@ dependencies = [
  "jni 0.22.4",
  "once_cell",
  "prefix-trie",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2253,7 +2254,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.2",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -2311,15 +2312,15 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -2568,7 +2569,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
  "url",
  "xmltree",
@@ -2641,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
+checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
 dependencies = [
  "backon",
  "blake3",
@@ -2673,9 +2674,9 @@ dependencies = [
  "pin-project",
  "portable-atomic",
  "portmapper",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest 0.13.4",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -2692,9 +2693,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
+checksum = "830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d"
 dependencies = [
  "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
@@ -2703,7 +2704,7 @@ dependencies = [
  "ed25519-dalek 3.0.0-rc.0",
  "getrandom 0.4.3",
  "n0-error",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "url",
  "zeroize",
@@ -2711,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
+checksum = "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -2724,7 +2725,7 @@ dependencies = [
  "n0-future",
  "ndk-context",
  "portable-atomic",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rustls",
  "simple-dns",
  "strum",
@@ -2762,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
+checksum = "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354"
 dependencies = [
  "blake3",
  "bytes",
@@ -2788,7 +2789,7 @@ dependencies = [
  "num_enum",
  "pin-project",
  "postcard",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "rustls",
  "rustls-pki-types",
@@ -2932,11 +2933,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -3140,9 +3141,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -3373,9 +3374,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netdev"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
 dependencies = [
  "block2",
  "dispatch2",
@@ -3386,7 +3387,7 @@ dependencies = [
  "mac-addr",
  "ndk-context",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route",
  "netlink-sys",
  "objc2",
  "objc2-core-foundation",
@@ -3405,18 +3406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
  "paste",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
-dependencies = [
- "bitflags 2.13.0",
- "libc",
- "log",
- "netlink-packet-core",
 ]
 
 [[package]]
@@ -3460,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8487d26d691cd98d5c17b2adb4b1fd4b31cccc820da1eac827d483295d7bb94a"
+checksum = "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3476,7 +3465,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.31.0",
+ "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -3556,9 +3545,9 @@ checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "noq"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
+checksum = "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3566,7 +3555,7 @@ dependencies = [
  "noq-proto",
  "noq-udp",
  "pin-project-lite",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3578,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
+checksum = "aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -3589,10 +3578,10 @@ dependencies = [
  "getrandom 0.4.3",
  "identity-hash",
  "lru-slab",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3605,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
+checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3627,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4016,13 +4005,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -4089,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
+checksum = "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4104,7 +4093,7 @@ dependencies = [
  "n0-future",
  "netwatch",
  "num_enum",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "smallvec",
  "socket2",
@@ -4343,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4361,7 +4350,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4372,16 +4361,17 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4393,16 +4383,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4459,11 +4449,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -4532,9 +4522,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -4733,9 +4723,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -4745,9 +4735,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4801,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4850,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -5836,9 +5826,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
@@ -5859,9 +5849,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5990,9 +5980,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6001,7 +5991,7 @@ dependencies = [
  "getrandom 0.4.3",
  "http",
  "httparse",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ring",
  "rustls-pki-types",
  "sha1_smol",
@@ -6351,9 +6341,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6787,15 +6777,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6827,28 +6808,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6873,12 +6837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6889,12 +6847,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6909,22 +6861,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6939,12 +6879,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6955,12 +6889,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6975,12 +6903,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6991,12 +6913,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7114,18 +7030,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/flake.lock
+++ b/flake.lock
@@ -56,12 +56,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1782462661,
-        "narHash": "sha256-vYQcPDeKjvhAigTJaEARpSLy7oEitPP7Vo2t9uN958s=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "410a3a0797f45e9306d8b7b6c4491ab09973afbe",
-        "type": "github"
+        "lastModified": 1783522079,
+        "narHash": "sha256-esY8Y5zEnqfTbhhWh8abFTviLCjIxE8N9mkx0R5mUxI=",
+        "rev": "1e94a0307f544377e2f2332daa7fca2833a1adc3",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1031291.1e94a0307f54/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -101,12 +100,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782233679,
-        "narHash": "sha256-QyuGP5+QOtmXpy4i2X4DhBVBaySBdDKQEhqKcphcp34=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "667d5cf1c59585031d743c78b394b0a647537c35",
-        "type": "github"
+        "lastModified": 1783389287,
+        "narHash": "sha256-R5cxRkQCq5wIM91F9OkIEgu8YoSGjlMeTjYl9o4gpKw=",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.4364.0ad6f47ea4fe/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -132,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782443907,
-        "narHash": "sha256-P+pADLtK7qC1mz0/5Xq9uF77oahUR4zYLTaitiHsUHg=",
+        "lastModified": 1783488441,
+        "narHash": "sha256-jmWf+H3iC/0z7/mmvTovaJx1E/LME1QyHkyk+AFfJPk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4b06ff4acf3491ff69721df852507fcc51d0a13d",
+        "rev": "7dc3a177a239ed879c5581a80f6dc246c7e102f1",
         "type": "github"
       },
       "original": {

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -75,7 +75,10 @@ in {
       timeout = lib.mkOption {
         type = lib.types.int;
         default = 5;
-        description = "Request timeout in seconds.";
+        description = ''
+          Roundtrip timeout in seconds for sync calls to peers (passes
+          `--timeout`).
+        '';
       };
 
       logFormat = lib.mkOption {

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -92,7 +92,10 @@ in {
       timeout = lib.mkOption {
         type = lib.types.int;
         default = 5;
-        description = "Request timeout in seconds.";
+        description = ''
+          Roundtrip timeout in seconds for sync calls to peers (passes
+          `--timeout`).
+        '';
       };
 
       logFormat = lib.mkOption {

--- a/subduction_cli/src/metrics.rs
+++ b/subduction_cli/src/metrics.rs
@@ -5,8 +5,7 @@
 
 use axum::{Router, routing::get};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
-use metrics_util::MetricKindMask;
-use std::{net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 use tokio::net::TcpListener;
 
 // Histogram buckets must be configured, or `metrics-exporter-prometheus`
@@ -20,25 +19,29 @@ use tokio::net::TcpListener;
 
 /// Fine buckets (seconds) for sub-millisecond/low-millisecond operations:
 /// per-message dispatch and individual storage operations. Resolves down to
-/// 50µs so fast ops don't collapse into one bucket, and extends to 10s so a
-/// write that stalls for seconds under redb write contention isn't clamped to
-/// the 1s bucket (which would hide the real p99).
+/// 50µs so fast ops don't collapse into one bucket, and extends to 60s so a
+/// dispatch or write that stalls under memory pressure or write contention
+/// isn't clamped to a low top bucket (a saturated top bucket reads as
+/// "p99 = ceiling" and hides how bad the tail really is).
 const FINE_BUCKETS_SECONDS: &[f64] = &[
     0.000_05, 0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-    1.0, 2.5, 5.0, 10.0,
+    1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
 ];
 
 /// Coarse buckets (seconds) for whole-round operations measured in
 /// milliseconds-to-seconds: foreground sync rounds. Sub-ms resolution would be
-/// wasted series here.
+/// wasted series here. Extends to 300s: round-trips queue for minutes when
+/// outbound queues congest, and the previous 60s ceiling clipped the tail.
 const COARSE_BUCKETS_SECONDS: &[f64] = &[
-    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
 ];
 
 /// Buckets (seconds) for outbound send-queue dwell — sub-millisecond
-/// (WebSocket) to tens of seconds (long-poll), so both transports resolve.
+/// (WebSocket) to minutes (congested consumers), so both transports resolve
+/// and a saturated queue's dwell distribution stays observable past 60s.
 const DWELL_BUCKETS_SECONDS: &[f64] = &[
-    0.000_5, 0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+    0.000_5, 0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0,
+    300.0,
 ];
 
 /// Buckets (message count) for outbound send-queue depth sampled at drain, up
@@ -49,12 +52,6 @@ const DWELL_BUCKETS_SECONDS: &[f64] = &[
 const DEPTH_BUCKETS: &[f64] = &[
     0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0,
 ];
-
-/// Idle series are evicted after this long with no updates. A safety valve:
-/// our label cardinality is bounded (`&'static str` only), but this bounds
-/// memory if a label value stops being produced. Applied to histograms only —
-/// counters/gauges are kept so `rate()`/`increase()` stay continuous.
-const IDLE_TIMEOUT: Duration = Duration::from_secs(60 * 60); // 1 hour
 
 /// Initialize the metrics recorder and return a handle for the HTTP endpoint.
 ///
@@ -107,12 +104,24 @@ pub fn init_metrics() -> PrometheusHandle {
             FINE_BUCKETS_SECONDS,
         )
         .expect("fine buckets are non-empty and sorted")
+        // Msg-queue dwell is µs on a healthy listener and seconds when the
+        // listen loop is the bottleneck; fine buckets resolve both regimes.
+        .set_buckets_for_metric(
+            Matcher::Full(names::MSG_QUEUE_DWELL_SECONDS.to_owned()),
+            FINE_BUCKETS_SECONDS,
+        )
+        .expect("fine buckets are non-empty and sorted")
         .set_buckets_for_metric(
             Matcher::Suffix("_duration_seconds".to_owned()),
             COARSE_BUCKETS_SECONDS,
         )
         .expect("coarse buckets are non-empty and sorted")
-        .idle_timeout(MetricKindMask::HISTOGRAM, Some(IDLE_TIMEOUT))
+        // No idle eviction. Histogram counts are cumulative; evicting an idle
+        // series silently resets it, which breaks `rate()`/`increase()` and
+        // any offline analysis of the counters (observed as non-monotonic
+        // histogram counts and whole families vanishing from `/metrics`).
+        // Label cardinality is bounded by design (`&'static str` values
+        // only), so unbounded-series growth is not a risk here.
         .install_recorder()
         .expect("failed to install Prometheus recorder");
     subduction_core::metrics::describe_all();
@@ -165,6 +174,7 @@ mod tests {
         subduction_core::metrics::sync_duration(2.0);
         subduction_core::metrics::outbound_queue_dwell("longpoll", 5.0, 3);
         subduction_core::metrics::dispatch_permit_waited(0.001);
+        subduction_core::metrics::msg_queue_dwell(0.000_2);
         subduction_core::metrics::mux_pending_duration(0.5);
 
         // Cache counters: 2 hits + 1 miss must render with exactly those totals
@@ -208,29 +218,30 @@ mod tests {
             "storage op histogram should use the fine 50us bucket:\n{storage_lines}"
         );
 
-        // The fine set extends past 1s so a contended storage write (seconds)
-        // isn't clamped to the 1s top bucket — p99 must stay observable.
+        // The fine set extends past 1s so a dispatch or storage write that
+        // stalls for seconds isn't clamped to a low top bucket — the tail
+        // must stay observable up to 60s.
         assert!(
-            storage_lines.contains("le=\"2.5\"") && storage_lines.contains("le=\"10\""),
+            storage_lines.contains("le=\"2.5\"") && storage_lines.contains("le=\"60\""),
             "storage op histogram should carry the >1s tail buckets:\n{storage_lines}"
         );
 
-        // The coarse-only 60s boundary must NOT appear on the fine storage
+        // The coarse-only 300s boundary must NOT appear on the fine storage
         // metric (proving the per-metric override took effect).
         assert!(
-            !storage_lines.contains("le=\"60\""),
-            "storage op histogram should NOT carry the coarse 60s bucket:\n{storage_lines}"
+            !storage_lines.contains("le=\"300\""),
+            "storage op histogram should NOT carry the coarse 300s bucket:\n{storage_lines}"
         );
 
-        // Sync rounds use the coarse set: the 60s boundary exists there.
+        // Sync rounds use the coarse set: the 300s boundary exists there.
         let sync_lines: String = rendered
             .lines()
             .filter(|l| l.contains("subduction_sync_duration_seconds_bucket"))
             .collect::<Vec<_>>()
             .join("\n");
         assert!(
-            sync_lines.contains("le=\"60\""),
-            "sync duration histogram should use the coarse 60s bucket:\n{sync_lines}"
+            sync_lines.contains("le=\"300\""),
+            "sync duration histogram should use the coarse 300s bucket:\n{sync_lines}"
         );
 
         // Outbound dwell/depth render as histograms (not summaries), carry the
@@ -262,6 +273,10 @@ mod tests {
         assert!(
             rendered.contains("subduction_dispatch_permit_wait_seconds_bucket"),
             "permit-wait histogram should render as buckets:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("subduction_msg_queue_dwell_seconds_bucket"),
+            "msg-queue dwell histogram should render as buckets:\n{rendered}"
         );
         assert!(
             rendered.contains("subduction_mux_pending_duration_seconds_bucket"),

--- a/subduction_cli/src/metrics.rs
+++ b/subduction_cli/src/metrics.rs
@@ -20,9 +20,8 @@ use tokio::net::TcpListener;
 /// Fine buckets (seconds) for sub-millisecond/low-millisecond operations:
 /// per-message dispatch and individual storage operations. Resolves down to
 /// 50µs so fast ops don't collapse into one bucket, and extends to 60s so a
-/// dispatch or write that stalls under memory pressure or write contention
-/// isn't clamped to a low top bucket (a saturated top bucket reads as
-/// "p99 = ceiling" and hides how bad the tail really is).
+/// stalled dispatch or write isn't clamped to a saturated top bucket
+/// (which reads as "p99 = ceiling").
 const FINE_BUCKETS_SECONDS: &[f64] = &[
     0.000_05, 0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
     1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
@@ -30,15 +29,14 @@ const FINE_BUCKETS_SECONDS: &[f64] = &[
 
 /// Coarse buckets (seconds) for whole-round operations measured in
 /// milliseconds-to-seconds: foreground sync rounds. Sub-ms resolution would be
-/// wasted series here. Extends to 300s: round-trips queue for minutes when
-/// outbound queues congest, and the previous 60s ceiling clipped the tail.
+/// wasted series here. Extends to 300s so rounds queued behind a congested
+/// outbound path stay observable.
 const COARSE_BUCKETS_SECONDS: &[f64] = &[
     0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
 ];
 
 /// Buckets (seconds) for outbound send-queue dwell — sub-millisecond
-/// (WebSocket) to minutes (congested consumers), so both transports resolve
-/// and a saturated queue's dwell distribution stays observable past 60s.
+/// (WebSocket) to minutes (congested consumers), so both transports resolve.
 const DWELL_BUCKETS_SECONDS: &[f64] = &[
     0.000_5, 0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0,
     300.0,
@@ -56,8 +54,9 @@ const DEPTH_BUCKETS: &[f64] = &[
 /// Initialize the metrics recorder and return a handle for the HTTP endpoint.
 ///
 /// This must be called once at startup before any metrics are recorded.
-/// Configures histogram buckets (so latency panels work) and an idle-eviction
-/// safety valve, then registers HELP/TYPE descriptions for all emitted metrics.
+/// Configures histogram buckets (so latency panels work), then registers
+/// HELP/TYPE descriptions for all emitted metrics. There is no idle-series
+/// eviction; see the builder comment for why.
 ///
 /// # Panics
 ///
@@ -116,12 +115,10 @@ pub fn init_metrics() -> PrometheusHandle {
             COARSE_BUCKETS_SECONDS,
         )
         .expect("coarse buckets are non-empty and sorted")
-        // No idle eviction. Histogram counts are cumulative; evicting an idle
-        // series silently resets it, which breaks `rate()`/`increase()` and
-        // any offline analysis of the counters (observed as non-monotonic
-        // histogram counts and whole families vanishing from `/metrics`).
-        // Label cardinality is bounded by design (`&'static str` values
-        // only), so unbounded-series growth is not a risk here.
+        // No idle eviction: histogram counts are cumulative, so evicting an
+        // idle series silently resets it and breaks `rate()`/`increase()`.
+        // Label cardinality is bounded (`&'static str` values only), so
+        // unbounded-series growth is not a risk.
         .install_recorder()
         .expect("failed to install Prometheus recorder");
     subduction_core::metrics::describe_all();

--- a/subduction_cli/src/server.rs
+++ b/subduction_cli/src/server.rs
@@ -101,7 +101,9 @@ pub(crate) struct ServerArgs {
     #[arg(long)]
     pub(crate) service_name: Option<String>,
 
-    /// Request timeout in seconds
+    /// Roundtrip timeout in seconds for sync calls to peers.
+    ///
+    /// Applied wherever a call resolves [`CallTimeout::Default`].
     #[arg(short, long, default_value = "5")]
     pub(crate) timeout: u64,
 
@@ -509,7 +511,8 @@ where
         .signer(signer.clone())
         .storage(storage, storage_policy)
         .spawner(TokioSpawn)
-        .timer(FuturesTimerTimeout);
+        .timer(FuturesTimerTimeout)
+        .roundtrip_timeout(Duration::from_secs(args.timeout));
 
     let builder = if let Some(max) = args.max_resident_trees {
         tracing::info!(

--- a/subduction_core/src/connection/manager.rs
+++ b/subduction_core/src/connection/manager.rs
@@ -92,6 +92,34 @@ pub enum Command<Conn> {
     Remove(Conn),
 }
 
+/// An inbound message admitted past the per-peer dispatch gate, waiting in
+/// the shared message queue for the listener to spawn its handler.
+///
+/// The [`SemaphoreGuardArc`] is the peer's dispatch permit: acquired in
+/// [`connection_loop`] before enqueueing, moved into the dispatch task, and
+/// released on drop when the handler completes.
+pub struct QueuedDispatch<Conn, WireMsg> {
+    /// The connection the message arrived on.
+    pub conn: Conn,
+    /// The decoded wire message.
+    pub msg: WireMsg,
+    /// The peer's dispatch permit, held until the handler completes.
+    pub permit: SemaphoreGuardArc,
+    /// When the message entered the queue; measures queue dwell.
+    #[cfg(feature = "metrics")]
+    pub enqueued_at: std::time::Instant,
+}
+
+impl<Conn: core::fmt::Debug, WireMsg> core::fmt::Debug for QueuedDispatch<Conn, WireMsg> {
+    // Deliberately skips `msg` (it can embed commit/blob bytes) and the
+    // permit (no useful representation).
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueuedDispatch")
+            .field("conn", &self.conn)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Manages connections by spawning an independent task for each one.
 ///
 /// Unlike [`SelectAll`]-based approaches, each connection runs in its own task,
@@ -125,7 +153,7 @@ pub struct ConnectionManager<
     /// Each message carries a [`SemaphoreGuardArc`] from its peer's dispatch
     /// semaphore, acquired in [`connection_loop`] and held until the spawned
     /// handler completes, which caps in-flight dispatches per peer.
-    messages: async_channel::Sender<(Conn, WireMsg, SemaphoreGuardArc)>,
+    messages: async_channel::Sender<QueuedDispatch<Conn, WireMsg>>,
 
     /// Fast path for response messages (bounded at high capacity).
     ///
@@ -156,7 +184,7 @@ impl<Async: FutureForm, Conn, WireMsg: Encode + Decode, Spawner: Spawn<Async>>
     pub fn new(
         spawner: Spawner,
         commands: async_channel::Receiver<Command<Conn>>,
-        messages: async_channel::Sender<(Conn, WireMsg, SemaphoreGuardArc)>,
+        messages: async_channel::Sender<QueuedDispatch<Conn, WireMsg>>,
         responses: async_channel::Sender<(Conn, WireMsg)>,
         is_response: fn(&WireMsg) -> bool,
         closed: async_channel::Sender<(ConnectionId, Conn)>,
@@ -382,7 +410,7 @@ async fn connection_loop<
 >(
     conn: Conn,
     peer_id: PeerId,
-    messages: async_channel::Sender<(Conn, WireMsg, SemaphoreGuardArc)>,
+    messages: async_channel::Sender<QueuedDispatch<Conn, WireMsg>>,
     responses: async_channel::Sender<(Conn, WireMsg)>,
     is_response: fn(&WireMsg) -> bool,
     dispatch_slots: Arc<Semaphore>,
@@ -416,7 +444,14 @@ async fn connection_loop<
                     };
                     #[cfg(not(feature = "metrics"))]
                     let permit = dispatch_slots.acquire_arc().await;
-                    if messages.send((conn.clone(), msg, permit)).await.is_err() {
+                    let queued = QueuedDispatch {
+                        conn: conn.clone(),
+                        msg,
+                        permit,
+                        #[cfg(feature = "metrics")]
+                        enqueued_at: std::time::Instant::now(),
+                    };
+                    if messages.send(queued).await.is_err() {
                         tracing::warn!(peer = %peer_id, "connection message channel closed");
                         break;
                     }

--- a/subduction_core/src/metrics.rs
+++ b/subduction_core/src/metrics.rs
@@ -36,6 +36,10 @@ pub mod names {
     /// Time spent waiting to acquire a per-peer dispatch permit (0 on the
     /// fast path; grows as a peer saturates its cap).
     pub const DISPATCH_PERMIT_WAIT_SECONDS: &str = "subduction_dispatch_permit_wait_seconds";
+    /// Time an inbound message spent in the shared message queue between the
+    /// connection reader (permit already held) and the listener spawning its
+    /// dispatch task. Growth means the listen loop itself is the bottleneck.
+    pub const MSG_QUEUE_DWELL_SECONDS: &str = "subduction_msg_queue_dwell_seconds";
     /// Total batch sync requests received.
     pub const BATCH_SYNC_REQUESTS_TOTAL: &str = "subduction_batch_sync_requests_total";
     /// Total batch sync responses received.
@@ -225,6 +229,13 @@ pub fn dispatch_completed(outcome: &'static str) {
 pub fn dispatch_permit_waited(wait_secs: f64) {
     metrics::counter!(names::DISPATCH_THROTTLED_TOTAL).increment(1);
     metrics::histogram!(names::DISPATCH_PERMIT_WAIT_SECONDS).record(wait_secs);
+}
+
+/// Record how long an inbound message dwelled in the shared message queue
+/// before the listener picked it up for dispatch.
+#[inline]
+pub fn msg_queue_dwell(dwell_secs: f64) {
+    metrics::histogram!(names::MSG_QUEUE_DWELL_SECONDS).record(dwell_secs);
 }
 
 /// Record a batch sync request.
@@ -491,6 +502,11 @@ pub fn describe_all() {
         names::DISPATCH_PERMIT_WAIT_SECONDS,
         metrics::Unit::Seconds,
         "Time spent waiting to acquire a per-peer dispatch permit (recorded only when the fast-path acquire fails)."
+    );
+    metrics::describe_histogram!(
+        names::MSG_QUEUE_DWELL_SECONDS,
+        metrics::Unit::Seconds,
+        "Time an inbound message spent queued between the connection reader and the listener spawning its dispatch task."
     );
     metrics::describe_counter!(
         names::BATCH_SYNC_REQUESTS_TOTAL,

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -198,9 +198,12 @@ pub struct Subduction<
     /// Backoff state per connection, keyed by [`ConnectionId`].
     reconnect_backoff: Arc<Mutex<Map<ConnectionId, Backoff>>>,
 
-    /// Outgoing subscriptions: sedimentrees we're subscribed to from each peer.
+    /// Outgoing-subscription claims: the sedimentrees this node has (or is
+    /// establishing) an upstream subscription to via each peer. Doubles as
+    /// the dedup/claim map for concurrent propagation.
     ///
-    /// Used to restore subscriptions after reconnection.
+    /// See [`propagate_subscription`](Self::propagate_subscription) for the
+    /// claim lifecycle.
     outgoing_subscriptions: Arc<Mutex<Map<PeerId, Set<SedimentreeId>>>>,
 
     /// Shared monotonic counter for outgoing messages, per peer.
@@ -439,11 +442,8 @@ where
     /// sedimentrees this node has (or is establishing) an upstream
     /// subscription to via that peer.
     ///
-    /// Observability accessor (used by integration tests). Claims are
-    /// dropped on the peer's last-connection teardown and re-established
-    /// by [`propagate_subscription`](Self::propagate_subscription) when a
-    /// later inbound subscribe retriggers it — there is no replay-on-
-    /// reconnect mechanism.
+    /// Observability accessor (used by integration tests). Claims drop on
+    /// the peer's last-connection teardown; there is no replay-on-reconnect.
     pub async fn get_peer_subscriptions(&self, peer_id: PeerId) -> Set<SedimentreeId> {
         self.outgoing_subscriptions
             .lock()
@@ -513,9 +513,12 @@ where
         self.reconnect_backoff.lock().await.remove(&conn_id);
     }
 
-    /// Track an outgoing subscription for reconnection restoration.
+    /// Record an established outgoing-subscription claim toward a peer.
     ///
-    /// Called internally when `sync_with_peer` is called with `subscribe: true`.
+    /// Called internally when `sync_with_peer` establishes a subscription
+    /// (`subscribe: true`). See
+    /// [`propagate_subscription`](Self::propagate_subscription) for the
+    /// claim lifecycle.
     async fn track_outgoing_subscription(&self, peer_id: PeerId, sedimentree_id: SedimentreeId) {
         self.outgoing_subscriptions
             .lock()
@@ -865,9 +868,9 @@ where
         // currently-connected peers.
         //
         // Unconditional, unlike the send-counter clear below: under a
-        // concurrent reconnect, clearing a fresh claim merely costs one
-        // redundant (idempotent) re-propagation, while keeping a stale
-        // claim suppresses re-establishment entirely.
+        // concurrent reconnect, clearing a fresh claim costs one redundant
+        // (idempotent) re-propagation, while keeping a stale claim
+        // suppresses re-establishment entirely.
         self.outgoing_subscriptions.lock().await.remove(peer_id);
 
         // Clear the send counter while holding the `connections` lock and

--- a/subduction_core/src/subduction.rs
+++ b/subduction_core/src/subduction.rs
@@ -73,7 +73,7 @@ use crate::{
         backoff::Backoff,
         id::ConnectionId,
         managed::{CallError, ManagedCall, ManagedConnection},
-        manager::{Command, ConnectionManager, RunManager},
+        manager::{Command, ConnectionManager, QueuedDispatch, RunManager},
         message::{
             BatchSyncRequest, BatchSyncResponse, DataRequestRejected, RequestedData, SyncDiff,
             SyncMessage, SyncResult, TryAsBatchSyncResponse, TryAsSubscribeRequest,
@@ -211,8 +211,7 @@ pub struct Subduction<
     send_counter: PeerCounter,
 
     manager_channel: Sender<Command<Authenticated<Conn, Async>>>,
-    msg_queue:
-        async_channel::Receiver<(Authenticated<Conn, Async>, Hdl::Message, SemaphoreGuardArc)>,
+    msg_queue: async_channel::Receiver<QueuedDispatch<Authenticated<Conn, Async>, Hdl::Message>>,
     response_queue: async_channel::Receiver<(Authenticated<Conn, Async>, Hdl::Message)>,
     connection_closed: async_channel::Receiver<(ConnectionId, Authenticated<Conn, Async>)>,
 
@@ -436,9 +435,15 @@ where
         backoff.next_delay()
     }
 
-    /// Get the sedimentrees we're subscribed to from a peer.
+    /// Get the outgoing-subscription claims held toward a peer: the
+    /// sedimentrees this node has (or is establishing) an upstream
+    /// subscription to via that peer.
     ///
-    /// Used to restore subscriptions after successful reconnection.
+    /// Observability accessor (used by integration tests). Claims are
+    /// dropped on the peer's last-connection teardown and re-established
+    /// by [`propagate_subscription`](Self::propagate_subscription) when a
+    /// later inbound subscribe retriggers it — there is no replay-on-
+    /// reconnect mechanism.
     pub async fn get_peer_subscriptions(&self, peer_id: PeerId) -> Set<SedimentreeId> {
         self.outgoing_subscriptions
             .lock()
@@ -851,6 +856,19 @@ where
     ) {
         Self::cancel_detached_muxes(muxes).await;
         peers::remove_peer_from_subscriptions(&self.subscriptions, *peer_id).await;
+
+        // Drop the peer's outgoing-subscription claims. The remote forgets
+        // our subscriptions when the connection dies, so a surviving claim
+        // would make `propagate_subscription` skip re-establishing them
+        // after a reconnect — leaving this node silently unsubscribed
+        // upstream. Clearing here also keeps the claim map bounded to
+        // currently-connected peers.
+        //
+        // Unconditional, unlike the send-counter clear below: under a
+        // concurrent reconnect, clearing a fresh claim merely costs one
+        // redundant (idempotent) re-propagation, while keeping a stale
+        // claim suppresses re-establishment entirely.
+        self.outgoing_subscriptions.lock().await.remove(peer_id);
 
         // Clear the send counter while holding the `connections` lock and
         // only if the peer is still gone. The caller removed the peer
@@ -1969,11 +1987,18 @@ where
     /// Any other outcome — `Err`, timeout, or `NotFound`/`Unauthorized`
     /// (both `Ok((false, ..))`) — rolls the claim back so a later
     /// subscribe retries, keeping [`outgoing_subscriptions`] limited to
-    /// established subscriptions (as [`get_peer_subscriptions`] assumes
-    /// when replaying them on reconnect).
+    /// established subscriptions.
+    ///
+    /// # Lifecycle
+    ///
+    /// Claims live only as long as the target peer's connection: the
+    /// peer's last-connection teardown drops them (the remote forgot our
+    /// subscriptions when the connection died), and a later inbound
+    /// subscribe re-establishes them through this method. There is no
+    /// replay-on-reconnect; re-propagation is driven entirely by
+    /// subsequent subscribes.
     ///
     /// [`outgoing_subscriptions`]: Self::outgoing_subscriptions
-    /// [`get_peer_subscriptions`]: Self::get_peer_subscriptions
     pub(crate) async fn propagate_subscription(&self, id: SedimentreeId, originator: PeerId) {
         let peers: Vec<PeerId> = {
             let conns = self.connections.lock().await;
@@ -3110,7 +3135,10 @@ where
                     // The per-peer permit was acquired upstream in the
                     // connection reader and rides the queue here; it's moved
                     // into the dispatch task and released on completion.
-                    if let Ok((conn, msg, permit)) = received {
+                    if let Ok(queued) = received {
+                        #[cfg(feature = "metrics")]
+                        crate::metrics::msg_queue_dwell(queued.enqueued_at.elapsed().as_secs_f64());
+                        let QueuedDispatch { conn, msg, permit, .. } = queued;
                         let peer_id = conn.peer_id();
                         // Don't Debug-format `msg` — it can embed commit/blob bytes.
                         tracing::trace!(peer = %peer_id, "listener received message");

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -1110,8 +1110,8 @@ async fn relay_repropagates_subscription_after_peer_reconnect() -> TestResult {
 
     // End-to-end: A's new commit must reach B through R. R forwards
     // received commits to *subscribers only* (no broadcast fallback on
-    // the relay path), so delivery proves the mutual push link to B was
-    // genuinely re-established rather than assumed from stale state.
+    // the relay path), so delivery proves the push link to B was
+    // re-established rather than assumed from stale state.
     a.add_commit(sed_id, make_head(77), BTreeSet::new(), make_blob(77))
         .await?;
     let delivered = wait_until(|| {

--- a/subduction_core/tests/relay_topology_sync.rs
+++ b/subduction_core/tests/relay_topology_sync.rs
@@ -1019,3 +1019,111 @@ async fn relay_topology_unauthorized_upstream_response_rolls_back_claim() -> Tes
 
     Ok(())
 }
+
+/// A peer's last-connection teardown must drop the outgoing-subscription
+/// claims held toward it. The remote forgets our subscriptions when the
+/// connection dies, so a surviving claim would suppress re-establishment
+/// forever (silent unsubscription) and the map would grow without bound
+/// as peers come and go.
+#[tokio::test]
+async fn relay_drops_outgoing_claims_on_peer_disconnect() -> TestResult {
+    let (a, r, _b, _a_s, r_signer, b_signer) = setup_relay_topology().await?;
+
+    let sed_id = SedimentreeId::new([43u8; 32]);
+    let r_peer = PeerId::from(r_signer.verifying_key());
+    let b_peer = PeerId::from(b_signer.verifying_key());
+
+    // A subscribes to R; R propagates upstream to B and claims (B, id).
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    let established = wait_until(|| {
+        let r = Arc::clone(&r);
+        async move { r.get_peer_subscriptions(b_peer).await.contains(&sed_id) }
+    })
+    .await;
+    assert!(established, "propagation to B never established");
+
+    // Drop R's last connection to B.
+    r.disconnect_from_peer(&b_peer).await?;
+
+    let cleared = wait_until(|| {
+        let r = Arc::clone(&r);
+        async move { r.get_peer_subscriptions(b_peer).await.is_empty() }
+    })
+    .await;
+    assert!(
+        cleared,
+        "teardown left stale outgoing-subscription claims toward B: {:?}",
+        r.get_peer_subscriptions(b_peer).await
+    );
+
+    Ok(())
+}
+
+/// After an upstream peer disconnects and reconnects, a fresh inbound
+/// subscribe must re-propagate — re-establishing both the upstream
+/// subscription and the mutual push link — so updates flow end-to-end
+/// again. Guards the "silent unsubscription" regression: with a stale
+/// claim surviving the disconnect, R would skip re-propagation and B
+/// would never see A's commits.
+#[tokio::test]
+async fn relay_repropagates_subscription_after_peer_reconnect() -> TestResult {
+    let (a, r, b, _a_s, r_signer, b_signer) = setup_relay_topology().await?;
+
+    let sed_id = SedimentreeId::new([44u8; 32]);
+    let r_peer = PeerId::from(r_signer.verifying_key());
+    let b_peer = PeerId::from(b_signer.verifying_key());
+
+    // Establish: A subscribes to R; R propagates to B.
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    let established = wait_until(|| {
+        let r = Arc::clone(&r);
+        async move { r.get_peer_subscriptions(b_peer).await.contains(&sed_id) }
+    })
+    .await;
+    assert!(established, "initial propagation to B never established");
+
+    // Sever R↔B (both sides), then reconnect with fresh transports.
+    r.disconnect_from_peer(&b_peer).await?;
+    let _ = b.disconnect_from_peer(&r_peer).await;
+    let cleared = wait_until(|| {
+        let r = Arc::clone(&r);
+        async move { r.get_peer_subscriptions(b_peer).await.is_empty() }
+    })
+    .await;
+    assert!(cleared, "claims not cleared before reconnect");
+    connect_pair(&r, &r_signer, &b, &b_signer).await?;
+
+    // A re-subscribes; R must re-propagate to the reconnected B.
+    a.sync_with_peer(&r_peer, sed_id, true, SYNC_TIMEOUT)
+        .await?;
+    let reestablished = wait_until(|| {
+        let r = Arc::clone(&r);
+        async move { r.get_peer_subscriptions(b_peer).await.contains(&sed_id) }
+    })
+    .await;
+    assert!(
+        reestablished,
+        "R did not re-propagate A's subscription after B reconnected"
+    );
+
+    // End-to-end: A's new commit must reach B through R. R forwards
+    // received commits to *subscribers only* (no broadcast fallback on
+    // the relay path), so delivery proves the mutual push link to B was
+    // genuinely re-established rather than assumed from stale state.
+    a.add_commit(sed_id, make_head(77), BTreeSet::new(), make_blob(77))
+        .await?;
+    let delivered = wait_until(|| {
+        let b = Arc::clone(&b);
+        async move { b.get_commits(sed_id).await.map(|c| c.len()) == Some(1) }
+    })
+    .await;
+    assert!(
+        delivered,
+        "A's commit never reached B after reconnect: B has {:?}",
+        b.get_commits(sed_id).await.map(|c| c.len())
+    );
+
+    Ok(())
+}

--- a/subduction_redb_storage/src/lib.rs
+++ b/subduction_redb_storage/src/lib.rs
@@ -133,6 +133,14 @@ pub const BLOBS_DIR_NAME: &str = "blobs";
 /// 64 KiB values.
 pub const DEFAULT_INLINE_THRESHOLD: usize = 16 * 1024;
 
+/// Default redb page-cache budget in bytes (1 GiB).
+///
+/// This matches redb's own built-in default, but is set explicitly so the
+/// process memory budget is visible here rather than buried in a
+/// dependency. The cache lives on the *heap* (counts toward RSS and any
+/// cgroup memory limit), not in the kernel page cache.
+pub const DEFAULT_CACHE_SIZE: usize = 1024 * 1024 * 1024;
+
 /// Hybrid redb + filesystem storage.
 ///
 /// Cheap to clone (the database handle and paths are shared). All
@@ -181,6 +189,24 @@ impl RedbStorage {
         root: impl AsRef<Path>,
         inline_threshold: usize,
     ) -> Result<Self, RedbStorageError> {
+        Self::with_settings(root, inline_threshold, DEFAULT_CACHE_SIZE)
+    }
+
+    /// Open (or create) hybrid storage with a custom inline threshold and
+    /// redb page-cache budget.
+    ///
+    /// `cache_size` bounds redb's in-heap page cache; see
+    /// [`DEFAULT_CACHE_SIZE`] for the memory-accounting caveat.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directories or database cannot be
+    /// created/opened, or the tables cannot be initialized.
+    pub fn with_settings(
+        root: impl AsRef<Path>,
+        inline_threshold: usize,
+        cache_size: usize,
+    ) -> Result<Self, RedbStorageError> {
         let root = root.as_ref();
         std::fs::create_dir_all(root).file_context(FileOp::CreateDir, root)?;
         let blobs_dir = root.join(BLOBS_DIR_NAME);
@@ -193,7 +219,9 @@ impl RedbStorage {
             fsync_dir_sync(parent)?;
         }
 
-        let db = Database::create(root.join(DB_FILE_NAME))?;
+        let db = Database::builder()
+            .set_cache_size(cache_size)
+            .create(root.join(DB_FILE_NAME))?;
 
         // Materialize all tables up front so read transactions never hit
         // `TableDoesNotExist`.

--- a/subduction_redb_storage/src/lib.rs
+++ b/subduction_redb_storage/src/lib.rs
@@ -167,7 +167,7 @@ impl RedbStorage {
     ///
     /// Returns an error if the directories or database cannot be
     /// created/opened, or the tables cannot be initialized.
-    pub fn new(root: impl AsRef<Path>) -> Result<Self, RedbStorageError> {
+    pub fn new<P: AsRef<Path>>(root: P) -> Result<Self, RedbStorageError> {
         Self::with_inline_threshold(root, DEFAULT_INLINE_THRESHOLD)
     }
 
@@ -185,8 +185,8 @@ impl RedbStorage {
     ///
     /// Returns an error if the directories or database cannot be
     /// created/opened, or the tables cannot be initialized.
-    pub fn with_inline_threshold(
-        root: impl AsRef<Path>,
+    pub fn with_inline_threshold<P: AsRef<Path>>(
+        root: P,
         inline_threshold: usize,
     ) -> Result<Self, RedbStorageError> {
         Self::with_settings(root, inline_threshold, DEFAULT_CACHE_SIZE)
@@ -202,8 +202,8 @@ impl RedbStorage {
     ///
     /// Returns an error if the directories or database cannot be
     /// created/opened, or the tables cannot be initialized.
-    pub fn with_settings(
-        root: impl AsRef<Path>,
+    pub fn with_settings<P: AsRef<Path>>(
+        root: P,
         inline_threshold: usize,
         cache_size: usize,
     ) -> Result<Self, RedbStorageError> {


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

- Drop outgoing-subscription claims on peer teardown (fixing silent unsubscription after reconnect in relay topologies)
- Set an explicit redb cache budget
- Wire --timeout through to the roundtrip deadline
- Extend metrics (msg-queue dwell, longer histogram tails, no idle-series eviction) so queue saturation stays observable

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [x] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
