### PR TITLE
Nonblocking Pings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "rev": "eba91ae4f4a48eedab31777ed817d3c593cee7a8",
         "revCount": 6,
         "type": "git",
-        "url": "https://codeberg.org/expede/nix-command-utils"
+        "url": "https://tangled.org/expede.wtf/nix-command-utils"
       },
       "original": {
         "type": "git",
-        "url": "https://codeberg.org/expede/nix-command-utils"
+        "url": "https://tangled.org/expede.wtf/nix-command-utils"
       }
     },
     "flake-utils": {
@@ -83,21 +83,6 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-grafana": {
-      "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-25.05",
-        "type": "indirect"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1785133411,
@@ -118,7 +103,6 @@
         "flake-utils": "flake-utils_2",
         "nixos-unstable": "nixos-unstable",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-grafana": "nixpkgs-grafana",
         "rust-overlay": "rust-overlay",
         "wasm-bodge-src": "wasm-bodge-src"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,13 +5,7 @@
     nixpkgs.url = "nixpkgs/nixos-26.05";
     nixos-unstable.url = "nixpkgs/nixos-unstable-small";
 
-    # Pinned solely for Grafana 12.x: nixos-26.05 ships Grafana 13.x, but the
-    # provisioned dashboard targets the 12.x schema and 13.x has proven
-    # GC-volatile in the dev store. The pinned 12.x is added to the dev shell
-    # (a gc root) so `monitoring:start` cannot lose its binary to GC.
-    nixpkgs-grafana.url = "nixpkgs/nixos-25.05";
-
-    command-utils.url = "git+https://codeberg.org/expede/nix-command-utils";
+    command-utils.url = "git+https://tangled.org/expede.wtf/nix-command-utils";
     flake-utils.url = "github:numtide/flake-utils";
 
     rust-overlay = {
@@ -30,7 +24,6 @@
     flake-utils,
     nixos-unstable,
     nixpkgs,
-    nixpkgs-grafana,
     rust-overlay,
     command-utils,
     wasm-bodge-src
@@ -57,12 +50,6 @@
           inherit system overlays;
           config.allowUnfree = true;
         };
-
-        # Grafana 12.x, pinned for the local `monitoring:start` dev command.
-        grafanaPinned = (import nixpkgs-grafana {
-          inherit system;
-          config.allowUnfree = true;
-        }).grafana;
 
         rustVersion = "1.91.0";
 
@@ -158,7 +145,7 @@
 
         # Project-specific commands (monitoring, etc.)
         projectCommands = import ./nix/commands.nix {
-          inherit pkgs system cmd wasm-bodge grafanaPinned;
+          inherit pkgs system cmd wasm-bodge;
         };
 
         command_menu = command-utils.commands.${system} [
@@ -257,7 +244,7 @@
               pkgs.chromedriver
               pkgs.esbuild
               pkgs.gnuplot
-              grafanaPinned
+              pkgs.grafana
               pkgs.grafana-loki
               pkgs.http-server
               pnpm

--- a/nix/commands.nix
+++ b/nix/commands.nix
@@ -4,11 +4,12 @@
   system,
   cmd,
   wasm-bodge,
-  grafanaPinned,
 }: let
   cargo = "${pkgs.cargo}/bin/cargo";
-  grafana-server = "${grafanaPinned}/bin/grafana-server";
-  grafana-homepath = "${grafanaPinned}/share/grafana";
+  # Grafana 13 replaced the `grafana-server` binary with a `server`
+  # subcommand on the unified `grafana` binary.
+  grafana-bin = "${pkgs.grafana}/bin/grafana";
+  grafana-homepath = "${pkgs.grafana}/share/grafana";
   pnpm = "${pkgs.pnpm}/bin/pnpm";
   playwright = "${pnpm} --dir=./subduction_wasm exec playwright";
   loki = "${pkgs.grafana-loki}/bin/loki";
@@ -506,7 +507,7 @@
 
       LOKI_BIN="${loki}"
       PROM_BIN="${prometheus}"
-      GRAFANA_BIN="${grafana-server}"
+      GRAFANA_BIN="${grafana-bin}"
       GRAFANA_HOME="${grafana-homepath}"
 
       # Pre-flight: fail loudly if a pinned binary is missing (e.g. its Nix
@@ -582,7 +583,7 @@
       PROM_PID=$!
       wait_for_port "Prometheus" 9092 "$PROM_PID"
 
-      "$GRAFANA_BIN" \
+      "$GRAFANA_BIN" server \
         --homepath="$GRAFANA_HOME" \
         --config="$WORKSPACE_ROOT/subduction_cli/monitoring/grafana/grafana.ini" \
         cfg:paths.data=/tmp/grafana-data \

--- a/subduction_cli/monitoring/grafana/grafana.ini
+++ b/subduction_cli/monitoring/grafana/grafana.ini
@@ -5,10 +5,11 @@ root_url = http://localhost:3939
 [paths]
 provisioning = provisioning
 
+# Grafana 13+: anonymous access is viewer-only (Admin is no longer honored).
 [auth.anonymous]
 enabled = true
 org_name = Main Org.
-org_role = Admin
+org_role = Viewer
 
 [auth]
 disable_login_form = true

--- a/subduction_cli/src/handler.rs
+++ b/subduction_cli/src/handler.rs
@@ -41,7 +41,7 @@ pub(crate) type CliConn = MessageTransport<UnifiedTransport>;
 
 /// The concrete ephemeral handler type for the CLI server.
 pub(crate) type CliEphemeralHandler =
-    EphemeralHandler<Sendable, CliConn, OpenEphemeralPolicy, StdClock>;
+    EphemeralHandler<Sendable, CliConn, OpenEphemeralPolicy, StdClock, TokioSpawn>;
 
 /// The concrete keyhive protocol type for the CLI server.
 pub(crate) type CliKeyhiveProtocol =

--- a/subduction_cli/src/server.rs
+++ b/subduction_cli/src/server.rs
@@ -567,6 +567,7 @@ where
                 OpenEphemeralPolicy,
                 EphemeralConfig::default(),
                 StdClock,
+                TokioSpawn,
             );
 
             // Drain ephemeral events — the server is a relay, not a consumer.

--- a/subduction_core/src/connection/managed.rs
+++ b/subduction_core/src/connection/managed.rs
@@ -227,11 +227,16 @@ where
     ///
     /// # Deadline (`timeout`)
     ///
-    /// This is the **low-level** entry point. `timeout` is a *total deadline*,
-    /// **not** a fallback to the configured default:
+    /// This is the **low-level** entry point. `timeout` is a *total deadline*
+    /// covering both the transport send and the response wait, **not** a
+    /// fallback to the configured default:
     ///
-    /// - `Some(d)` — fail with [`CallError::Timeout`] if no response arrives
-    ///   within `d`.
+    /// - `Some(d)` — fail with [`CallError::Timeout`] if the request cannot
+    ///   be sent *and* answered within `d`. A send that parks (bounded
+    ///   transport queue behind a backpressured connection) consumes the
+    ///   budget rather than waiting unboundedly with a live pending entry.
+    ///   The dropped send future enqueues nothing — the bundled transports'
+    ///   sends are cancel-safe channel enqueues.
     /// - `None` — **no deadline**: the bare cancel-safe wait. The caller owns
     ///   the cancellation policy (wrap in an outer `select!`/`timeout`/shutdown
     ///   token; dropping this future removes the pending entry). The call still
@@ -268,31 +273,39 @@ where
             let mut guard = PendingGuard::new(Arc::clone(&self.multiplexer), req_id);
 
             let wire_msg: WireMsg = SyncMessage::BatchSyncRequest(req).into();
-            Connection::<Sendable, WireMsg>::send(&self.authenticated, &wire_msg)
-                .await
-                .map_err(CallError::Send)?;
+            // The deadline covers the send AND the response wait: a send
+            // parked on a bounded transport queue must consume the caller's
+            // budget instead of holding a live pending entry unboundedly.
+            let send_then_wait = async move {
+                Connection::<Sendable, WireMsg>::send(&self.authenticated, &wire_msg)
+                    .await
+                    .map_err(CallError::Send)?;
+                Ok(rx.await)
+            };
 
-            // `Some(d)` wraps the wait in a deadline; `None` is the bare
-            // (uncapped) cancel-safe wait.
+            // `Some(d)` wraps the roundtrip in a deadline; `None` is the
+            // bare (uncapped) cancel-safe wait.
             let waited = match timeout {
-                Some(deadline) => self.timer.timeout(deadline, rx.boxed()).await,
-                None => Ok(rx.await),
+                Some(deadline) => self.timer.timeout(deadline, send_then_wait.boxed()).await,
+                None => Ok(send_then_wait.await),
             };
 
             match waited {
-                Ok(Ok(resp)) => {
+                Ok(Ok(Ok(resp))) => {
                     // Entry already removed by `resolve_pending`.
                     guard.disarm();
                     tracing::debug!(req = ?req_id, "request completed");
                     Ok(resp)
                 }
-                Ok(Err(_)) => {
+                Ok(Ok(Err(_))) => {
                     // Sender dropped (e.g. `cancel_all_pending` on disconnect)
                     // already removed the entry.
                     guard.disarm();
                     tracing::debug!(req = ?req_id, "request response channel dropped");
                     Err(CallError::ResponseDropped)
                 }
+                // Send failed; the armed guard removes the pending entry.
+                Ok(Err(send_err)) => Err(send_err),
                 Err(TimedOut) => {
                     // Deadline elapsed with the entry still registered; let
                     // the armed guard remove it on drop.
@@ -351,28 +364,35 @@ where
             let mut guard = PendingGuard::new(Arc::clone(&self.multiplexer), req_id);
 
             let wire_msg: WireMsg = SyncMessage::BatchSyncRequest(req).into();
-            Connection::<Local, WireMsg>::send(&self.authenticated, &wire_msg)
-                .await
-                .map_err(CallError::Send)?;
+            // See the `Sendable` variant: the deadline covers send + wait.
+            let send_then_wait = async move {
+                Connection::<Local, WireMsg>::send(&self.authenticated, &wire_msg)
+                    .await
+                    .map_err(CallError::Send)?;
+                Ok(rx.await)
+            };
 
-            // `Some(d)` wraps the wait in a deadline; `None` is the bare
-            // (uncapped) cancel-safe wait.
             let waited = match timeout {
-                Some(deadline) => self.timer.timeout(deadline, rx.boxed_local()).await,
-                None => Ok(rx.await),
+                Some(deadline) => {
+                    self.timer
+                        .timeout(deadline, send_then_wait.boxed_local())
+                        .await
+                }
+                None => Ok(send_then_wait.await),
             };
 
             match waited {
-                Ok(Ok(resp)) => {
+                Ok(Ok(Ok(resp))) => {
                     guard.disarm();
                     tracing::debug!(req = ?req_id, "request completed");
                     Ok(resp)
                 }
-                Ok(Err(_)) => {
+                Ok(Ok(Err(_))) => {
                     guard.disarm();
                     tracing::debug!(req = ?req_id, "request response channel dropped");
                     Err(CallError::ResponseDropped)
                 }
+                Ok(Err(send_err)) => Err(send_err),
                 Err(TimedOut) => {
                     tracing::warn!(req = ?req_id, timeout = ?timeout, "request timed out");
                     Err(CallError::Timeout)

--- a/subduction_core/src/connection/test_utils.rs
+++ b/subduction_core/src/connection/test_utils.rs
@@ -713,6 +713,12 @@ pub fn test_signer() -> MemorySigner {
 }
 
 /// A spawner that doesn't actually spawn (for tests that don't need task execution).
+///
+/// The future is dropped without being polled: no side effects run and
+/// nothing is delivered. Drop-based cleanup still executes (e.g.
+/// `EphemeralHandler`'s RAII in-flight guards release, keeping accounting
+/// correct). Tests that assert on delivery or other task side effects
+/// should use [`TokioSpawn`] instead.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TestSpawn;
 

--- a/subduction_core/src/metrics.rs
+++ b/subduction_core/src/metrics.rs
@@ -267,6 +267,13 @@ pub fn keepalive_close() {
     metrics::counter!(names::KEEPALIVE_CLOSES_TOTAL).increment(1);
 }
 
+/// Record a keepalive cycle whose ping could not be delivered (queue full
+/// for the whole pong window with zero drainage).
+#[inline]
+pub fn keepalive_ping_undelivered() {
+    metrics::counter!(names::KEEPALIVE_PINGS_UNDELIVERED_TOTAL).increment(1);
+}
+
 /// A correlated request was registered (pending++).
 #[inline]
 pub fn mux_request_registered() {
@@ -634,6 +641,10 @@ pub fn describe_all() {
     metrics::describe_counter!(
         names::KEEPALIVE_CLOSES_TOTAL,
         "Connections closed by keepalive after the pong-miss threshold (the server reaping an unresponsive peer)."
+    );
+    metrics::describe_counter!(
+        names::KEEPALIVE_PINGS_UNDELIVERED_TOTAL,
+        "Keepalive cycles whose ping could not be delivered (outbound queue full with zero drainage for the whole window); liveness rode on the write-progress gate alone."
     );
     metrics::describe_gauge!(
         names::MUX_PENDING,

--- a/subduction_core/src/metrics/names.rs
+++ b/subduction_core/src/metrics/names.rs
@@ -84,9 +84,13 @@ pub const REQUESTED_DATA_SEND_FAILURES_TOTAL: &str =
 /// outbound queue dwell: dwell above the sync timeout manufactures these.
 pub const LATE_RESPONSES_TOTAL: &str = "subduction_late_responses_total";
 /// Keepalive pongs missed (one per miss, before the close threshold).
+/// Also counts cycles whose ping was dropped because the outbound queue
+/// was full — a wedged connection misses without any ping reaching the
+/// wire. Cycles forgiven by the write-progress gate do not count.
 pub const KEEPALIVE_PONGS_MISSED_TOTAL: &str = "subduction_keepalive_pongs_missed_total";
-/// Connections closed by keepalive (pong-miss threshold reached) — the
-/// server reaping an unresponsive peer.
+/// Connections closed by keepalive — the server reaping an unresponsive
+/// peer, either via the pong-miss threshold or via the
+/// progress-but-no-pong hard ceiling.
 pub const KEEPALIVE_CLOSES_TOTAL: &str = "subduction_keepalive_closes_total";
 
 // Multiplexer (request/response correlation).

--- a/subduction_core/src/metrics/names.rs
+++ b/subduction_core/src/metrics/names.rs
@@ -98,8 +98,7 @@ pub const KEEPALIVE_CLOSES_TOTAL: &str = "subduction_keepalive_closes_total";
 /// Undelivered pings accrue no liveness evidence, so a sustained nonzero
 /// rate means the end-to-end (pong) check is blind for those connections
 /// and liveness rests on the write-progress gate alone.
-pub const KEEPALIVE_PINGS_UNDELIVERED_TOTAL: &str =
-    "subduction_keepalive_pings_undelivered_total";
+pub const KEEPALIVE_PINGS_UNDELIVERED_TOTAL: &str = "subduction_keepalive_pings_undelivered_total";
 // Multiplexer (request/response correlation).
 /// Outstanding correlated requests awaiting a response (across all muxes).
 pub const MUX_PENDING: &str = "subduction_mux_pending";

--- a/subduction_core/src/metrics/names.rs
+++ b/subduction_core/src/metrics/names.rs
@@ -92,6 +92,15 @@ pub const KEEPALIVE_PONGS_MISSED_TOTAL: &str = "subduction_keepalive_pongs_misse
 /// peer, either via the pong-miss threshold or via the
 /// progress-but-no-pong hard ceiling.
 pub const KEEPALIVE_CLOSES_TOTAL: &str = "subduction_keepalive_closes_total";
+/// Keepalive cycles in which the ping could not be delivered at all: the
+/// outbound queue was full at every attempt AND the sender task completed
+/// no frame during the pong window (zero drainage — no injection point).
+/// Undelivered pings accrue no liveness evidence against the peer, so
+/// this counter is the honest measure of how often congestion blinds the
+/// end-to-end (pong-based) check. Sustained nonzero rates mean liveness
+/// is riding on the write-progress gate alone for those connections.
+pub const KEEPALIVE_PINGS_UNDELIVERED_TOTAL: &str =
+    "subduction_keepalive_pings_undelivered_total";
 
 // Multiplexer (request/response correlation).
 /// Outstanding correlated requests awaiting a response (across all muxes).

--- a/subduction_core/src/metrics/names.rs
+++ b/subduction_core/src/metrics/names.rs
@@ -92,15 +92,14 @@ pub const KEEPALIVE_PONGS_MISSED_TOTAL: &str = "subduction_keepalive_pongs_misse
 /// peer, either via the pong-miss threshold or via the
 /// progress-but-no-pong hard ceiling.
 pub const KEEPALIVE_CLOSES_TOTAL: &str = "subduction_keepalive_closes_total";
-/// Keepalive cycles in which the ping could not be delivered at all: the
-/// outbound queue was full at every attempt AND the sender task completed
-/// no frame during the pong window (zero drainage — no injection point).
-/// Undelivered pings accrue no liveness evidence against the peer, so
-/// this counter is the honest measure of how often congestion blinds the
-/// end-to-end (pong-based) check. Sustained nonzero rates mean liveness
-/// is riding on the write-progress gate alone for those connections.
-pub const KEEPALIVE_PINGS_UNDELIVERED_TOTAL: &str = "subduction_keepalive_pings_undelivered_total";
-
+/// Keepalive cycles whose ping could not be delivered: the outbound queue
+/// was full at every attempt and the sender task completed no frame
+/// during the pong window (zero drainage, so no injection point either).
+/// Undelivered pings accrue no liveness evidence, so a sustained nonzero
+/// rate means the end-to-end (pong) check is blind for those connections
+/// and liveness rests on the write-progress gate alone.
+pub const KEEPALIVE_PINGS_UNDELIVERED_TOTAL: &str =
+    "subduction_keepalive_pings_undelivered_total";
 // Multiplexer (request/response correlation).
 /// Outstanding correlated requests awaiting a response (across all muxes).
 pub const MUX_PENDING: &str = "subduction_mux_pending";

--- a/subduction_core/src/metrics/names.rs
+++ b/subduction_core/src/metrics/names.rs
@@ -99,8 +99,7 @@ pub const KEEPALIVE_CLOSES_TOTAL: &str = "subduction_keepalive_closes_total";
 /// this counter is the honest measure of how often congestion blinds the
 /// end-to-end (pong-based) check. Sustained nonzero rates mean liveness
 /// is riding on the write-progress gate alone for those connections.
-pub const KEEPALIVE_PINGS_UNDELIVERED_TOTAL: &str =
-    "subduction_keepalive_pings_undelivered_total";
+pub const KEEPALIVE_PINGS_UNDELIVERED_TOTAL: &str = "subduction_keepalive_pings_undelivered_total";
 
 // Multiplexer (request/response correlation).
 /// Outstanding correlated requests awaiting a response (across all muxes).

--- a/subduction_core/tests/roundtrip_timeout_default.rs
+++ b/subduction_core/tests/roundtrip_timeout_default.rs
@@ -155,3 +155,64 @@ async fn call_timeout_default_uses_builder_configured_deadline() -> TestResult {
 
     Ok(())
 }
+
+/// The deadline covers the *send phase*, not just the response wait.
+///
+/// Wedging OUR transport parks the request send forever (a bounded
+/// transport queue behind a backpressured connection looks the same). The
+/// call must still resolve at the configured deadline with
+/// [`CallError::Timeout`] — with a send-phase gap it would hang until the
+/// outer test bound and fail. This is the mechanism that froze
+/// `mux_pending` during the 2026-07 incidents: senders parked with live
+/// pending entries and no running timer.
+#[tokio::test(flavor = "current_thread")]
+async fn call_timeout_covers_wedged_send_phase() -> TestResult {
+    let a_signer = make_signer(52);
+    let b_signer = make_signer(53);
+    let a = make_node_with_default(a_signer.clone(), CONFIGURED_DEFAULT);
+    let b = make_node_with_default(b_signer.clone(), CONFIGURED_DEFAULT);
+
+    let (t_a, _t_b) = connect_pair(&a, &a_signer, &b, &b_signer).await?;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Wedge OUR side: A's `send_bytes` parks forever, so the request never
+    // leaves and no response can ever arrive. Only a deadline that covers
+    // the send phase can resolve this call.
+    t_a.pause();
+
+    let sed_id = SedimentreeId::new([10u8; 32]);
+    let started = std::time::Instant::now();
+
+    let result = tokio::time::timeout(
+        BOUND,
+        a.sync_with_all_peers(sed_id, true, CallTimeout::Default),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "a call whose send parks must consume its deadline; hanging past \
+         {BOUND:?} means the deadline covers only the response wait"
+    );
+    let per_peer = result.expect("did not resolve in time")?;
+
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= CONFIGURED_DEFAULT,
+        "call resolved in {elapsed:?}, before the configured \
+         {CONFIGURED_DEFAULT:?} deadline could have elapsed"
+    );
+
+    let b_peer = PeerId::from(b_signer.verifying_key());
+    let (success, _stats, conn_errs) = per_peer
+        .get(&b_peer)
+        .expect("peer must be present in the result map");
+    assert!(!success, "wedged send should not have succeeded");
+    assert!(
+        matches!(conn_errs[0].1, CallError::Timeout),
+        "a parked send must resolve as Timeout; got {:?}",
+        conn_errs[0].1
+    );
+
+    Ok(())
+}

--- a/subduction_ephemeral/src/handler.rs
+++ b/subduction_ephemeral/src/handler.rs
@@ -107,6 +107,14 @@ pub struct EphemeralHandler<
     /// harmlessly. Increment/decrement pairing is enforced by
     /// [`InflightGuard`] (RAII), so counters cannot leak even if a fan-out
     /// future is cancelled, aborted, or never polled.
+    ///
+    /// The generation guarantee holds when the disconnect is observed by
+    /// the core listen loop. FIXME(core): the proactive disconnect APIs
+    /// (`disconnect`, `disconnect_from_peer`, `disconnect_all`) tear the
+    /// peer down without invoking `on_peer_disconnect`, so entries removed
+    /// via those paths linger until the peer reconnects and disconnects
+    /// normally — same pre-existing gap as ephemeral subscriptions and the
+    /// nonce cache. Fix belongs in `subduction_core`'s teardown.
     inflight_sends: Arc<Mutex<Map<PeerId, Arc<AtomicUsize>>>>,
 }
 
@@ -299,7 +307,10 @@ impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: C
         // every admitted send does, so a wedged subscriber parks this call
         // until the transport tears the connection down. Callers needing
         // bounded latency may wrap `publish` in a timeout: cancellation is
-        // leak-free (each send's InflightGuard releases on drop).
+        // leak-free for the accounting (each send's InflightGuard releases
+        // on drop), though it also abandons in-flight sends to healthy
+        // targets — harmless assuming the transport's `send` is
+        // cancel-safe, which the bundled transports are (queue handoff).
         if let Some(fan_out) = self.admit_fan_out(msg, targets).await {
             fan_out.run().await;
         }

--- a/subduction_ephemeral/src/handler.rs
+++ b/subduction_ephemeral/src/handler.rs
@@ -16,6 +16,7 @@
 //! [`EphemeralMessage`]: crate::message::EphemeralMessage
 
 use alloc::{sync::Arc, vec::Vec};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use async_channel::Sender;
 use async_lock::Mutex;
@@ -56,6 +57,11 @@ use crate::{
 /// messages for healthy peers, small enough that a wedged peer holds at
 /// most `64 × max_payload_size` (4 MiB at the 64 KiB default) in parked
 /// sends.
+///
+/// Note this cap governs *parked sends* only. Total per-peer buffering
+/// also includes the transport's own outbound queue (e.g. up to 1024
+/// frames on the WebSocket transport), which fills before sends start
+/// parking at all.
 pub const MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER: usize = 64;
 
 /// Handler for ephemeral (non-persisted) messages.
@@ -93,7 +99,15 @@ pub struct EphemeralHandler<
     spawner: Sp,
     /// Unfinished fan-out sends per peer; see
     /// [`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`].
-    inflight_sends: Arc<Mutex<Map<PeerId, usize>>>,
+    ///
+    /// The map holds one shared counter per connected peer *generation*:
+    /// [`on_peer_disconnect`](Handler::on_peer_disconnect) removes the
+    /// entry, so a reconnecting peer gets a fresh counter and stragglers
+    /// from the previous generation decrement their own orphaned counter
+    /// harmlessly. Increment/decrement pairing is enforced by
+    /// [`InflightGuard`] (RAII), so counters cannot leak even if a fan-out
+    /// future is cancelled, aborted, or never polled.
+    inflight_sends: Arc<Mutex<Map<PeerId, Arc<AtomicUsize>>>>,
 }
 
 impl<
@@ -278,9 +292,14 @@ impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: C
 
         // Fan out concurrently so one backpressured peer can't head-of-line
         // block delivery to the others. Peers already at their in-flight cap
-        // are dropped (fire-and-forget semantics) instead of parked on, so a
-        // wedged subscriber can stall `publish` for at most
-        // MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER sends.
+        // are dropped (fire-and-forget semantics) instead of parked on.
+        //
+        // Note: the cap bounds how many sends can be *parked* per peer, not
+        // how long this publish may block — `run()` completes only when
+        // every admitted send does, so a wedged subscriber parks this call
+        // until the transport tears the connection down. Callers needing
+        // bounded latency may wrap `publish` in a timeout: cancellation is
+        // leak-free (each send's InflightGuard releases on drop).
         if let Some(fan_out) = self.admit_fan_out(msg, targets).await {
             fan_out.run().await;
         }
@@ -456,7 +475,10 @@ impl<Async: FutureForm, Conn, E, Clk, Sp> Handler<Async, Conn>
             self.nonce_cache.lock().await.remove_peer(peer);
             self.inflight_sends.lock().await.remove(&peer);
 
-            debug!(peer = %peer, "cleaned ephemeral subscriptions and nonce cache on disconnect");
+            debug!(
+                peer = %peer,
+                "cleaned ephemeral subscriptions, nonce cache, and in-flight accounting on disconnect"
+            );
         })
     }
 }
@@ -505,24 +527,25 @@ impl<
         message: EphemeralMessage,
         targets: Vec<Authenticated<Conn, Async>>,
     ) -> Option<EphemeralFanOut<Conn, Async>> {
-        let admitted: Vec<Authenticated<Conn, Async>> = {
+        let admitted: Vec<(Authenticated<Conn, Async>, InflightGuard)> = {
             let mut inflight = self.inflight_sends.lock().await;
             targets
                 .into_iter()
-                .filter(|conn| {
+                .filter_map(|conn| {
                     let peer = conn.peer_id();
-                    let n = inflight.get(&peer).copied().unwrap_or(0);
-                    if n >= MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER {
+                    let counter = inflight
+                        .entry(peer)
+                        .or_insert_with(|| Arc::new(AtomicUsize::new(0)));
+
+                    let admitted = InflightGuard::admit(counter);
+                    if admitted.is_none() {
                         debug!(
                             peer = %peer,
-                            inflight = n,
+                            cap = MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER,
                             "ephemeral send dropped: peer at in-flight cap"
                         );
-                        false
-                    } else {
-                        inflight.insert(peer, n + 1);
-                        true
                     }
+                    admitted.map(|guard| (conn, guard))
                 })
                 .collect()
         };
@@ -534,7 +557,6 @@ impl<
         Some(EphemeralFanOut {
             message,
             targets: admitted,
-            inflight_sends: Arc::clone(&self.inflight_sends),
         })
     }
 
@@ -809,13 +831,14 @@ impl<
 /// originating peer's dispatch permit. `publish` runs it inline (the
 /// application controls its own concurrency there).
 ///
-/// Each target was admitted against the per-peer in-flight cap
-/// ([`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`]) with its counter already
-/// incremented; [`run`](Self::run) decrements as each send completes.
+/// Each target carries the [`InflightGuard`] claimed for it during
+/// admission, so its slot in the per-peer budget is released exactly when
+/// its send completes — or when the fan-out future is dropped without
+/// running (cancellation, abort, a spawner that never polls). Counters
+/// cannot leak.
 struct EphemeralFanOut<Conn: Clone + 'static, Async: FutureForm> {
     message: EphemeralMessage,
-    targets: Vec<Authenticated<Conn, Async>>,
-    inflight_sends: Arc<Mutex<Map<PeerId, usize>>>,
+    targets: Vec<(Authenticated<Conn, Async>, InflightGuard)>,
 }
 
 impl<Conn, Async> EphemeralFanOut<Conn, Async>
@@ -827,14 +850,22 @@ where
     ///
     /// Sends run via `FuturesUnordered` so one slow target can't
     /// head-of-line block the others. Failures are logged and dropped
-    /// (fire-and-forget). Per-peer in-flight counters are decremented as
-    /// sends complete, re-admitting the peer for future fan-outs.
+    /// (fire-and-forget). Each target's [`InflightGuard`] is dropped the
+    /// moment its own send completes, re-admitting that peer for future
+    /// fan-outs — a wedged sibling target does not pin it.
     async fn run(self) {
-        let msg = &self.message;
-        let mut sends: FuturesUnordered<_> = self
-            .targets
-            .iter()
-            .map(|conn| async move { (conn.peer_id(), conn.send(msg).await) })
+        let Self { message, targets } = self;
+        let msg = &message;
+
+        let mut sends: FuturesUnordered<_> = targets
+            .into_iter()
+            .map(|(conn, guard)| async move {
+                let result = conn.send(msg).await;
+                // Release this peer's budget slot as soon as *its* send
+                // finishes, independent of the other targets.
+                drop(guard);
+                (conn.peer_id(), result)
+            })
             .collect();
 
         while let Some((peer, result)) = sends.next().await {
@@ -845,14 +876,39 @@ where
                     "ephemeral fan-out send failed"
                 );
             }
-
-            let mut inflight = self.inflight_sends.lock().await;
-            if let Some(n) = inflight.get_mut(&peer) {
-                *n = n.saturating_sub(1);
-                if *n == 0 {
-                    inflight.remove(&peer);
-                }
-            }
         }
+    }
+}
+
+/// RAII claim on one slot of a peer's in-flight fan-out budget.
+///
+/// Claimed via [`admit`](Self::admit) under the cap check; released on
+/// `Drop`. Tying the release to `Drop` (rather than an explicit decrement
+/// after each send) makes the accounting immune to cancelled `publish`
+/// futures, aborted spawns, and spawners that drop tasks without polling
+/// them — none of which can leak a slot and starve a healthy peer.
+///
+/// Holds its own [`Arc`] to the counter, so a guard from a previous
+/// connection generation (the peer disconnected and its map entry was
+/// replaced) decrements the orphaned counter, never the fresh one.
+struct InflightGuard(Arc<AtomicUsize>);
+
+impl InflightGuard {
+    /// Claim a slot against [`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`].
+    ///
+    /// Returns `None` when the peer is at its cap.
+    fn admit(counter: &Arc<AtomicUsize>) -> Option<Self> {
+        counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                (n < MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER).then_some(n + 1)
+            })
+            .ok()
+            .map(|_| Self(Arc::clone(counter)))
+    }
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
     }
 }

--- a/subduction_ephemeral/src/handler.rs
+++ b/subduction_ephemeral/src/handler.rs
@@ -45,9 +45,9 @@ use crate::{
 /// payloads to that peer are dropped.
 ///
 /// Sends to a healthy peer complete as soon as the detached fan-out task is
-/// polled, so the in-flight count stays near zero; only a genuinely
-/// backpressured connection (e.g. a peer that stopped reading its socket)
-/// accumulates toward the cap. Dropping is safe — ephemeral messages are
+/// polled, so the in-flight count stays near zero; only a backpressured
+/// connection (e.g. a peer that stopped reading its socket) accumulates
+/// toward the cap. Dropping is safe — ephemeral messages are
 /// fire-and-forget by design, and a subscriber dozens of messages behind
 /// has no use for stale payloads anyway.
 ///
@@ -58,10 +58,9 @@ use crate::{
 /// most `64 × max_payload_size` (4 MiB at the 64 KiB default) in parked
 /// sends.
 ///
-/// Note this cap governs *parked sends* only. Total per-peer buffering
-/// also includes the transport's own outbound queue (e.g. up to 1024
-/// frames on the WebSocket transport), which fills before sends start
-/// parking at all.
+/// This cap governs *parked sends* only. Total per-peer buffering also
+/// includes the transport's own outbound queue (e.g. up to 1024 frames on
+/// the WebSocket transport), which fills before sends start parking.
 pub const MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER: usize = 64;
 
 /// Handler for ephemeral (non-persisted) messages.
@@ -108,13 +107,11 @@ pub struct EphemeralHandler<
     /// [`InflightGuard`] (RAII), so counters cannot leak even if a fan-out
     /// future is cancelled, aborted, or never polled.
     ///
-    /// The generation guarantee holds when the disconnect is observed by
-    /// the core listen loop. FIXME(core): the proactive disconnect APIs
-    /// (`disconnect`, `disconnect_from_peer`, `disconnect_all`) tear the
-    /// peer down without invoking `on_peer_disconnect`, so entries removed
-    /// via those paths linger until the peer reconnects and disconnects
-    /// normally — same pre-existing gap as ephemeral subscriptions and the
-    /// nonce cache. Fix belongs in `subduction_core`'s teardown.
+    /// FIXME(core): the proactive disconnect APIs (`disconnect`,
+    /// `disconnect_from_peer`, `disconnect_all`) tear the peer down
+    /// without invoking `on_peer_disconnect`, so entries evicted via those
+    /// paths linger — the same pre-existing gap as ephemeral subscriptions
+    /// and the nonce cache. Fix belongs in `subduction_core`'s teardown.
     inflight_sends: Arc<Mutex<Map<PeerId, Arc<AtomicUsize>>>>,
 }
 
@@ -302,15 +299,14 @@ impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: C
         // block delivery to the others. Peers already at their in-flight cap
         // are dropped (fire-and-forget semantics) instead of parked on.
         //
-        // Note: the cap bounds how many sends can be *parked* per peer, not
-        // how long this publish may block — `run()` completes only when
-        // every admitted send does, so a wedged subscriber parks this call
-        // until the transport tears the connection down. Callers needing
-        // bounded latency may wrap `publish` in a timeout: cancellation is
-        // leak-free for the accounting (each send's InflightGuard releases
-        // on drop), though it also abandons in-flight sends to healthy
-        // targets — harmless assuming the transport's `send` is
-        // cancel-safe, which the bundled transports are (queue handoff).
+        // The cap bounds how many sends can be *parked* per peer, not how
+        // long this publish may block: `run()` completes only when every
+        // admitted send does, so a wedged subscriber parks this call until
+        // the transport tears the connection down. Callers needing bounded
+        // latency may wrap `publish` in a timeout — cancellation is
+        // leak-free (guards release on drop) and abandons in-flight sends,
+        // which requires the transport's `send` to be cancel-safe (the
+        // bundled transports are).
         if let Some(fan_out) = self.admit_fan_out(msg, targets).await {
             fan_out.run().await;
         }

--- a/subduction_ephemeral/src/handler.rs
+++ b/subduction_ephemeral/src/handler.rs
@@ -25,6 +25,7 @@ use nonempty::NonEmpty;
 use sedimentree_core::collections::{Map, Set};
 use subduction_core::{
     authenticated::Authenticated, connection::Connection, handler::Handler, peer::id::PeerId,
+    spawn::Spawn,
 };
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -39,11 +40,34 @@ use crate::{
     topic::Topic,
 };
 
+/// Maximum unfinished fan-out sends per peer before further ephemeral
+/// payloads to that peer are dropped.
+///
+/// Sends to a healthy peer complete as soon as the detached fan-out task is
+/// polled, so the in-flight count stays near zero; only a genuinely
+/// backpressured connection (e.g. a peer that stopped reading its socket)
+/// accumulates toward the cap. Dropping is safe — ephemeral messages are
+/// fire-and-forget by design, and a subscriber dozens of messages behind
+/// has no use for stale payloads anyway.
+///
+/// This bounds how many detached fan-out sends can park against a wedged
+/// connection between keepalive reaps. Sizing: large enough that a burst
+/// dispatched before the executor polls the fan-out tasks doesn't shed
+/// messages for healthy peers, small enough that a wedged peer holds at
+/// most `64 × max_payload_size` (4 MiB at the 64 KiB default) in parked
+/// sends.
+pub const MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER: usize = 64;
+
 /// Handler for ephemeral (non-persisted) messages.
 ///
 /// Manages ephemeral subscriptions, performs authorization via
 /// [`EphemeralPolicy`], verifies signatures on inbound messages,
 /// deduplicates by nonce, and fans out payloads to subscribers.
+///
+/// Inbound relay fan-out runs *off* the per-peer dispatch permit: `handle`
+/// spawns the sends via `Sp` so a backpressured subscriber parks a detached
+/// task instead of stalling inbound dispatch (see
+/// [`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`] for the parking bound).
 ///
 /// Construct via [`new()`](Self::new), which returns both the handler
 /// and a receiver for inbound [`EphemeralEvent`]s.
@@ -53,6 +77,7 @@ pub struct EphemeralHandler<
     Conn: Clone + 'static,
     E: EphemeralPolicy<Async>,
     Clk: Clock,
+    Sp,
 > {
     /// Inbound subscriptions: which peers are subscribed to receive ephemeral messages from us.
     ephemeral_subscriptions: Arc<Mutex<Map<Topic, Set<PeerId>>>>,
@@ -65,10 +90,19 @@ pub struct EphemeralHandler<
     max_message_age: core::time::Duration,
     clock: Clk,
     nonce_cache: Arc<Mutex<EphemeralNonceCache>>,
+    spawner: Sp,
+    /// Unfinished fan-out sends per peer; see
+    /// [`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`].
+    inflight_sends: Arc<Mutex<Map<PeerId, usize>>>,
 }
 
-impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async> + Clone, Clk: Clock> Clone
-    for EphemeralHandler<Async, Conn, E, Clk>
+impl<
+    Async: FutureForm,
+    Conn: Clone + 'static,
+    E: EphemeralPolicy<Async> + Clone,
+    Clk: Clock,
+    Sp: Clone,
+> Clone for EphemeralHandler<Async, Conn, E, Clk, Sp>
 {
     fn clone(&self) -> Self {
         Self {
@@ -81,31 +115,35 @@ impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async> + Clone
             max_message_age: self.max_message_age,
             clock: self.clock.clone(),
             nonce_cache: self.nonce_cache.clone(),
+            spawner: self.spawner.clone(),
+            inflight_sends: self.inflight_sends.clone(),
         }
     }
 }
 
-impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock>
-    core::fmt::Debug for EphemeralHandler<Async, Conn, E, Clk>
+impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock, Sp>
+    core::fmt::Debug for EphemeralHandler<Async, Conn, E, Clk, Sp>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("EphemeralHandler").finish_non_exhaustive()
     }
 }
 
-impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock>
-    EphemeralHandler<Async, Conn, E, Clk>
+impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: Clock, Sp>
+    EphemeralHandler<Async, Conn, E, Clk, Sp>
 {
     /// Create a new ephemeral handler.
     ///
     /// Returns the handler and a receiver for inbound [`EphemeralEvent`]s.
     /// The `connections` map is shared with `Subduction` / `SyncHandler`.
+    /// `spawner` runs relay fan-out sends detached from inbound dispatch.
     #[allow(clippy::type_complexity)]
     pub fn new(
         connections: Arc<Mutex<Map<PeerId, NonEmpty<Authenticated<Conn, Async>>>>>,
         policy: E,
         config: EphemeralConfig,
         clock: Clk,
+        spawner: Sp,
     ) -> (Self, async_channel::Receiver<EphemeralEvent>) {
         let (tx, rx) = async_channel::bounded(config.channel_capacity);
 
@@ -121,6 +159,8 @@ impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: C
             nonce_cache: Arc::new(Mutex::new(EphemeralNonceCache::new(
                 config.nonce_window_duration,
             ))),
+            spawner,
+            inflight_sends: Arc::new(Mutex::new(Map::new())),
         };
 
         (handler, rx)
@@ -237,20 +277,12 @@ impl<Async: FutureForm, Conn: Clone + 'static, E: EphemeralPolicy<Async>, Clk: C
         };
 
         // Fan out concurrently so one backpressured peer can't head-of-line
-        // block delivery to the others.
-        let msg_ref = &msg;
-        let mut sends: FuturesUnordered<_> = targets
-            .iter()
-            .map(|conn| async move { (conn.peer_id(), conn.send(msg_ref).await) })
-            .collect();
-        while let Some((peer, result)) = sends.next().await {
-            if let Err(e) = result {
-                debug!(
-                    %peer,
-                    error = %e,
-                    "ephemeral fan-out send failed"
-                );
-            }
+        // block delivery to the others. Peers already at their in-flight cap
+        // are dropped (fire-and-forget semantics) instead of parked on, so a
+        // wedged subscriber can stall `publish` for at most
+        // MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER sends.
+        if let Some(fan_out) = self.admit_fan_out(msg, targets).await {
+            fan_out.run().await;
         }
     }
 
@@ -382,14 +414,16 @@ pub enum EphemeralHandlerError<SendErr: core::error::Error> {
         E::PublishDisallowed: Send + 'static,
         Conn::SendError: Send + 'static,
         Clk: Clock + Send + Sync,
+        Sp: Spawn<Sendable> + Send + Sync + 'static,
     Local where
         Conn: Connection<Local, EphemeralMessage>
             + Clone + 'static,
         E: EphemeralPolicy<Local>,
-        Clk: Clock
+        Clk: Clock,
+        Sp: Spawn<Local> + 'static
 )]
-impl<Async: FutureForm, Conn, E, Clk> Handler<Async, Conn>
-    for EphemeralHandler<Async, Conn, E, Clk>
+impl<Async: FutureForm, Conn, E, Clk, Sp> Handler<Async, Conn>
+    for EphemeralHandler<Async, Conn, E, Clk, Sp>
 {
     type Message = EphemeralMessage;
     type HandlerError = EphemeralHandlerError<Conn::SendError>;
@@ -399,7 +433,16 @@ impl<Async: FutureForm, Conn, E, Clk> Handler<Async, Conn>
         conn: &'a Authenticated<Conn, Async>,
         message: EphemeralMessage,
     ) -> Async::Future<'a, Result<(), Self::HandlerError>> {
-        Async::from_future(async move { self.dispatch(conn, message).await })
+        Async::from_future(async move {
+            // The relay fan-out is spawned OFF the per-peer dispatch permit
+            // so a backpressured subscriber parks a detached task instead of
+            // stalling inbound dispatch for this peer (and, transitively,
+            // every publisher sharing a topic with the slow subscriber).
+            if let Some(fan_out) = self.dispatch(conn, message).await? {
+                self.spawner.spawn(Async::from_future(fan_out.run()));
+            }
+            Ok(())
+        })
     }
 
     fn on_peer_disconnect(&self, peer: PeerId) -> Async::Future<'_, ()> {
@@ -411,6 +454,7 @@ impl<Async: FutureForm, Conn, E, Clk> Handler<Async, Conn>
             });
 
             self.nonce_cache.lock().await.remove_peer(peer);
+            self.inflight_sends.lock().await.remove(&peer);
 
             debug!(peer = %peer, "cleaned ephemeral subscriptions and nonce cache on disconnect");
         })
@@ -422,16 +466,17 @@ impl<
     Conn: Connection<Async, EphemeralMessage> + Clone + 'static,
     E: EphemeralPolicy<Async>,
     Clk: Clock,
-> EphemeralHandler<Async, Conn, E, Clk>
+    Sp,
+> EphemeralHandler<Async, Conn, E, Clk, Sp>
 {
     async fn dispatch(
         &self,
         conn: &Authenticated<Conn, Async>,
         message: EphemeralMessage,
-    ) -> Result<(), EphemeralHandlerError<Conn::SendError>> {
+    ) -> Result<Option<EphemeralFanOut<Conn, Async>>, EphemeralHandlerError<Conn::SendError>> {
         match message {
             EphemeralMessage::Ephemeral { .. } => {
-                self.recv_ephemeral(conn, message).await;
+                return Ok(self.recv_ephemeral(conn, message).await);
             }
             EphemeralMessage::Subscribe { topics } => {
                 self.recv_subscribe(conn, topics).await;
@@ -444,7 +489,53 @@ impl<
                 debug!("received SubscribeRejected (informational)");
             }
         }
-        Ok(())
+        Ok(None)
+    }
+
+    /// Admit `targets` against the per-peer in-flight cap, incrementing the
+    /// counter for each admitted connection.
+    ///
+    /// Connections whose peer is already at
+    /// [`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`] are dropped from the
+    /// fan-out — fire-and-forget semantics make dropping safe, and it stops
+    /// a wedged connection from accumulating parked send tasks. Returns
+    /// `None` when nothing was admitted.
+    async fn admit_fan_out(
+        &self,
+        message: EphemeralMessage,
+        targets: Vec<Authenticated<Conn, Async>>,
+    ) -> Option<EphemeralFanOut<Conn, Async>> {
+        let admitted: Vec<Authenticated<Conn, Async>> = {
+            let mut inflight = self.inflight_sends.lock().await;
+            targets
+                .into_iter()
+                .filter(|conn| {
+                    let peer = conn.peer_id();
+                    let n = inflight.get(&peer).copied().unwrap_or(0);
+                    if n >= MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER {
+                        debug!(
+                            peer = %peer,
+                            inflight = n,
+                            "ephemeral send dropped: peer at in-flight cap"
+                        );
+                        false
+                    } else {
+                        inflight.insert(peer, n + 1);
+                        true
+                    }
+                })
+                .collect()
+        };
+
+        if admitted.is_empty() {
+            return None;
+        }
+
+        Some(EphemeralFanOut {
+            message,
+            targets: admitted,
+            inflight_sends: Arc::clone(&self.inflight_sends),
+        })
     }
 
     /// Handle an inbound signed ephemeral message from a peer.
@@ -461,9 +552,13 @@ impl<
     ///
     /// [`design/ephemeral.md`]: https://github.com/inkandswitch/subduction/blob/main/design/ephemeral.md#recv-ephemeralhandlerrecv_ephemeral
     #[allow(clippy::too_many_lines)]
-    async fn recv_ephemeral(&self, conn: &Authenticated<Conn, Async>, message: EphemeralMessage) {
+    async fn recv_ephemeral(
+        &self,
+        conn: &Authenticated<Conn, Async>,
+        message: EphemeralMessage,
+    ) -> Option<EphemeralFanOut<Conn, Async>> {
         let EphemeralMessage::Ephemeral(ref signed) = message else {
-            return;
+            return None;
         };
 
         let relay = conn.peer_id();
@@ -483,7 +578,7 @@ impl<
                     error = %e,
                     "ephemeral payload undecodable, dropping"
                 );
-                return;
+                return None;
             }
         };
 
@@ -503,7 +598,7 @@ impl<
                 max = max_payload,
                 "ephemeral payload too large, dropping"
             );
-            return;
+            return None;
         }
 
         // 2b. Message age (signature-independent).
@@ -522,7 +617,7 @@ impl<
                     max_age_secs = max_age.as_secs(),
                     "ephemeral message too old or too far in the future, dropping"
                 );
-                return;
+                return None;
             }
         }
 
@@ -537,7 +632,7 @@ impl<
                     nonce = untrusted_nonce,
                     "duplicate ephemeral nonce (pre-verify fast path), dropping"
                 );
-                return;
+                return None;
             }
         }
 
@@ -551,7 +646,7 @@ impl<
                     error = %e,
                     "ephemeral signature verification failed, dropping"
                 );
-                return;
+                return None;
             }
         };
 
@@ -572,7 +667,7 @@ impl<
                     nonce = nonce,
                     "duplicate ephemeral nonce (post-verify race), dropping"
                 );
-                return;
+                return None;
             }
         }
 
@@ -585,7 +680,7 @@ impl<
                 error = %e,
                 "ephemeral publish unauthorized"
             );
-            return;
+            return None;
         }
 
         // 6. Deliver to local callback channel.
@@ -616,7 +711,7 @@ impl<
         };
 
         if subscriber_peers.is_empty() {
-            return;
+            return None;
         }
 
         let authorized_peers = self
@@ -639,16 +734,11 @@ impl<
                 .collect()
         };
 
-        // Forward the original signed message as-is (preserving sender + signature).
-        for target_conn in &targets {
-            if let Err(e) = target_conn.send(&message).await {
-                debug!(
-                    peer = %target_conn.peer_id(),
-                    error = %e,
-                    "ephemeral fan-out send failed"
-                );
-            }
-        }
+        // Forward the original signed message as-is (preserving sender +
+        // signature). The returned fan-out is spawned by `handle` OFF this
+        // peer's dispatch permit; peers at their in-flight cap were dropped
+        // by `admit_fan_out`.
+        self.admit_fan_out(message, targets).await
     }
 
     /// Handle a subscribe request from a peer.
@@ -705,6 +795,62 @@ impl<
                 peers.remove(&peer);
                 if peers.is_empty() {
                     subs.remove(topic);
+                }
+            }
+        }
+    }
+}
+
+/// Deferred fan-out of an ephemeral payload to subscriber connections.
+///
+/// Built on the dispatch path but **run off it**: [`EphemeralHandler`]'s
+/// `handle` spawns [`run`](Self::run) via the handler's spawner, so a
+/// backpressured subscriber parks a detached task instead of holding the
+/// originating peer's dispatch permit. `publish` runs it inline (the
+/// application controls its own concurrency there).
+///
+/// Each target was admitted against the per-peer in-flight cap
+/// ([`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`]) with its counter already
+/// incremented; [`run`](Self::run) decrements as each send completes.
+struct EphemeralFanOut<Conn: Clone + 'static, Async: FutureForm> {
+    message: EphemeralMessage,
+    targets: Vec<Authenticated<Conn, Async>>,
+    inflight_sends: Arc<Mutex<Map<PeerId, usize>>>,
+}
+
+impl<Conn, Async> EphemeralFanOut<Conn, Async>
+where
+    Conn: Connection<Async, EphemeralMessage> + Clone + 'static,
+    Async: FutureForm,
+{
+    /// Send the payload to every admitted target concurrently.
+    ///
+    /// Sends run via `FuturesUnordered` so one slow target can't
+    /// head-of-line block the others. Failures are logged and dropped
+    /// (fire-and-forget). Per-peer in-flight counters are decremented as
+    /// sends complete, re-admitting the peer for future fan-outs.
+    async fn run(self) {
+        let msg = &self.message;
+        let mut sends: FuturesUnordered<_> = self
+            .targets
+            .iter()
+            .map(|conn| async move { (conn.peer_id(), conn.send(msg).await) })
+            .collect();
+
+        while let Some((peer, result)) = sends.next().await {
+            if let Err(e) = result {
+                debug!(
+                    %peer,
+                    error = %e,
+                    "ephemeral fan-out send failed"
+                );
+            }
+
+            let mut inflight = self.inflight_sends.lock().await;
+            if let Some(n) = inflight.get_mut(&peer) {
+                *n = n.saturating_sub(1);
+                if *n == 0 {
+                    inflight.remove(&peer);
                 }
             }
         }

--- a/subduction_ephemeral/tests/amplification.rs
+++ b/subduction_ephemeral/tests/amplification.rs
@@ -20,8 +20,11 @@ use future_form::Sendable;
 use nonempty::NonEmpty;
 use sedimentree_core::collections::Map;
 use subduction_core::{
-    authenticated::Authenticated, connection::test_utils::ChannelMockConnection, handler::Handler,
-    peer::id::PeerId, timestamp::TimestampSeconds,
+    authenticated::Authenticated,
+    connection::test_utils::{ChannelMockConnection, TokioSpawn},
+    handler::Handler,
+    peer::id::PeerId,
+    timestamp::TimestampSeconds,
 };
 use subduction_crypto::{
     signed::Signed,
@@ -49,7 +52,8 @@ const fn peer(n: u8) -> PeerId {
     PeerId::new([n; 32])
 }
 
-type OpenHandler = Arc<EphemeralHandler<Sendable, EphConn, OpenEphemeralPolicy, FakeClock>>;
+type OpenHandler =
+    Arc<EphemeralHandler<Sendable, EphConn, OpenEphemeralPolicy, FakeClock, TokioSpawn>>;
 
 fn make_open_handler(
     connections: Connections,
@@ -59,6 +63,7 @@ fn make_open_handler(
         OpenEphemeralPolicy,
         EphemeralConfig::default(),
         FakeClock::new(TEST_CLOCK_SECS),
+        TokioSpawn,
     );
     (Arc::new(handler), rx)
 }
@@ -96,15 +101,21 @@ async fn make_signed_ephemeral_for(
     EphemeralMessage::Ephemeral(Box::new(verified.into_signed()))
 }
 
-/// Drain all immediately-available messages from a connection handle.
+/// Drain all messages produced by already-completed handler calls.
 ///
-/// `EphemeralHandler::handle` awaits each fan-out send sequentially over
-/// the mock's unbounded channel, so by the time the caller reaches
-/// `drain`, every message produced by the just-completed handler call is
-/// already queued. `try_recv` is therefore non-blocking and not subject
-/// to CI-scheduling jitter — replacing an earlier polling drain that
-/// could intermittently stop early on slow runners.
-fn drain(handle: &EphHandle) -> Vec<EphemeralMessage> {
+/// `EphemeralHandler::handle` *spawns* the relay fan-out (so a slow
+/// subscriber can't stall dispatch), so the sends land only after the
+/// detached task runs. Every operation in that task is immediately ready
+/// on the mock's unbounded channel — no timers, no I/O — so yielding to
+/// the (current-thread) runtime a bounded number of times is enough to
+/// let it run to completion deterministically. After settling, `try_recv`
+/// is non-blocking and not subject to CI-scheduling jitter.
+async fn drain(handle: &EphHandle) -> Vec<EphemeralMessage> {
+    // One yield per lock hop in the fan-out task, with headroom.
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+
     let mut out = Vec::new();
     while let Ok(msg) = handle.outbound_rx.try_recv() {
         out.push(msg);
@@ -185,8 +196,8 @@ async fn setup_publishing_server() -> (
 
     // Drain the legitimate initial fan-out so tests can observe only
     // the bounce-back behaviour.
-    drop(drain(&handle_a));
-    drop(drain(&handle_b));
+    drop(drain(&handle_a).await);
+    drop(drain(&handle_b).await);
 
     (handler, event_rx, auth_a, handle_a, handle_b, msg)
 }
@@ -230,7 +241,7 @@ async fn publish_bounce_back_triggers_re_fanout_to_other_subscribers() -> TestRe
     // Peer B (the other subscriber) must NOT receive a second copy.
     // If publish() seeded the cache, the nonce check fires and the
     // bounce is dropped before fan-out.
-    let b_again = count_ephemerals(&drain(&handle_b));
+    let b_again = count_ephemerals(&drain(&handle_b).await);
     assert_eq!(
         b_again, 0,
         "BUG: server re-fanned out its own message to other subscribers when a peer \
@@ -239,7 +250,7 @@ async fn publish_bounce_back_triggers_re_fanout_to_other_subscribers() -> TestRe
     );
 
     // A (the bouncer) must not get a copy back — relay filter excludes it.
-    let a_again = count_ephemerals(&drain(&handle_a));
+    let a_again = count_ephemerals(&drain(&handle_a).await);
     assert_eq!(
         a_again, 0,
         "A (relay) should not get the message back via re-fan-out, but got {a_again}"
@@ -298,7 +309,7 @@ async fn server_dedupes_same_message_arriving_via_two_relays() -> TestResult {
 
     // Downstream gets exactly one fan-out copy.
     assert_eq!(
-        count_ephemerals(&drain(&handle_d)),
+        count_ephemerals(&drain(&handle_d).await),
         1,
         "downstream subscriber should receive exactly one copy across both arrivals"
     );
@@ -383,8 +394,8 @@ async fn triangle_topology_does_not_exponentially_amplify() -> TestResult {
     h1.handle(&s1_view_of_orig, msg.clone()).await?;
 
     // S1 should fan out one copy to each of S2 and S3 — and no more.
-    let s1_to_2 = drain(&h_s1_to_2);
-    let s1_to_3 = drain(&h_s1_to_3);
+    let s1_to_2 = drain(&h_s1_to_2).await;
+    let s1_to_3 = drain(&h_s1_to_3).await;
     assert_eq!(
         count_ephemerals(&s1_to_2),
         1,
@@ -408,8 +419,8 @@ async fn triangle_topology_does_not_exponentially_amplify() -> TestResult {
     let _e3 = tokio::time::timeout(Duration::from_millis(100), rx3.recv()).await??;
 
     // The cross-edges (S2→S3 and S3→S2) each happen exactly once.
-    let s2_to_3 = drain(&h_s2_to_3);
-    let s3_to_2 = drain(&h_s3_to_2);
+    let s2_to_3 = drain(&h_s2_to_3).await;
+    let s3_to_2 = drain(&h_s3_to_2).await;
     assert_eq!(
         count_ephemerals(&s2_to_3),
         1,
@@ -453,7 +464,7 @@ async fn triangle_topology_does_not_exponentially_amplify() -> TestResult {
         ("S3→S2", &h_s3_to_2),
     ] {
         assert_eq!(
-            count_ephemerals(&drain(h)),
+            count_ephemerals(&drain(h).await),
             0,
             "{label}: no further fan-out after cross-edge dedup"
         );
@@ -512,9 +523,9 @@ async fn relay_does_not_refanout_after_seeing_its_own_outbound_come_back() -> Te
     // First arrival: from the originator. Server fans out to subs[T]
     // minus the originator = {sub1, sub2, sub3, loop}.
     handler.handle(&auth_origin, msg.clone()).await?;
-    assert_eq!(count_ephemerals(&drain(&handle_sub1)), 1);
-    assert_eq!(count_ephemerals(&drain(&handle_sub2)), 1);
-    assert_eq!(count_ephemerals(&drain(&handle_sub3)), 1);
+    assert_eq!(count_ephemerals(&drain(&handle_sub1).await), 1);
+    assert_eq!(count_ephemerals(&drain(&handle_sub2).await), 1);
+    assert_eq!(count_ephemerals(&drain(&handle_sub3).await), 1);
 
     // Now the loop peer replays the exact same signed message back.
     handler.handle(&auth_loop, msg.clone()).await?;
@@ -522,17 +533,17 @@ async fn relay_does_not_refanout_after_seeing_its_own_outbound_come_back() -> Te
     // NO subscriber should get a second copy — the nonce cache must
     // catch the replay regardless of which relay it came through.
     assert_eq!(
-        count_ephemerals(&drain(&handle_sub1)),
+        count_ephemerals(&drain(&handle_sub1).await),
         0,
         "sub1 must not get a second copy"
     );
     assert_eq!(
-        count_ephemerals(&drain(&handle_sub2)),
+        count_ephemerals(&drain(&handle_sub2).await),
         0,
         "sub2 must not get a second copy"
     );
     assert_eq!(
-        count_ephemerals(&drain(&handle_sub3)),
+        count_ephemerals(&drain(&handle_sub3).await),
         0,
         "sub3 must not get a second copy"
     );
@@ -594,7 +605,7 @@ async fn cross_edge_duplicate_with_corrupted_signature_is_dropped_silently() -> 
 
     // Drain the legitimate event + fan-out.
     let _first_event = tokio::time::timeout(Duration::from_millis(100), event_rx.recv()).await??;
-    let first_fanout = drain(&handle_sub);
+    let first_fanout = drain(&handle_sub).await;
     assert_eq!(
         count_ephemerals(&first_fanout),
         1,
@@ -632,7 +643,7 @@ async fn cross_edge_duplicate_with_corrupted_signature_is_dropped_silently() -> 
 
     // No re-fan-out — the subscriber sees no second copy.
     assert_eq!(
-        count_ephemerals(&drain(&handle_sub)),
+        count_ephemerals(&drain(&handle_sub).await),
         0,
         "duplicate must not trigger fan-out (it was dropped by the cache)"
     );

--- a/subduction_ephemeral/tests/ephemeral_handler.rs
+++ b/subduction_ephemeral/tests/ephemeral_handler.rs
@@ -12,8 +12,11 @@ use future_form::Sendable;
 use nonempty::NonEmpty;
 use sedimentree_core::collections::Map;
 use subduction_core::{
-    authenticated::Authenticated, connection::test_utils::ChannelMockConnection, handler::Handler,
-    peer::id::PeerId, timestamp::TimestampSeconds,
+    authenticated::Authenticated,
+    connection::test_utils::{ChannelMockConnection, TokioSpawn},
+    handler::Handler,
+    peer::id::PeerId,
+    timestamp::TimestampSeconds,
 };
 use subduction_crypto::{
     signed::Signed,
@@ -41,7 +44,8 @@ const fn peer(n: u8) -> PeerId {
     PeerId::new([n; 32])
 }
 
-type OpenHandler = Arc<EphemeralHandler<Sendable, EphConn, OpenEphemeralPolicy, FakeClock>>;
+type OpenHandler =
+    Arc<EphemeralHandler<Sendable, EphConn, OpenEphemeralPolicy, FakeClock, TokioSpawn>>;
 
 fn make_open_handler(
     connections: Connections,
@@ -51,6 +55,7 @@ fn make_open_handler(
         OpenEphemeralPolicy,
         EphemeralConfig::default(),
         FakeClock::new(TimestampSeconds::new(1_000)),
+        TokioSpawn,
     );
     (Arc::new(handler), rx)
 }
@@ -68,6 +73,7 @@ fn make_small_payload_handler(
         OpenEphemeralPolicy,
         config,
         FakeClock::new(TimestampSeconds::new(1_000)),
+        TokioSpawn,
     );
     (Arc::new(handler), rx)
 }
@@ -494,6 +500,7 @@ async fn subscribe_rejected_by_policy() -> TestResult {
         deny_policy::DenyAll,
         EphemeralConfig::default(),
         FakeClock::new(TimestampSeconds::new(1_000)),
+        TokioSpawn,
     );
     let handler = Arc::new(handler);
     let (auth, handle) = register_peer(&connections, peer(1)).await;
@@ -534,6 +541,7 @@ async fn publish_rejected_by_policy_no_callback() -> TestResult {
         deny_policy::DenyAll,
         EphemeralConfig::default(),
         FakeClock::new(TimestampSeconds::new(1_000)),
+        TokioSpawn,
     );
     let handler = Arc::new(handler);
     let (auth_a, _handle_a) = register_peer(&connections, peer(1)).await;
@@ -1590,6 +1598,7 @@ async fn callback_channel_full_still_fans_out() -> TestResult {
         OpenEphemeralPolicy,
         config,
         FakeClock::new(TEST_CLOCK_SECS),
+        TokioSpawn,
     );
     let handler = Arc::new(handler);
 
@@ -1722,6 +1731,7 @@ async fn partial_policy_selective_subscribe() -> TestResult {
         selective_policy::AllowPeer1Only,
         EphemeralConfig::default(),
         FakeClock::new(TEST_CLOCK_SECS),
+        TokioSpawn,
     );
     let handler = Arc::new(handler);
 

--- a/subduction_ephemeral/tests/wedged_subscriber.rs
+++ b/subduction_ephemeral/tests/wedged_subscriber.rs
@@ -304,9 +304,14 @@ async fn cancelled_publish_does_not_leak_inflight_budget() -> TestResult {
         let cancelled = tokio::time::timeout(Duration::from_millis(20), handler.publish(msg))
             .await
             .is_err();
-        assert!(cancelled, "publish should park on the wedged subscriber");
+        // This is the leak detector: a leaky implementation stops admitting
+        // at the cap, `admit_fan_out` returns None, publish completes
+        // instantly, and this assert fails at iteration cap+1.
+        assert!(
+            cancelled,
+            "publish returned early — admission returned None (leaked in-flight slot?)"
+        );
     }
-    settle().await;
 
     // Every publish was admitted (slot freed by the previous cancellation),
     // so the wedged mock saw `total` attempts. A budget leak pins this at

--- a/subduction_ephemeral/tests/wedged_subscriber.rs
+++ b/subduction_ephemeral/tests/wedged_subscriber.rs
@@ -1,0 +1,327 @@
+//! Regression tests for the detached, capped ephemeral fan-out.
+//!
+//! Scenario:
+//!
+//! 1. `handle` returns promptly even when a subscriber's send never
+//!    completes (the fan-out runs on a detached task, not the dispatch
+//!    path), and healthy subscribers keep receiving messages.
+//! 2. The per-peer in-flight cap
+//!    ([`MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER`]) bounds how many detached
+//!    sends can park against a wedged peer; further payloads to that peer
+//!    are dropped (fire-and-forget) instead of accumulating tasks.
+
+#![allow(clippy::panic)]
+
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_lock::Mutex;
+use future_form::{FutureForm, Sendable};
+use nonempty::NonEmpty;
+use sedimentree_core::collections::Map;
+use subduction_core::{
+    authenticated::Authenticated, connection::Connection,
+    connection::test_utils::TokioSpawn, handler::Handler, peer::id::PeerId,
+    timestamp::TimestampSeconds,
+};
+use subduction_crypto::{signed::Signed, signer::memory::MemorySigner};
+use subduction_ephemeral::{
+    clock::fake::FakeClock,
+    config::{EphemeralConfig, EphemeralEvent},
+    handler::{EphemeralHandler, MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER},
+    message::{EphemeralMessage, EphemeralPayload},
+    policy::OpenEphemeralPolicy,
+    topic::Topic,
+};
+use testresult::TestResult;
+
+// ── Wedgeable mock connection ───────────────────────────────────────────
+
+/// A mock connection that either delivers sends to an unbounded channel
+/// (healthy) or counts the attempt and parks forever (wedged) — modelling
+/// a peer that stopped reading its socket.
+#[derive(Clone)]
+struct WedgeableConn {
+    peer_id: PeerId,
+    mode: Mode,
+}
+
+#[derive(Clone)]
+enum Mode {
+    Healthy(async_channel::Sender<EphemeralMessage>),
+    Wedged(Arc<AtomicUsize>),
+}
+
+impl WedgeableConn {
+    fn healthy(peer_id: PeerId) -> (Self, async_channel::Receiver<EphemeralMessage>) {
+        let (tx, rx) = async_channel::unbounded();
+        (
+            Self {
+                peer_id,
+                mode: Mode::Healthy(tx),
+            },
+            rx,
+        )
+    }
+
+    fn wedged(peer_id: PeerId) -> (Self, Arc<AtomicUsize>) {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                peer_id,
+                mode: Mode::Wedged(attempts.clone()),
+            },
+            attempts,
+        )
+    }
+}
+
+impl PartialEq for WedgeableConn {
+    fn eq(&self, other: &Self) -> bool {
+        self.peer_id == other.peer_id
+    }
+}
+
+impl Connection<Sendable, EphemeralMessage> for WedgeableConn {
+    type DisconnectionError = Infallible;
+    type SendError = async_channel::SendError<EphemeralMessage>;
+    type RecvError = async_channel::RecvError;
+
+    fn disconnect(
+        &self,
+    ) -> <Sendable as FutureForm>::Future<'_, Result<(), Self::DisconnectionError>> {
+        Sendable::from_future(async { Ok(()) })
+    }
+
+    fn send(
+        &self,
+        message: &EphemeralMessage,
+    ) -> <Sendable as FutureForm>::Future<'_, Result<(), Self::SendError>> {
+        let mode = self.mode.clone();
+        let message = message.clone();
+        Sendable::from_future(async move {
+            match mode {
+                Mode::Healthy(tx) => tx.send(message).await,
+                Mode::Wedged(attempts) => {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    futures::future::pending::<()>().await;
+                    unreachable!("pending() never resolves")
+                }
+            }
+        })
+    }
+
+    fn recv(&self) -> <Sendable as FutureForm>::Future<'_, Result<EphemeralMessage, Self::RecvError>> {
+        Sendable::from_future(async { futures::future::pending().await })
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+type Auth = Authenticated<WedgeableConn, Sendable>;
+type Connections = Arc<Mutex<Map<PeerId, NonEmpty<Auth>>>>;
+type OpenHandler =
+    Arc<EphemeralHandler<Sendable, WedgeableConn, OpenEphemeralPolicy, FakeClock, TokioSpawn>>;
+
+const TEST_CLOCK_SECS: TimestampSeconds = TimestampSeconds::new(1_000);
+
+const fn peer(n: u8) -> PeerId {
+    PeerId::new([n; 32])
+}
+
+fn make_handler(
+    connections: Connections,
+) -> (OpenHandler, async_channel::Receiver<EphemeralEvent>) {
+    let (handler, rx) = EphemeralHandler::new(
+        connections,
+        OpenEphemeralPolicy,
+        EphemeralConfig::default(),
+        FakeClock::new(TEST_CLOCK_SECS),
+        TokioSpawn,
+    );
+    (Arc::new(handler), rx)
+}
+
+async fn register(connections: &Connections, conn: WedgeableConn) -> Auth {
+    let peer_id = conn.peer_id;
+    let auth = Authenticated::new_for_test(conn, peer_id);
+    connections
+        .lock()
+        .await
+        .insert(peer_id, NonEmpty::new(auth.clone()));
+    auth
+}
+
+fn rand_nonce() -> u64 {
+    let mut buf = [0u8; 8];
+    #[allow(clippy::expect_used, reason = "getrandom is infallible on test platforms")]
+    getrandom::getrandom(&mut buf).expect("getrandom failed");
+    u64::from_le_bytes(buf)
+}
+
+async fn make_signed_ephemeral(
+    signer: &MemorySigner,
+    id: Topic,
+    payload: Vec<u8>,
+) -> EphemeralMessage {
+    let ep = EphemeralPayload {
+        id,
+        nonce: rand_nonce(),
+        timestamp: TEST_CLOCK_SECS,
+        payload,
+    };
+    let verified = Signed::seal::<Sendable, _>(signer, ep).await;
+    EphemeralMessage::Ephemeral(Box::new(verified.into_signed()))
+}
+
+/// Yield to the (current-thread) runtime so detached fan-out tasks make
+/// progress. All healthy-path operations are immediately ready, so a
+/// bounded number of yields settles them deterministically.
+async fn settle() {
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+/// A subscriber whose send never completes must not stall `handle` (the
+/// dispatch path) nor delivery to healthy subscribers, and parked sends
+/// toward it must stop at the in-flight cap.
+#[tokio::test]
+async fn wedged_subscriber_does_not_stall_dispatch_and_is_capped() -> TestResult {
+    let connections: Connections = Arc::new(Mutex::new(Map::new()));
+    let (handler, _event_rx) = make_handler(connections.clone());
+
+    let topic = Topic::new([0xAA; 32]);
+
+    // The relay peer that inbound messages arrive through.
+    let (relay_conn, _relay_rx) = WedgeableConn::healthy(peer(1));
+    let auth_relay = register(&connections, relay_conn).await;
+
+    // A healthy subscriber and a wedged one.
+    let (healthy_conn, healthy_rx) = WedgeableConn::healthy(peer(2));
+    let auth_healthy = register(&connections, healthy_conn).await;
+    let (wedged_conn, wedged_attempts) = WedgeableConn::wedged(peer(3));
+    let auth_wedged = register(&connections, wedged_conn).await;
+
+    for auth in [&auth_healthy, &auth_wedged] {
+        handler
+            .handle(
+                auth,
+                EphemeralMessage::Subscribe {
+                    topics: NonEmpty::new(topic),
+                },
+            )
+            .await?;
+    }
+
+    // Relay strictly more messages than the cap. Each `handle` must return
+    // promptly: the fan-out (including the never-completing send to the
+    // wedged peer) runs on a detached task, not the dispatch path. Settle
+    // between messages so healthy sends complete (modelling paced arrival);
+    // the wedged peer's sends park regardless.
+    let originator = MemorySigner::generate();
+    let total = MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER + 4;
+    for i in 0..total {
+        let msg = make_signed_ephemeral(&originator, topic, vec![u8::try_from(i)?]).await;
+        tokio::time::timeout(Duration::from_secs(5), handler.handle(&auth_relay, msg))
+            .await
+            .map_err(|_| "handle() stalled on a wedged subscriber (fan-out not detached?)")??;
+        settle().await;
+    }
+
+    // Healthy subscriber received every payload despite its wedged sibling.
+    let mut healthy_received = 0;
+    while let Ok(msg) = healthy_rx.try_recv() {
+        if matches!(msg, EphemeralMessage::Ephemeral(_)) {
+            healthy_received += 1;
+        }
+    }
+    assert_eq!(
+        healthy_received, total,
+        "healthy subscriber must receive all payloads"
+    );
+
+    // Sends toward the wedged peer stopped at the cap: the excess payloads
+    // were dropped instead of accumulating parked tasks.
+    assert_eq!(
+        wedged_attempts.load(Ordering::SeqCst),
+        MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER,
+        "parked sends toward a wedged peer must stop at the in-flight cap"
+    );
+
+    Ok(())
+}
+
+/// Disconnecting a wedged peer clears its in-flight accounting: after
+/// `on_peer_disconnect`, a fresh (healthy) connection for the same peer
+/// receives payloads again rather than being treated as still-at-cap.
+#[tokio::test]
+async fn disconnect_resets_inflight_accounting() -> TestResult {
+    let connections: Connections = Arc::new(Mutex::new(Map::new()));
+    let (handler, _event_rx) = make_handler(connections.clone());
+
+    let topic = Topic::new([0xBB; 32]);
+
+    let (relay_conn, _relay_rx) = WedgeableConn::healthy(peer(1));
+    let auth_relay = register(&connections, relay_conn).await;
+
+    // Wedge peer(2) and drive it to its cap.
+    let (wedged_conn, wedged_attempts) = WedgeableConn::wedged(peer(2));
+    let auth_wedged = register(&connections, wedged_conn).await;
+    handler
+        .handle(
+            &auth_wedged,
+            EphemeralMessage::Subscribe {
+                topics: NonEmpty::new(topic),
+            },
+        )
+        .await?;
+
+    let originator = MemorySigner::generate();
+    for i in 0..(MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER + 2) {
+        let msg = make_signed_ephemeral(&originator, topic, vec![u8::try_from(i)?]).await;
+        handler.handle(&auth_relay, msg).await?;
+    }
+    settle().await;
+    assert_eq!(
+        wedged_attempts.load(Ordering::SeqCst),
+        MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER,
+        "precondition: peer(2) is at its cap"
+    );
+
+    // The keepalive reaper (or teardown) removes the connection; the
+    // handler is told about it. This must clear the in-flight counter.
+    connections.lock().await.remove(&peer(2));
+    handler.on_peer_disconnect(peer(2)).await;
+
+    // Peer(2) reconnects healthy and re-subscribes.
+    let (fresh_conn, fresh_rx) = WedgeableConn::healthy(peer(2));
+    let auth_fresh = register(&connections, fresh_conn).await;
+    handler
+        .handle(
+            &auth_fresh,
+            EphemeralMessage::Subscribe {
+                topics: NonEmpty::new(topic),
+            },
+        )
+        .await?;
+
+    let msg = make_signed_ephemeral(&originator, topic, vec![0xFF]).await;
+    handler.handle(&auth_relay, msg).await?;
+    settle().await;
+
+    assert!(
+        matches!(fresh_rx.try_recv(), Ok(EphemeralMessage::Ephemeral(_))),
+        "reconnected peer must receive payloads (stale in-flight count not cleared?)"
+    );
+
+    Ok(())
+}

--- a/subduction_ephemeral/tests/wedged_subscriber.rs
+++ b/subduction_ephemeral/tests/wedged_subscriber.rs
@@ -26,8 +26,10 @@ use future_form::{FutureForm, Sendable};
 use nonempty::NonEmpty;
 use sedimentree_core::collections::Map;
 use subduction_core::{
-    authenticated::Authenticated, connection::Connection,
-    connection::test_utils::TokioSpawn, handler::Handler, peer::id::PeerId,
+    authenticated::Authenticated,
+    connection::{Connection, test_utils::TokioSpawn},
+    handler::Handler,
+    peer::id::PeerId,
     timestamp::TimestampSeconds,
 };
 use subduction_crypto::{signed::Signed, signer::memory::MemorySigner};
@@ -117,7 +119,9 @@ impl Connection<Sendable, EphemeralMessage> for WedgeableConn {
         })
     }
 
-    fn recv(&self) -> <Sendable as FutureForm>::Future<'_, Result<EphemeralMessage, Self::RecvError>> {
+    fn recv(
+        &self,
+    ) -> <Sendable as FutureForm>::Future<'_, Result<EphemeralMessage, Self::RecvError>> {
         Sendable::from_future(async { futures::future::pending().await })
     }
 }
@@ -160,7 +164,10 @@ async fn register(connections: &Connections, conn: WedgeableConn) -> Auth {
 
 fn rand_nonce() -> u64 {
     let mut buf = [0u8; 8];
-    #[allow(clippy::expect_used, reason = "getrandom is infallible on test platforms")]
+    #[allow(
+        clippy::expect_used,
+        reason = "getrandom is infallible on test platforms"
+    )]
     getrandom::getrandom(&mut buf).expect("getrandom failed");
     u64::from_le_bytes(buf)
 }
@@ -255,6 +262,59 @@ async fn wedged_subscriber_does_not_stall_dispatch_and_is_capped() -> TestResult
         wedged_attempts.load(Ordering::SeqCst),
         MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER,
         "parked sends toward a wedged peer must stop at the in-flight cap"
+    );
+
+    Ok(())
+}
+
+/// Cancelling `publish` mid-flight must not leak in-flight budget.
+///
+/// `publish` awaits its fan-out inline, so a caller wrapping it in a
+/// timeout drops the fan-out future while sends toward a wedged peer are
+/// still parked. The RAII `InflightGuard`s must release those slots on
+/// drop: each subsequent publish re-admits the peer, so send *attempts*
+/// keep accruing past the cap. A leaky implementation (increment at
+/// admit, decrement only on send completion) pins attempts at the cap and
+/// silently locks the peer out of ephemera.
+#[tokio::test]
+async fn cancelled_publish_does_not_leak_inflight_budget() -> TestResult {
+    let connections: Connections = Arc::new(Mutex::new(Map::new()));
+    let (handler, _event_rx) = make_handler(connections.clone());
+
+    let topic = Topic::new([0xCC; 32]);
+
+    // One wedged subscriber; publishes fan out to it and park forever.
+    let (wedged_conn, wedged_attempts) = WedgeableConn::wedged(peer(2));
+    let auth_wedged = register(&connections, wedged_conn).await;
+    handler
+        .handle(
+            &auth_wedged,
+            EphemeralMessage::Subscribe {
+                topics: NonEmpty::new(topic),
+            },
+        )
+        .await?;
+
+    let publisher = MemorySigner::generate();
+    let total = MAX_INFLIGHT_EPHEMERAL_SENDS_PER_PEER + 4;
+    for i in 0..total {
+        let msg = make_signed_ephemeral(&publisher, topic, vec![u8::try_from(i)?]).await;
+        // Each publish parks on the wedged send; cancel it via timeout.
+        // Dropping the fan-out future must release the admitted slot.
+        let cancelled = tokio::time::timeout(Duration::from_millis(20), handler.publish(msg))
+            .await
+            .is_err();
+        assert!(cancelled, "publish should park on the wedged subscriber");
+    }
+    settle().await;
+
+    // Every publish was admitted (slot freed by the previous cancellation),
+    // so the wedged mock saw `total` attempts. A budget leak pins this at
+    // the cap and drops the rest at admission.
+    assert_eq!(
+        wedged_attempts.load(Ordering::SeqCst),
+        total,
+        "cancelled publishes must release their in-flight slots"
     );
 
     Ok(())

--- a/subduction_wasm/src/handler.rs
+++ b/subduction_wasm/src/handler.rs
@@ -153,7 +153,8 @@ type WasmSyncHandler = SyncHandler<
     JsRemoteHeadsObserver,
 >;
 
-type WasmEphemeralHandler = EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock, WasmSpawn>;
+type WasmEphemeralHandler =
+    EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock, WasmSpawn>;
 
 pub(crate) type WasmListenError = ListenError<Local, JsStorage, WasmConn, WireMessage>;
 

--- a/subduction_wasm/src/handler.rs
+++ b/subduction_wasm/src/handler.rs
@@ -153,7 +153,7 @@ type WasmSyncHandler = SyncHandler<
     JsRemoteHeadsObserver,
 >;
 
-type WasmEphemeralHandler = EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock>;
+type WasmEphemeralHandler = EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock, WasmSpawn>;
 
 pub(crate) type WasmListenError = ListenError<Local, JsStorage, WasmConn, WireMessage>;
 

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -128,7 +128,8 @@ use subduction_keyhive::KeyhiveMessage;
 
 type WasmConn = MessageTransport<JsTransport>;
 
-type WasmEphemeralHandler = EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock, WasmSpawn>;
+type WasmEphemeralHandler =
+    EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock, WasmSpawn>;
 
 type WasmSubductionCore = Subduction<
     'static,

--- a/subduction_wasm/src/subduction.rs
+++ b/subduction_wasm/src/subduction.rs
@@ -128,7 +128,7 @@ use subduction_keyhive::KeyhiveMessage;
 
 type WasmConn = MessageTransport<JsTransport>;
 
-type WasmEphemeralHandler = EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock>;
+type WasmEphemeralHandler = EphemeralHandler<Local, WasmConn, JsEphemeralPolicy, JsClock, WasmSpawn>;
 
 type WasmSubductionCore = Subduction<
     'static,
@@ -243,6 +243,7 @@ impl WasmSubduction {
             eph_policy,
             EphemeralConfig::default(),
             JsClock,
+            WasmSpawn,
         );
         let ephemeral_for_wasm = ephemeral_handler.clone();
 

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -6,7 +6,7 @@ use core::{
     future::{Future, IntoFuture},
     marker::PhantomData,
     num::NonZeroU32,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
     time::Duration,
 };
 
@@ -234,6 +234,17 @@ pub struct WebSocket<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> {
     /// keepalive task. Unused (but cheap) when keepalive is disabled.
     pong_received: Arc<AtomicBool>,
 
+    /// Incremented by the sender task after each completed *data*
+    /// (Binary/Text) socket write. Control frames (Ping/Pong/Close) are
+    /// deliberately excluded: if the keepalive's own ping writes moved this
+    /// counter, an idle dead peer would look "alive" to the progress gate
+    /// and never be reaped.
+    ///
+    /// The keepalive loop reads this to distinguish a *wedged* connection
+    /// (full outbound queue, no writes completing) from a *saturated but
+    /// draining* one, and only counts pong misses against the former.
+    data_write_progress: Arc<AtomicU64>,
+
     _phantom: PhantomData<Async>,
 }
 
@@ -329,11 +340,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
         // Initial value is irrelevant — the keepalive loop clears the
         // flag before each ping.
         let pong_received = Arc::new(AtomicBool::new(false));
+        let data_write_progress = Arc::new(AtomicU64::new(0));
 
         let ws_sender = Arc::new(Mutex::new(ws_writer));
 
         let sender_task = {
             let ws_sender = ws_sender.clone();
+            let data_write_progress = data_write_progress.clone();
             async move {
                 tracing::debug!(peer = %peer_id, "starting WebSocket sender task");
 
@@ -354,7 +367,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
                             item.msg.len(),
                         );
                     }
+                    // Data frames feed the keepalive's progress gate; control
+                    // frames must not (see `data_write_progress` field docs).
+                    let is_data = matches!(item.msg, Message::Binary(_) | Message::Text(_));
                     ws_sender.send(item.msg).await?;
+                    if is_data {
+                        data_write_progress.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
 
                 tracing::debug!("sender task: outbound channel closed, shutting down");
@@ -372,6 +391,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
             inbound_writer,
             inbound_reader,
             pong_received,
+            data_write_progress,
 
             _phantom: PhantomData,
         };
@@ -574,6 +594,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> WebSocket<T, Sendable> {
             this.outbound_tx.clone(),
             this.inbound_writer.clone(),
             this.pong_received.clone(),
+            this.data_write_progress.clone(),
             sleeper,
         );
         let task = KeepAliveTask::new(body.boxed());
@@ -663,14 +684,24 @@ impl ReadErrorKind {
 
 /// Keepalive task body.
 ///
-/// Cycle: `sleep(ping)` → clear flag → send Ping → `sleep(pong)` →
-/// check flag. Threshold consecutive misses trigger disconnect.
+/// Cycle: snapshot write progress → `sleep(ping)` → clear flag → send Ping
+/// (non-blocking) → `sleep(pong)` → check flag *and* progress. Threshold
+/// consecutive misses trigger disconnect.
+///
+/// A cycle counts as alive if either a Pong arrived (end-to-end liveness)
+/// or the sender completed at least one *data* write during the cycle
+/// (`data_write_progress` advanced). The progress gate stops a saturated
+/// but draining connection from being reaped just because its outbound
+/// queue happened to be full at the ping instant; a genuinely wedged
+/// socket makes no write progress, so it still accumulates misses and is
+/// reaped at the threshold.
 async fn keepalive_loop<S, Async>(
     config: KeepAlive,
     peer_id: PeerId,
     outbound_tx: async_channel::Sender<Outbound>,
     inbound_writer: async_channel::Sender<Vec<u8>>,
     pong_received: Arc<AtomicBool>,
+    data_write_progress: Arc<AtomicU64>,
     sleeper: S,
 ) -> KeepAliveOutcome
 where
@@ -681,6 +712,8 @@ where
     let threshold = config.missed_pong_threshold.get();
 
     loop {
+        let progress_snapshot = data_write_progress.load(Ordering::Relaxed);
+
         sleeper.sleep(config.ping_interval).await;
 
         // Clear before sending so a stale Pong from a previous cycle
@@ -689,18 +722,52 @@ where
 
         // Empty payload: we don't verify the Pong reply matches a
         // specific Ping, so a unique payload would just be overhead.
+        //
+        // Non-blocking: a full outbound queue means the sender task is not
+        // draining (e.g. the peer stopped reading and the socket write is
+        // parked). A blocking send here would park *this* task before it
+        // could ever reach the miss check below, so the one connection that
+        // most needs reaping would never be reaped. Dropping the ping lets
+        // the cycle proceed: no pong can arrive for a ping that never left,
+        // so the miss counter advances toward the close threshold.
         let ping = tungstenite::Message::Ping(Vec::new().into());
-        if outbound_tx.send(Outbound::new(ping)).await.is_err() {
-            tracing::debug!(peer = %peer_id, "keepalive: outbound closed; exiting");
-            return KeepAliveOutcome::ConnectionClosed;
+        match outbound_tx.try_send(Outbound::new(ping)) {
+            Ok(()) => {
+                tracing::trace!(peer = %peer_id, "keepalive: sent ping");
+            }
+            Err(async_channel::TrySendError::Closed(_)) => {
+                tracing::debug!(peer = %peer_id, "keepalive: outbound closed; exiting");
+                return KeepAliveOutcome::ConnectionClosed;
+            }
+            Err(async_channel::TrySendError::Full(_)) => {
+                tracing::warn!(
+                    peer = %peer_id,
+                    "keepalive: outbound queue full; ping dropped (counts toward misses)"
+                );
+            }
         }
-        tracing::trace!(peer = %peer_id, "keepalive: sent ping");
 
         sleeper.sleep(config.pong_timeout).await;
 
         if pong_received.load(Ordering::Relaxed) {
             if consecutive_misses > 0 {
                 tracing::debug!(peer = %peer_id, "keepalive: pong recovered after misses");
+            }
+            consecutive_misses = 0;
+            continue;
+        }
+
+        // No pong — but if data writes completed this cycle the transport is
+        // demonstrably moving (e.g. the queue was full at the ping instant on
+        // a link mid-bulk-transfer). Don't count a miss against a connection
+        // that is making progress; a wedged socket completes nothing and
+        // falls through to the miss path.
+        if data_write_progress.load(Ordering::Relaxed) != progress_snapshot {
+            if consecutive_misses > 0 {
+                tracing::debug!(
+                    peer = %peer_id,
+                    "keepalive: write progress observed; resetting misses"
+                );
             }
             consecutive_misses = 0;
             continue;
@@ -752,6 +819,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> Clone for WebSocket<T
             inbound_writer: self.inbound_writer.clone(),
             inbound_reader: self.inbound_reader.clone(),
             pong_received: self.pong_received.clone(),
+            data_write_progress: self.data_write_progress.clone(),
             _phantom: PhantomData,
         }
     }
@@ -900,6 +968,7 @@ mod tests {
             outbound_tx,
             inbound_writer.clone(),
             pong_received,
+            Arc::new(AtomicU64::new(0)),
             TokioSleeper,
         )
         .await;
@@ -968,6 +1037,7 @@ mod tests {
                 outbound_tx.clone(),
                 inbound_writer.clone(),
                 pong_received,
+                Arc::new(AtomicU64::new(0)),
                 TokioSleeper,
             ),
         )
@@ -1025,6 +1095,7 @@ mod tests {
                 outbound_tx.clone(),
                 inbound_writer.clone(),
                 pong_received,
+                Arc::new(AtomicU64::new(0)),
                 TokioSleeper,
             ),
         )
@@ -1073,6 +1144,7 @@ mod tests {
             outbound_tx,
             inbound_writer.clone(),
             pong_received,
+            Arc::new(AtomicU64::new(0)),
             TokioSleeper,
         )
         .await;
@@ -1123,6 +1195,180 @@ mod tests {
         Ok(())
     }
 
+    /// Regression: the keepalive *ping* uses `try_send`. Reverting to
+    /// `send().await` would park the keepalive task forever when the
+    /// outbound channel is full — the exact wedged-socket condition where
+    /// the reaper is needed most. (Observed in production: a peer that
+    /// stopped reading filled the outbound queue; the parked keepalive
+    /// never counted a miss, so the connection was never reaped and held
+    /// dispatch resources for 90+ minutes.)
+    ///
+    /// A full-and-never-drained channel must still produce `Timeout` at
+    /// the threshold, with the inbound writer closed so the connection
+    /// tears down.
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_reaps_connection_when_outbound_full() -> TestResult {
+        // Capacity 1, pre-filled, never drained: simulates a sender task
+        // parked on a peer that stopped reading its socket.
+        let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(1);
+        outbound_tx
+            .send(Outbound::new(tungstenite::Message::Binary(
+                vec![0xEE].into(),
+            )))
+            .await?;
+
+        let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
+        let pong_received = Arc::new(AtomicBool::new(false));
+
+        let config = KeepAlive {
+            ping_interval: Duration::from_millis(40),
+            pong_timeout: Duration::from_millis(20),
+            missed_pong_threshold: nz(2),
+        };
+
+        // Bound the whole run in virtual time: with a blocking ping send
+        // this would never complete (the channel is never drained), and
+        // with paused time the timeout fires deterministically.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(10),
+            keepalive_loop(
+                config,
+                PeerId::new([42u8; 32]),
+                outbound_tx.clone(),
+                inbound_writer.clone(),
+                pong_received,
+                Arc::new(AtomicU64::new(0)),
+                TokioSleeper,
+            ),
+        )
+        .await
+        .map_err(|_| "keepalive_loop parked on a full outbound channel (ping send blocked)")?;
+
+        let KeepAliveOutcome::Timeout { missed } = outcome else {
+            return Err(format!("expected Timeout outcome, got {outcome:?}").into());
+        };
+        assert_eq!(missed, 2, "should close on exactly the threshold count");
+
+        assert!(
+            inbound_writer.is_closed(),
+            "inbound_writer should be closed so the connection tears down"
+        );
+        assert!(outbound_tx.is_closed(), "outbound should be closed");
+
+        // The wedged payload is still queued — dropped pings/Close never
+        // displaced it (that would reorder the peer's stream).
+        assert_eq!(outbound_rx.len(), 1, "pre-existing message untouched");
+        Ok(())
+    }
+
+    /// A saturated-but-draining connection must NOT be reaped: the outbound
+    /// queue is full at every ping instant (pings are dropped), but the
+    /// sender keeps completing data writes, so the progress gate resets the
+    /// miss counter each cycle.
+    ///
+    /// Reverting the progress gate would reap this connection at
+    /// `threshold × (ping + pong)` — exactly what a bulk cold-sync to a
+    /// slow-but-alive client looks like.
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_does_not_reap_full_but_progressing_connection() -> TestResult {
+        // Capacity 1, pre-filled, never drained: full at every ping instant.
+        let (outbound_tx, _outbound_rx) = async_channel::bounded::<Outbound>(1);
+        outbound_tx
+            .send(Outbound::new(tungstenite::Message::Binary(
+                vec![0xEE].into(),
+            )))
+            .await?;
+
+        let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
+        let pong_received = Arc::new(AtomicBool::new(false));
+        let progress = Arc::new(AtomicU64::new(0));
+
+        // Simulate a sender task that keeps completing data writes even
+        // though the queue stays full (producers instantly refill it).
+        let writer = {
+            let progress = progress.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(15)).await;
+                    progress.fetch_add(1, Ordering::Relaxed);
+                }
+            })
+        };
+
+        let config = KeepAlive {
+            ping_interval: Duration::from_millis(40),
+            pong_timeout: Duration::from_millis(20),
+            missed_pong_threshold: nz(2),
+        };
+
+        // Without the gate this reaps at 2 × (40+20) = 120ms of virtual
+        // time; give it well past that.
+        let outcome_or_timeout = tokio::time::timeout(
+            Duration::from_millis(500),
+            keepalive_loop(
+                config,
+                PeerId::new([42u8; 32]),
+                outbound_tx.clone(),
+                inbound_writer.clone(),
+                pong_received,
+                progress,
+                TokioSleeper,
+            ),
+        )
+        .await;
+
+        writer.abort();
+        if let Ok(unexpected) = outcome_or_timeout {
+            return Err(format!(
+                "keepalive must not reap a connection making write progress, got {unexpected:?}"
+            )
+            .into());
+        }
+        assert!(
+            !inbound_writer.is_closed(),
+            "progressing connection must not be torn down"
+        );
+        Ok(())
+    }
+
+    /// The progress gate must only see *data* writes: the sender task
+    /// counts Binary/Text frames and excludes control frames. If the
+    /// keepalive's own Ping writes moved the counter, an idle dead peer
+    /// would look alive forever and never be reaped.
+    #[tokio::test]
+    async fn sender_task_counts_only_data_writes() -> TestResult {
+        let ws = create_mock_websocket_stream().await;
+        let (websocket, sender_task): (WebSocket<_, Sendable>, _) =
+            WebSocket::new(ws, PeerId::new([7u8; 32]));
+
+        let progress = websocket.data_write_progress.clone();
+        let tx = websocket.outbound_tx.clone();
+
+        let sender = tokio::spawn(sender_task);
+
+        tx.send(Outbound::new(tungstenite::Message::Ping(Vec::new().into())))
+            .await?;
+        tx.send(Outbound::new(tungstenite::Message::Binary(
+            vec![1, 2, 3].into(),
+        )))
+        .await?;
+        tx.send(Outbound::new(tungstenite::Message::Pong(Vec::new().into())))
+            .await?;
+        tx.send(Outbound::new(tungstenite::Message::Text("hi".into())))
+            .await?;
+
+        // Close the channel so the sender task drains and exits.
+        tx.close();
+        sender.await??;
+
+        assert_eq!(
+            progress.load(Ordering::Relaxed),
+            2,
+            "only the Binary and Text frames may count as progress"
+        );
+        Ok(())
+    }
+
     /// Property: silent peer closes at exactly
     /// `threshold × (ping + pong)` of virtual time.
     #[test]
@@ -1170,6 +1416,7 @@ mod tests {
                         tx,
                         inbound_tx,
                         pong_received,
+                        Arc::new(AtomicU64::new(0)),
                         TokioSleeper,
                     )
                     .await;

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -33,6 +33,45 @@ use crate::{
 /// providing backpressure if the sender task can't keep up.
 const OUTBOUND_CHANNEL_CAPACITY: usize = 1024;
 
+/// Hard upper bound on consecutive *delivered-but-unanswered* pings before
+/// the connection is reaped, regardless of write progress.
+///
+/// The keepalive's progress gate forgives missing pongs while
+/// data writes are completing (a saturated-but-draining link). Without a
+/// ceiling, a peer whose transport drains our frames but whose protocol
+/// endpoint never answers pings — a frame-swallowing middlebox, or a
+/// proxy in front of a dead backend — would evade the reaper indefinitely.
+///
+/// Only pings that actually reached the outbound queue count: an
+/// undelivered ping says something about *our* congestion, not about the
+/// peer, so it must not accrue evidence against them (see
+/// [`PING_DELIVERY_ATTEMPTS`] for how delivery is ensured under load).
+/// WebSocket pongs are answered by the remote *protocol stack* (RFC 6455
+/// auto-reply), independent of application load — so a busy-but-healthy
+/// peer always resets this counter, and this many consecutive unanswered
+/// pings over TCP means the remote endpoint is genuinely gone.
+///
+/// With [`KeepAlive::balanced`] (40 s cycles), worst-case detection for
+/// this class is `8 × 40 s ≈ 5.3 min`. Note this also effectively caps
+/// [`KeepAlive::missed_pong_threshold`] values above it.
+///
+/// If this ever becomes a `KeepAlive` field, make it `NonZeroU8` (zero
+/// would mean reap-every-cycle — the same footgun `missed_pong_threshold`
+/// guards against with `NonZeroU32`).
+pub const MAX_UNANSWERED_PINGS: u8 = 8;
+
+/// Delivery attempts for each cycle's keepalive ping.
+///
+/// The ping is attempted at the start of the pong window and retried at
+/// each sub-interval boundary until it enqueues; the sub-sleeps sum to
+/// exactly `pong_timeout`, so cycle timing is unchanged. A draining
+/// outbound queue frees a slot between attempts (write progress implies
+/// drainage implies a retry lands), so a saturated-but-healthy connection
+/// still gets pinged — and its pong resets both liveness counters. Only a
+/// zero-drainage queue (a wedged socket) defeats every attempt, and that
+/// case is caught by the progress-gated miss path instead.
+pub const PING_DELIVERY_ATTEMPTS: u32 = 4;
+
 /// An outbound message, plus its enqueue instant under the `metrics` feature so
 /// the sender task can record queue dwell. Without the feature the timestamp
 /// field is gone — a zero-overhead newtype, and no `std::time` on wasm.
@@ -58,7 +97,16 @@ impl Outbound {
 ///
 /// A peer that misses [`missed_pong_threshold`] consecutive pongs is
 /// declared dead; total detection latency is
-/// `missed_pong_threshold × (ping_interval + pong_timeout)`.
+/// `missed_pong_threshold × (ping_interval + pong_timeout)` for a peer
+/// making no write progress. A peer whose connection keeps completing
+/// data writes (saturated but draining) is forgiven fast-path misses, but
+/// delivered pings that go unanswered accumulate toward
+/// [`MAX_UNANSWERED_PINGS`], so worst-case detection for a
+/// write-accepting-but-silent peer is
+/// `MAX_UNANSWERED_PINGS × (ping_interval + pong_timeout)`
+/// (~5.3 min with [`balanced`](KeepAlive::balanced)). That ceiling also
+/// effectively caps `missed_pong_threshold` values above it whenever
+/// pings are deliverable.
 ///
 /// [`missed_pong_threshold`]: KeepAlive::missed_pong_threshold
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -176,6 +224,21 @@ pub enum KeepAliveOutcome {
     Timeout {
         /// Consecutive missed pongs at the moment of close.
         missed: u32,
+    },
+
+    /// [`MAX_UNANSWERED_PINGS`] consecutive delivered pings went
+    /// unanswered; the keepalive task closed the channels.
+    ///
+    /// Distinct from [`Timeout`](Self::Timeout) because it fires even for
+    /// a connection making write progress: a peer whose transport drains
+    /// our frames but whose remote endpoint never pongs (frame-swallowing
+    /// middlebox, WS proxy in front of a dead backend) — a different
+    /// operational signal than a silent socket.
+    #[error("keepalive task exited: {unanswered} consecutive pings unanswered")]
+    StaleNoPong {
+        /// Consecutive delivered-but-unanswered pings at the moment of close.
+        /// Never exceeds [`MAX_UNANSWERED_PINGS`], hence the width.
+        unanswered: u8,
     },
 }
 
@@ -708,7 +771,20 @@ where
     S: Sleeper<Async>,
     Async: FutureForm + ?Sized,
 {
+    // One liveness detector, two patience levels over the same ping/pong
+    // evidence stream:
+    //
+    //  - `consecutive_misses` (reset by pong OR data-write progress):
+    //    fast path, `missed_pong_threshold` cycles (~80 s balanced).
+    //    Catches wedged/dead connections where nothing moves.
+    //
+    //  - `unanswered_pings` (reset by pong ONLY; counts only pings that
+    //    were actually delivered to the outbound queue): patient path,
+    //    MAX_UNANSWERED_PINGS cycles (~5.3 min balanced). Catches
+    //    transports that keep draining data while the remote protocol
+    //    stack never answers — exactly the peers progress forgives.
     let mut consecutive_misses: u32 = 0;
+    let mut unanswered_pings: u8 = 0;
     let threshold = config.missed_pong_threshold.get();
 
     loop {
@@ -720,48 +796,87 @@ where
         // can't satisfy this one.
         pong_received.store(false, Ordering::Relaxed);
 
-        // Empty payload: we don't verify the Pong reply matches a
-        // specific Ping, so a unique payload would just be overhead.
+        // Attempt ping delivery across the pong window: once at the window
+        // start, then again at each sub-interval boundary until it lands.
         //
-        // Non-blocking: a full outbound queue means the sender task is not
-        // draining (e.g. the peer stopped reading and the socket write is
-        // parked). A blocking send here would park *this* task before it
-        // could ever reach the miss check below, so the one connection that
-        // most needs reaping would never be reaped. Dropping the ping lets
-        // the cycle proceed: no pong can arrive for a ping that never left,
-        // so the miss counter advances toward the close threshold.
-        let ping = tungstenite::Message::Ping(Vec::new().into());
-        match outbound_tx.try_send(Outbound::new(ping)) {
-            Ok(()) => {
-                tracing::trace!(peer = %peer_id, "keepalive: sent ping");
+        // Non-blocking throughout: a blocking send would park *this* task
+        // on the very condition (full outbound queue) it exists to detect.
+        // The retries make delivery reliable on a draining queue — a slot
+        // frees between attempts — so failing every attempt implies zero
+        // drainage, which the miss path below catches via the absent write
+        // progress. Empty ping payload: we don't verify the Pong matches a
+        // specific Ping, so a unique payload would just be overhead.
+        let window = PongWindow::plan(config.pong_timeout);
+        let mut ping_sent = false;
+        for attempt in 0..window.attempts {
+            if !ping_sent {
+                let ping = tungstenite::Message::Ping(Vec::new().into());
+                match outbound_tx.try_send(Outbound::new(ping)) {
+                    Ok(()) => {
+                        ping_sent = true;
+                        tracing::trace!(peer = %peer_id, attempt, "keepalive: sent ping");
+                    }
+                    Err(async_channel::TrySendError::Closed(_)) => {
+                        tracing::debug!(peer = %peer_id, "keepalive: outbound closed; exiting");
+                        return KeepAliveOutcome::ConnectionClosed;
+                    }
+                    Err(async_channel::TrySendError::Full(_)) => {
+                        tracing::trace!(
+                            peer = %peer_id,
+                            attempt,
+                            "keepalive: outbound full; will retry ping"
+                        );
+                    }
+                }
             }
-            Err(async_channel::TrySendError::Closed(_)) => {
-                tracing::debug!(peer = %peer_id, "keepalive: outbound closed; exiting");
-                return KeepAliveOutcome::ConnectionClosed;
-            }
-            Err(async_channel::TrySendError::Full(_)) => {
-                tracing::warn!(
-                    peer = %peer_id,
-                    "keepalive: outbound queue full; ping dropped (counts toward misses)"
-                );
-            }
+
+            sleeper.sleep(window.sleep_after(attempt)).await;
         }
 
-        sleeper.sleep(config.pong_timeout).await;
+        if !ping_sent {
+            // Says something about our congestion, not the peer — must not
+            // count against them. The miss path below judges this cycle by
+            // write progress alone.
+            tracing::debug!(
+                peer = %peer_id,
+                "keepalive: outbound full for the whole window; ping undelivered"
+            );
+        }
 
         if pong_received.load(Ordering::Relaxed) {
-            if consecutive_misses > 0 {
-                tracing::debug!(peer = %peer_id, "keepalive: pong recovered after misses");
+            if consecutive_misses > 0 || unanswered_pings > 0 {
+                tracing::debug!(peer = %peer_id, "keepalive: pong received; counters reset");
             }
             consecutive_misses = 0;
+            unanswered_pings = 0;
             continue;
         }
 
-        // No pong — but if data writes completed this cycle the transport is
-        // demonstrably moving (e.g. the queue was full at the ping instant on
-        // a link mid-bulk-transfer). Don't count a miss against a connection
-        // that is making progress; a wedged socket completes nothing and
-        // falls through to the miss path.
+        if ping_sent {
+            unanswered_pings += 1;
+
+            if unanswered_pings >= MAX_UNANSWERED_PINGS {
+                // A delivered ping is answered by any compliant, reachable
+                // WS stack regardless of application load, so this many in
+                // a row means the remote protocol endpoint is gone — even
+                // if the transport is still draining our data frames.
+                tracing::warn!(
+                    peer = %peer_id,
+                    unanswered = unanswered_pings,
+                    "keepalive: consecutive pings unanswered; closing connection"
+                );
+                reap(&outbound_tx, &inbound_writer);
+                return KeepAliveOutcome::StaleNoPong {
+                    unanswered: unanswered_pings,
+                };
+            }
+        }
+
+        // No pong — but if data writes completed this cycle the transport
+        // is demonstrably moving (e.g. the queue was full for the whole
+        // window on a link mid-bulk-transfer). Don't count a fast-path miss
+        // against a connection that is making progress; a wedged socket
+        // completes nothing and falls through to the miss path.
         if data_write_progress.load(Ordering::Relaxed) != progress_snapshot {
             if consecutive_misses > 0 {
                 tracing::debug!(
@@ -789,23 +904,81 @@ where
                 misses = consecutive_misses,
                 "keepalive: threshold reached; closing connection"
             );
-            #[cfg(feature = "metrics")]
-            subduction_core::metrics::keepalive_close();
-            // Best-effort Close frame; non-blocking since we're closing
-            // the channel right after.
-            let close_frame = tungstenite::Message::Close(Some(CloseFrame {
-                code: CloseCode::Away,
-                reason: "keepalive timeout".into(),
-            }));
-            drop(outbound_tx.try_send(Outbound::new(close_frame)));
-
-            outbound_tx.close();
-            inbound_writer.close();
+            reap(&outbound_tx, &inbound_writer);
             return KeepAliveOutcome::Timeout {
                 missed: consecutive_misses,
             };
         }
     }
+}
+
+/// Sub-sleep schedule for one pong window (see [`PING_DELIVERY_ATTEMPTS`]).
+///
+/// The sub-sleeps always sum to exactly the configured `pong_timeout`, so
+/// cycle timing is identical whether or not ping retries happen.
+struct PongWindow {
+    attempts: u32,
+    sub_sleep: Duration,
+    last_sleep: Duration,
+}
+
+impl PongWindow {
+    /// Plan the window schedule.
+    ///
+    /// Sub-sleeps are whole milliseconds: timer wheels (tokio's included)
+    /// round sub-millisecond sleeps *up*, which would stretch the window.
+    /// When the window is too small to split cleanly, fall back to a
+    /// single delivery attempt spanning the full window.
+    fn plan(pong_timeout: Duration) -> Self {
+        let sub_ms = u64::try_from(pong_timeout.as_millis()).unwrap_or(u64::MAX)
+            / u64::from(PING_DELIVERY_ATTEMPTS);
+        let (attempts, sub_sleep) = if sub_ms == 0 {
+            (1, pong_timeout)
+        } else {
+            (PING_DELIVERY_ATTEMPTS, Duration::from_millis(sub_ms))
+        };
+        // The final sub-sleep absorbs division rounding so the window's
+        // total is exactly `pong_timeout`.
+        let last_sleep = pong_timeout
+            .checked_sub(sub_sleep * (attempts - 1))
+            .unwrap_or(sub_sleep);
+
+        Self {
+            attempts,
+            sub_sleep,
+            last_sleep,
+        }
+    }
+
+    /// The sleep duration following attempt number `attempt`.
+    const fn sleep_after(&self, attempt: u32) -> Duration {
+        if attempt == self.attempts - 1 {
+            self.last_sleep
+        } else {
+            self.sub_sleep
+        }
+    }
+}
+
+/// Tear a connection down from the keepalive task: best-effort Close
+/// frame (non-blocking — the channel may be full or already closing),
+/// then close both channels so every parked producer and `recv_bytes`
+/// waiter errors out and the connection unwinds.
+fn reap(
+    outbound_tx: &async_channel::Sender<Outbound>,
+    inbound_writer: &async_channel::Sender<Vec<u8>>,
+) {
+    #[cfg(feature = "metrics")]
+    subduction_core::metrics::keepalive_close();
+
+    let close_frame = tungstenite::Message::Close(Some(CloseFrame {
+        code: CloseCode::Away,
+        reason: "keepalive timeout".into(),
+    }));
+    drop(outbound_tx.try_send(Outbound::new(close_frame)));
+
+    outbound_tx.close();
+    inbound_writer.close();
 }
 
 impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> Clone for WebSocket<T, Async> {
@@ -1302,9 +1475,15 @@ mod tests {
         };
 
         // Without the gate this reaps at 2 × (40+20) = 120ms of virtual
-        // time; give it well past that.
+        // time; observe well past that. The MAX_UNANSWERED_PINGS ceiling
+        // never engages here: the queue has zero drainage, so no ping is
+        // ever delivered, and undelivered pings say something about our
+        // congestion — not the peer — so they accrue no evidence. (In
+        // reality progress implies drainage implies a retry would land;
+        // this test pokes the progress counter directly to isolate the
+        // gate.)
         let outcome_or_timeout = tokio::time::timeout(
-            Duration::from_millis(500),
+            Duration::from_millis(400),
             keepalive_loop(
                 config,
                 PeerId::new([42u8; 32]),
@@ -1328,6 +1507,171 @@ mod tests {
             !inbound_writer.is_closed(),
             "progressing connection must not be torn down"
         );
+        Ok(())
+    }
+
+    /// The progress gate forgives missing pongs only up to
+    /// `MAX_UNANSWERED_PINGS`: a peer that keeps accepting data writes
+    /// but never answers delivered pings (frame-swallowing middlebox,
+    /// proxy fronting a dead backend) must still be reaped at the hard
+    /// ceiling. Removing the ceiling would let such a peer evade the
+    /// reaper indefinitely.
+    #[tokio::test(start_paused = true)]
+    async fn keepalive_reaps_progressing_peer_that_never_pongs() -> TestResult {
+        let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
+        let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
+        let pong_received = Arc::new(AtomicBool::new(false));
+        let progress = Arc::new(AtomicU64::new(0));
+
+        // Drain pings (so try_send succeeds) but never pong; keep write
+        // progress advancing every cycle.
+        let drain = tokio::spawn(async move { while outbound_rx.recv().await.is_ok() {} });
+        let writer = {
+            let progress = progress.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(15)).await;
+                    progress.fetch_add(1, Ordering::Relaxed);
+                }
+            })
+        };
+
+        let config = KeepAlive {
+            ping_interval: Duration::from_millis(40),
+            pong_timeout: Duration::from_millis(20),
+            missed_pong_threshold: nz(2),
+        };
+
+        let start = tokio::time::Instant::now();
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(10),
+            keepalive_loop(
+                config,
+                PeerId::new([42u8; 32]),
+                outbound_tx.clone(),
+                inbound_writer.clone(),
+                pong_received,
+                progress,
+                TokioSleeper,
+            ),
+        )
+        .await
+        .map_err(|_| "progressing-but-silent peer must still be reaped at the hard ceiling")?;
+        let elapsed = start.elapsed();
+        writer.abort();
+
+        let KeepAliveOutcome::StaleNoPong { unanswered } = outcome else {
+            return Err(format!("expected StaleNoPong outcome, got {outcome:?}").into());
+        };
+        assert_eq!(unanswered, MAX_UNANSWERED_PINGS);
+        // 8 cycles × (40 + 20)ms of virtual time — the retry sub-sleeps
+        // sum to exactly pong_timeout, so cycle timing is unchanged.
+        assert_eq!(
+            elapsed,
+            Duration::from_millis(u64::from(MAX_UNANSWERED_PINGS) * 60),
+            "reap must land exactly at the ceiling"
+        );
+        assert!(
+            inbound_writer.is_closed(),
+            "stale connection must be torn down"
+        );
+
+        outbound_tx.close();
+        drop(drain.await);
+        Ok(())
+    }
+
+    /// A queue that is full at the ping instant but *draining* must not
+    /// cost the peer liveness evidence: the in-window retry delivers the
+    /// ping once a slot frees, the (healthy) peer pongs, and both counters
+    /// reset. Without the retry, a busy peer whose inbound queue from us
+    /// hovers at capacity would never be pinged at all and could be
+    /// falsely reaped by the unanswered-ping ceiling.
+    #[tokio::test(start_paused = true)]
+    async fn ping_retry_delivers_on_draining_queue_and_pong_resets_counters() -> TestResult {
+        // Capacity 1, pre-filled: the first try_send (window start, t=40ms)
+        // fails. Config: 40ms interval, 20ms window → retries at t=45/50/55.
+        let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(1);
+        outbound_tx
+            .send(Outbound::new(tungstenite::Message::Binary(
+                vec![0xEE].into(),
+            )))
+            .await?;
+
+        let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
+        let pong_received = Arc::new(AtomicBool::new(false));
+        let progress = Arc::new(AtomicU64::new(0));
+
+        // Scripted peer: at t=47ms drain the Binary (freeing a slot between
+        // the t=45 and t=50 retries), then receive the retried ping at t=50
+        // and answer it. Records that a Ping was actually observed.
+        let saw_ping = Arc::new(AtomicBool::new(false));
+        let peer = {
+            let pong_received = pong_received.clone();
+            let saw_ping = saw_ping.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(47)).await;
+                let first = outbound_rx.recv().await;
+                assert!(
+                    matches!(
+                        first.as_ref().map(|o| &o.msg),
+                        Ok(tungstenite::Message::Binary(_))
+                    ),
+                    "first drained frame should be the pre-filled Binary"
+                );
+
+                // Parks until the t=50 retry enqueues the ping.
+                if let Ok(item) = outbound_rx.recv().await
+                    && matches!(item.msg, tungstenite::Message::Ping(_))
+                {
+                    saw_ping.store(true, Ordering::Relaxed);
+                    pong_received.store(true, Ordering::Relaxed);
+                }
+
+                // Keep draining so subsequent cycles behave normally.
+                while let Ok(item) = outbound_rx.recv().await {
+                    if matches!(item.msg, tungstenite::Message::Ping(_)) {
+                        pong_received.store(true, Ordering::Relaxed);
+                    }
+                }
+            })
+        };
+
+        let config = KeepAlive {
+            ping_interval: Duration::from_millis(40),
+            pong_timeout: Duration::from_millis(20),
+            missed_pong_threshold: nz(2),
+        };
+
+        // Run several cycles; a false reap would resolve the loop early.
+        let outcome_or_timeout = tokio::time::timeout(
+            Duration::from_millis(300),
+            keepalive_loop(
+                config,
+                PeerId::new([42u8; 32]),
+                outbound_tx.clone(),
+                inbound_writer.clone(),
+                pong_received,
+                progress,
+                TokioSleeper,
+            ),
+        )
+        .await;
+
+        if let Ok(unexpected) = outcome_or_timeout {
+            return Err(format!(
+                "healthy draining+ponging peer must not be reaped, got {unexpected:?}"
+            )
+            .into());
+        }
+        assert!(
+            saw_ping.load(Ordering::Relaxed),
+            "the retry must have delivered a ping after the initial Full"
+        );
+        assert!(!inbound_writer.is_closed());
+
+        outbound_tx.close();
+        peer.await?;
         Ok(())
     }
 
@@ -1423,21 +1767,41 @@ mod tests {
                     let elapsed = start.elapsed();
                     drop(drain.await);
 
+                    // A silent-but-draining peer receives every ping, so
+                    // both liveness counters advance each cycle and the
+                    // reap lands at whichever bound is lower: the
+                    // configured miss threshold (fast path, `Timeout`) or
+                    // the unanswered-ping ceiling (`StaleNoPong`). The
+                    // ceiling check runs first within a cycle, so a
+                    // threshold equal to the ceiling also yields
+                    // `StaleNoPong`.
+                    let expected_cycles = threshold_u32.min(u32::from(MAX_UNANSWERED_PINGS));
                     let expected = Duration::from_millis(
-                        u64::from(threshold_u32) * (interval_ms + timeout_ms),
+                        u64::from(expected_cycles) * (interval_ms + timeout_ms),
                     );
                     assert_eq!(
                         elapsed, expected,
                         "ping={interval_ms}ms pong={timeout_ms}ms threshold={threshold_u32}: \
                          expected close at {expected:?}, observed {elapsed:?}"
                     );
-                    assert!(
-                        matches!(
-                            outcome,
-                            KeepAliveOutcome::Timeout { missed } if missed == threshold_u32
-                        ),
-                        "outcome was {outcome:?}, expected Timeout {{ missed: {threshold_u32} }}"
-                    );
+                    if threshold_u32 < u32::from(MAX_UNANSWERED_PINGS) {
+                        assert!(
+                            matches!(
+                                outcome,
+                                KeepAliveOutcome::Timeout { missed } if missed == threshold_u32
+                            ),
+                            "outcome was {outcome:?}, expected Timeout {{ missed: {threshold_u32} }}"
+                        );
+                    } else {
+                        assert!(
+                            matches!(
+                                outcome,
+                                KeepAliveOutcome::StaleNoPong { unanswered }
+                                    if unanswered == MAX_UNANSWERED_PINGS
+                            ),
+                            "outcome was {outcome:?}, expected StaleNoPong {{ unanswered: {MAX_UNANSWERED_PINGS} }}"
+                        );
+                    }
                 });
             });
     }

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -42,22 +42,17 @@ const OUTBOUND_CHANNEL_CAPACITY: usize = 1024;
 /// endpoint never answers pings — a frame-swallowing middlebox, or a
 /// proxy in front of a dead backend — would evade the reaper indefinitely.
 ///
-/// Only pings that were actually delivered count: an undelivered ping
-/// says something about *our* congestion, not about the peer, so it must
-/// not accrue evidence against them. Delivery is via `try_send` retries
-/// across the pong window, plus sender-task injection when the queue is
-/// full (see [`PING_DELIVERY_ATTEMPTS`]), so a ping lands whenever the
-/// connection drains at all during the window; only a zero-drainage
-/// (wedged) window goes undelivered, and that case is caught by the
-/// progress-gated miss path instead. WebSocket pongs are answered by the
-/// remote protocol stack (RFC 6455 auto-reply — in most implementations
-/// whenever the peer drives its read loop), largely independent of
-/// application load — so a busy-but-healthy peer keeps resetting this
-/// counter, and this many consecutive unanswered pings over TCP means the
-/// remote endpoint has stopped servicing the protocol.
+/// Only delivered pings count: an undelivered ping reflects our own
+/// congestion, not the peer, so it accrues no evidence against them.
+/// Delivery is guaranteed under any drainage (see
+/// [`PING_DELIVERY_ATTEMPTS`]); a zero-drainage window goes undelivered
+/// and is caught by the progress-gated miss path instead. Pongs are RFC
+/// 6455 auto-replies from the peer's protocol stack, independent of its
+/// application load, so this many consecutive unanswered pings over TCP
+/// means the remote endpoint has stopped servicing the protocol.
 ///
 /// With [`KeepAlive::balanced`] (40 s cycles), worst-case detection for
-/// this class is `8 × 40 s ≈ 5.3 min`. Note this also effectively caps
+/// this class is `8 × 40 s ≈ 5.3 min`. This also effectively caps
 /// [`KeepAlive::missed_pong_threshold`] values above it.
 ///
 /// If this ever becomes a `KeepAlive` field, make it `NonZeroU8` (zero
@@ -70,13 +65,10 @@ pub const MAX_UNANSWERED_PINGS: u8 = 8;
 /// The ping is attempted at the start of the pong window and retried at
 /// each sub-interval boundary until it enqueues; the sub-sleeps sum to
 /// exactly `pong_timeout`, so cycle timing is unchanged. Retries alone
-/// are best-effort — parked producers woken FIFO usually win freed slots
-/// — so a failed attempt also raises `ping_requested`, and the *sender
-/// task* injects the ping directly into the sink after its next completed
-/// frame. Between the two paths, delivery is guaranteed whenever the
-/// connection drains at least one frame during the window; only a
-/// zero-drainage queue (a wedged socket) defeats both, and that case is
-/// caught by the progress-gated miss path instead.
+/// are best-effort (parked producers woken FIFO usually win freed slots),
+/// so a failed attempt also raises `KeepAliveSignals::ping_requested` for
+/// sender-task injection. Between the two paths, delivery is guaranteed
+/// whenever the connection drains at least one frame during the window.
 pub const PING_DELIVERY_ATTEMPTS: u32 = 4;
 
 /// An outbound message, plus its enqueue instant under the `metrics` feature so
@@ -482,15 +474,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
                         signals.data_write_progress.fetch_add(1, Ordering::Relaxed);
                     }
 
-                    // Keepalive ping injection: the keepalive raises
-                    // `ping_requested` when its try_send found the queue
-                    // full. Injecting here — between frames, directly into
-                    // the sink — bypasses the queue entirely, so parked
-                    // producers can't starve the ping: delivery is
-                    // guaranteed whenever any frame completes during the
-                    // pong window. On a wedged socket this point is never
-                    // reached, and the undelivered ping correctly accrues
-                    // no evidence against the peer.
+                    // Keepalive ping injection — between frames, directly
+                    // into the sink, bypassing the queue. See
+                    // `KeepAliveSignals::ping_requested`.
                     if signals.ping_requested.swap(false, Ordering::Relaxed) {
                         let ping = tungstenite::Message::Ping(Vec::new().into());
                         #[cfg(feature = "metrics")]
@@ -694,17 +680,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin> WebSocket<T, Sendable> {
     ///
     /// # Pong asymmetry
     ///
-    /// Outbound *ping* delivery is guaranteed under drainage (queue
-    /// retries + sender-task injection), but our *pong replies* to the
-    /// peer's pings remain single-shot `try_send`s from the listener — the
-    /// read loop cannot sleep-retry without stalling inbound traffic. If a
-    /// symmetric peer runs this same unanswered-ping ceiling, a sustained
-    /// (> `MAX_UNANSWERED_PINGS` cycles) period of our outbound queue
-    /// being full at every pong-reply instant could cause *them* to reap a
-    /// healthy connection. Currently moot — browsers auto-pong natively
-    /// and cannot send application pings — but relevant for future
-    /// server↔server links; a priority slot for control frames would close
-    /// it.
+    /// Outbound *ping* delivery is guaranteed under drainage, but our
+    /// *pong replies* remain single-shot `try_send`s from the listener
+    /// (the read loop cannot sleep-retry without stalling inbound
+    /// traffic). A symmetric peer running this same unanswered-ping
+    /// ceiling could therefore reap a healthy connection whose queue
+    /// toward it stays full for > `MAX_UNANSWERED_PINGS` cycles. Moot for
+    /// browser peers (native auto-pong, no application pings); relevant
+    /// for server↔server links. A priority slot for control frames would
+    /// close it.
     ///
     /// `sleeper` provides the in-between waits — typically
     /// [`TokioSleeper`](crate::sleep::TokioSleeper) or
@@ -830,9 +814,9 @@ impl ReadErrorKind {
 /// or the sender completed at least one *data* write during the cycle
 /// (`data_write_progress` advanced). The progress gate stops a saturated
 /// but draining connection from being reaped just because its outbound
-/// queue happened to be full at the ping instant; a genuinely wedged
-/// socket makes no write progress, so it still accumulates misses and is
-/// reaped at the threshold.
+/// queue happened to be full at the ping instant; a wedged socket makes
+/// no write progress, so it still accumulates misses and is reaped at the
+/// threshold.
 #[allow(
     clippy::too_many_lines,
     reason = "a deliberately linear liveness state machine; the extractable \
@@ -873,14 +857,12 @@ where
         sleeper.sleep(config.ping_interval).await;
 
         // Clear before sending so a stale Pong from a previous cycle can't
-        // satisfy this one — but a pong that arrived during the interval is
-        // still evidence the peer's protocol stack answered our *previous*
-        // ping (just late, e.g. a ping delivered on the window's last
-        // attempt leaves less than a full window to reply). Credit it
-        // against the unanswered-ping ceiling so a slow-but-answering peer
-        // isn't misclassified as protocol-dead. The fast-path miss counter
-        // is deliberately not credited: late pongs say nothing about
-        // whether anything moved *this* cycle.
+        // satisfy this one — but a pong that arrived during the interval
+        // still answers the *previous* ping (late, e.g. one delivered on
+        // the window's last attempt). Credit it against the ceiling so a
+        // slow-but-answering peer isn't misclassified as protocol-dead.
+        // The miss counter is not credited: late pongs say nothing about
+        // whether anything moved this cycle.
         if signals.pong_received.swap(false, Ordering::Relaxed) && unanswered_pings > 0 {
             tracing::debug!(
                 peer = %peer_id,
@@ -890,18 +872,11 @@ where
         }
         signals.ping_injected.store(false, Ordering::Relaxed);
 
-        // Attempt ping delivery across the pong window: once at the window
-        // start, then again at each sub-interval boundary until it lands.
-        // If the queue is full, raise `ping_requested` so the sender task
-        // injects the ping directly into the sink between frames — parked
-        // producers competing for freed slots can't starve it.
-        //
-        // Non-blocking throughout: a blocking send would park *this* task
-        // on the very condition (full outbound queue) it exists to detect.
-        // Failure of every path implies zero drainage for the whole window,
-        // which the miss path below catches via the absent write progress.
-        // Empty ping payload: we don't verify the Pong matches a specific
-        // Ping, so a unique payload would just be overhead.
+        // Deliver the ping: try_send at each sub-interval boundary, plus
+        // sender-task injection when the queue is full (see
+        // PING_DELIVERY_ATTEMPTS). Non-blocking throughout — a blocking
+        // send would park this task on the very condition it exists to
+        // detect. Empty payload: we don't match Pongs to specific Pings.
         let window = PongWindow::plan(config.pong_timeout);
         let mut ping_queued = false;
         for attempt in 0..window.attempts {
@@ -939,9 +914,9 @@ where
             // Cancel the standing injection request so a stale ping isn't
             // injected long after this window (the next cycle re-requests).
             signals.ping_requested.store(false, Ordering::Relaxed);
-            // An undelivered ping says something about our congestion, not
-            // the peer — it must not count against them. The miss path
-            // below judges this cycle by write progress alone.
+            // Undelivered pings accrue no evidence (see
+            // MAX_UNANSWERED_PINGS); the miss path judges this cycle by
+            // write progress alone.
             #[cfg(feature = "metrics")]
             subduction_core::metrics::keepalive_ping_undelivered();
             tracing::debug!(
@@ -950,7 +925,10 @@ where
             );
         }
 
-        if signals.pong_received.load(Ordering::Relaxed) {
+        // `swap`, not `load`: pong evidence is consumed exactly once. A
+        // `load` would leave the flag set for the next cycle's late-pong
+        // credit, double-counting one pong as two cycles of evidence.
+        if signals.pong_received.swap(false, Ordering::Relaxed) {
             if consecutive_misses > 0 || unanswered_pings > 0 {
                 tracing::debug!(peer = %peer_id, "keepalive: pong received; counters reset");
             }
@@ -1045,10 +1023,9 @@ impl PongWindow {
             (PING_DELIVERY_ATTEMPTS, Duration::from_millis(sub_ms))
         };
         // The final sub-sleep absorbs division rounding so the window's
-        // total is exactly `pong_timeout`. The fallback is believed
-        // unreachable (3·⌊x/4⌋ ≤ x) and is deliberately non-panicking: this
-        // code runs inside the keepalive task, whose unconditional survival
-        // is the whole point — a slightly-off window beats a dead reaper.
+        // total is exactly `pong_timeout`. The fallback is unreachable
+        // (3·⌊x/4⌋ ≤ x) and deliberately non-panicking: a panic here would
+        // kill the keepalive task itself.
         let last_sleep = pong_timeout
             .checked_sub(sub_sleep * (attempts - 1))
             .unwrap_or(sub_sleep);
@@ -1475,10 +1452,7 @@ mod tests {
     /// Regression: the keepalive *ping* uses `try_send`. Reverting to
     /// `send().await` would park the keepalive task forever when the
     /// outbound channel is full — the exact wedged-socket condition where
-    /// the reaper is needed most. (Observed in production: a peer that
-    /// stopped reading filled the outbound queue; the parked keepalive
-    /// never counted a miss, so the connection was never reaped and held
-    /// dispatch resources for 90+ minutes.)
+    /// the reaper is needed most.
     ///
     /// A full-and-never-drained channel must still produce `Timeout` at
     /// the threshold, with the inbound writer closed so the connection
@@ -1578,12 +1552,10 @@ mod tests {
         };
 
         // Without the gate this reaps at 2 × (40+20) = 120ms of virtual
-        // time. The MAX_UNANSWERED_PINGS ceiling never engages here: the
-        // queue has zero drainage, so no ping is ever delivered, and
-        // undelivered pings say something about our congestion — not the
-        // peer — so they accrue no evidence. Observe past the point where
-        // a mutant that counts undelivered pings would reap (8 × 60 =
-        // 480ms) to make that claim load-bearing.
+        // time. The ceiling never engages: zero drainage means no ping is
+        // ever delivered, and undelivered pings accrue no evidence. The
+        // window extends past 8 × 60 = 480ms to catch a mutant that counts
+        // undelivered pings toward the ceiling.
         let outcome_or_timeout = tokio::time::timeout(
             Duration::from_millis(650),
             keepalive_loop(
@@ -1772,18 +1744,19 @@ mod tests {
         Ok(())
     }
 
-    /// A pong resets the unanswered-ping counter: a peer that misses some
-    /// pongs but then answers must never accumulate to the ceiling. The
-    /// progress writer suppresses the fast (miss) path so this pins the
-    /// ceiling counter's reset specifically — a non-resetting counter
-    /// would reap at the 8th cumulative unanswered ping (~540ms here).
+    /// A pong resets the unanswered-ping counter. The peer answers only
+    /// every second ping: a resetting counter oscillates between 0 and 1
+    /// and never reaps; a non-resetting counter accumulates one unanswered
+    /// ping per two cycles and reaps `StaleNoPong` at cycle 15 (~900ms
+    /// here). The intervening pongs keep the fast-path miss counter below
+    /// its threshold, so only the ceiling's reset behavior is in play.
     #[tokio::test(start_paused = true)]
     async fn pong_resets_unanswered_ping_counter() -> TestResult {
         let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
         let signals = KeepAliveSignals::new();
 
-        // Peer: ignores the first two pings, answers every ping after.
+        // Peer: answers even-numbered pings only.
         let peer = {
             let pong_received = signals.pong_received.clone();
             tokio::spawn(async move {
@@ -1791,24 +1764,12 @@ mod tests {
                 while let Ok(item) = outbound_rx.recv().await {
                     if matches!(item.msg, tungstenite::Message::Ping(_)) {
                         seen += 1;
-                        if seen > 2 {
+                        if seen.is_multiple_of(2) {
                             pong_received.store(true, Ordering::Relaxed);
                         }
                     }
                 }
                 seen
-            })
-        };
-
-        // Progress advances every cycle so the fast path (threshold 2)
-        // never fires; only the unanswered-ping ceiling is in play.
-        let writer = {
-            let progress = signals.data_write_progress.clone();
-            tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(Duration::from_millis(15)).await;
-                    progress.fetch_add(1, Ordering::Relaxed);
-                }
             })
         };
 
@@ -1818,11 +1779,8 @@ mod tests {
             missed_pong_threshold: nz(2),
         };
 
-        // A broken (non-resetting) unanswered counter reaps at the 8th
-        // cumulative unanswered ping: cycles 1-2 unanswered, so cycle 14
-        // (~840ms). Observe past that.
         let outcome_or_timeout = tokio::time::timeout(
-            Duration::from_millis(1000),
+            Duration::from_millis(1100),
             keepalive_loop(
                 config,
                 PeerId::new([42u8; 32]),
@@ -1834,10 +1792,9 @@ mod tests {
         )
         .await;
 
-        writer.abort();
         if let Ok(unexpected) = outcome_or_timeout {
             return Err(format!(
-                "peer that resumed ponging must not be reaped, got {unexpected:?}"
+                "alternating-pong peer must not be reaped, got {unexpected:?}"
             )
             .into());
         }
@@ -1845,7 +1802,7 @@ mod tests {
 
         outbound_tx.close();
         let seen = peer.await?;
-        assert!(seen > 8, "expected many ping cycles, saw {seen}");
+        assert!(seen > 16, "expected many ping cycles, saw {seen}");
         Ok(())
     }
 

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -1793,10 +1793,9 @@ mod tests {
         .await;
 
         if let Ok(unexpected) = outcome_or_timeout {
-            return Err(format!(
-                "alternating-pong peer must not be reaped, got {unexpected:?}"
-            )
-            .into());
+            return Err(
+                format!("alternating-pong peer must not be reaped, got {unexpected:?}").into(),
+            );
         }
         assert!(!inbound_writer.is_closed());
 

--- a/subduction_websocket/src/websocket.rs
+++ b/subduction_websocket/src/websocket.rs
@@ -42,14 +42,19 @@ const OUTBOUND_CHANNEL_CAPACITY: usize = 1024;
 /// endpoint never answers pings — a frame-swallowing middlebox, or a
 /// proxy in front of a dead backend — would evade the reaper indefinitely.
 ///
-/// Only pings that actually reached the outbound queue count: an
-/// undelivered ping says something about *our* congestion, not about the
-/// peer, so it must not accrue evidence against them (see
-/// [`PING_DELIVERY_ATTEMPTS`] for how delivery is ensured under load).
-/// WebSocket pongs are answered by the remote *protocol stack* (RFC 6455
-/// auto-reply), independent of application load — so a busy-but-healthy
-/// peer always resets this counter, and this many consecutive unanswered
-/// pings over TCP means the remote endpoint is genuinely gone.
+/// Only pings that were actually delivered count: an undelivered ping
+/// says something about *our* congestion, not about the peer, so it must
+/// not accrue evidence against them. Delivery is via `try_send` retries
+/// across the pong window, plus sender-task injection when the queue is
+/// full (see [`PING_DELIVERY_ATTEMPTS`]), so a ping lands whenever the
+/// connection drains at all during the window; only a zero-drainage
+/// (wedged) window goes undelivered, and that case is caught by the
+/// progress-gated miss path instead. WebSocket pongs are answered by the
+/// remote protocol stack (RFC 6455 auto-reply — in most implementations
+/// whenever the peer drives its read loop), largely independent of
+/// application load — so a busy-but-healthy peer keeps resetting this
+/// counter, and this many consecutive unanswered pings over TCP means the
+/// remote endpoint has stopped servicing the protocol.
 ///
 /// With [`KeepAlive::balanced`] (40 s cycles), worst-case detection for
 /// this class is `8 × 40 s ≈ 5.3 min`. Note this also effectively caps
@@ -60,16 +65,18 @@ const OUTBOUND_CHANNEL_CAPACITY: usize = 1024;
 /// guards against with `NonZeroU32`).
 pub const MAX_UNANSWERED_PINGS: u8 = 8;
 
-/// Delivery attempts for each cycle's keepalive ping.
+/// Queue-delivery attempts for each cycle's keepalive ping.
 ///
 /// The ping is attempted at the start of the pong window and retried at
 /// each sub-interval boundary until it enqueues; the sub-sleeps sum to
-/// exactly `pong_timeout`, so cycle timing is unchanged. A draining
-/// outbound queue frees a slot between attempts (write progress implies
-/// drainage implies a retry lands), so a saturated-but-healthy connection
-/// still gets pinged — and its pong resets both liveness counters. Only a
-/// zero-drainage queue (a wedged socket) defeats every attempt, and that
-/// case is caught by the progress-gated miss path instead.
+/// exactly `pong_timeout`, so cycle timing is unchanged. Retries alone
+/// are best-effort — parked producers woken FIFO usually win freed slots
+/// — so a failed attempt also raises `ping_requested`, and the *sender
+/// task* injects the ping directly into the sink after its next completed
+/// frame. Between the two paths, delivery is guaranteed whenever the
+/// connection drains at least one frame during the window; only a
+/// zero-drainage queue (a wedged socket) defeats both, and that case is
+/// caught by the progress-gated miss path instead.
 pub const PING_DELIVERY_ATTEMPTS: u32 = 4;
 
 /// An outbound message, plus its enqueue instant under the `metrics` feature so
@@ -293,8 +300,23 @@ pub struct WebSocket<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> {
     inbound_writer: async_channel::Sender<Vec<u8>>,
     inbound_reader: async_channel::Receiver<Vec<u8>>,
 
-    /// Set by [`Self::listen`] on incoming Pong; read and cleared by the
-    /// keepalive task. Unused (but cheap) when keepalive is disabled.
+    /// Shared liveness signals linking the listener, the sender task, and
+    /// the keepalive task. Unused (but cheap) when keepalive is disabled.
+    signals: KeepAliveSignals,
+
+    _phantom: PhantomData<Async>,
+}
+
+/// Shared atomics linking the listener, the sender task, and the keepalive
+/// task's liveness evaluation.
+///
+/// All fields use `Relaxed` ordering: each is an independent flag or a
+/// monotonic counter compared only against its own prior value — no
+/// cross-atomic ordering invariants exist.
+#[derive(Clone, Debug)]
+struct KeepAliveSignals {
+    /// Set by the listener on incoming Pong; read and cleared by the
+    /// keepalive task.
     pong_received: Arc<AtomicBool>,
 
     /// Incremented by the sender task after each completed *data*
@@ -308,7 +330,32 @@ pub struct WebSocket<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> {
     /// draining* one, and only counts pong misses against the former.
     data_write_progress: Arc<AtomicU64>,
 
-    _phantom: PhantomData<Async>,
+    /// Raised by the keepalive task when its `try_send` found the outbound
+    /// queue full; consumed by the sender task, which then injects a Ping
+    /// directly into the sink after finishing its in-flight frame. This
+    /// gives ping delivery priority over parked producers competing for
+    /// freed queue slots: the party that owns drainage owns delivery, so a
+    /// ping lands whenever at least one frame completes during the window.
+    ping_requested: Arc<AtomicBool>,
+
+    /// Set by the sender task after a successful injected ping write; read
+    /// and cleared by the keepalive task at window end, where it counts as
+    /// a delivered ping.
+    ping_injected: Arc<AtomicBool>,
+}
+
+impl KeepAliveSignals {
+    fn new() -> Self {
+        Self {
+            // Initial values are irrelevant: the keepalive loop clears the
+            // pong and injected flags at each window boundary, and the
+            // progress counter is only compared against its own snapshots.
+            pong_received: Arc::new(AtomicBool::new(false)),
+            data_write_progress: Arc::new(AtomicU64::new(0)),
+            ping_requested: Arc::new(AtomicBool::new(false)),
+            ping_injected: Arc::new(AtomicBool::new(false)),
+        }
+    }
 }
 
 #[future_form(
@@ -400,16 +447,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
         let (outbound_tx, outbound_rx) =
             async_channel::bounded::<Outbound>(OUTBOUND_CHANNEL_CAPACITY);
         let chan_id = rand::random::<u64>();
-        // Initial value is irrelevant — the keepalive loop clears the
-        // flag before each ping.
-        let pong_received = Arc::new(AtomicBool::new(false));
-        let data_write_progress = Arc::new(AtomicU64::new(0));
+        let signals = KeepAliveSignals::new();
 
         let ws_sender = Arc::new(Mutex::new(ws_writer));
 
         let sender_task = {
             let ws_sender = ws_sender.clone();
-            let data_write_progress = data_write_progress.clone();
+            let signals = signals.clone();
             async move {
                 tracing::debug!(peer = %peer_id, "starting WebSocket sender task");
 
@@ -431,11 +475,29 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
                         );
                     }
                     // Data frames feed the keepalive's progress gate; control
-                    // frames must not (see `data_write_progress` field docs).
+                    // frames must not (see `KeepAliveSignals` field docs).
                     let is_data = matches!(item.msg, Message::Binary(_) | Message::Text(_));
                     ws_sender.send(item.msg).await?;
                     if is_data {
-                        data_write_progress.fetch_add(1, Ordering::Relaxed);
+                        signals.data_write_progress.fetch_add(1, Ordering::Relaxed);
+                    }
+
+                    // Keepalive ping injection: the keepalive raises
+                    // `ping_requested` when its try_send found the queue
+                    // full. Injecting here — between frames, directly into
+                    // the sink — bypasses the queue entirely, so parked
+                    // producers can't starve the ping: delivery is
+                    // guaranteed whenever any frame completes during the
+                    // pong window. On a wedged socket this point is never
+                    // reached, and the undelivered ping correctly accrues
+                    // no evidence against the peer.
+                    if signals.ping_requested.swap(false, Ordering::Relaxed) {
+                        let ping = tungstenite::Message::Ping(Vec::new().into());
+                        #[cfg(feature = "metrics")]
+                        subduction_core::metrics::network_frame("websocket", "sent", ping.len());
+                        ws_sender.send(ping).await?;
+                        signals.ping_injected.store(true, Ordering::Relaxed);
+                        tracing::trace!(peer = %peer_id, "keepalive: ping injected by sender task");
                     }
                 }
 
@@ -453,8 +515,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
             ws_sender,
             inbound_writer,
             inbound_reader,
-            pong_received,
-            data_write_progress,
+            signals,
 
             _phantom: PhantomData,
         };
@@ -554,7 +615,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> WebSocket<T, Async> {
                     }
                     Ok(tungstenite::Message::Pong(p)) => {
                         tracing::trace!(size = p.len(), peer = %self.peer_id, "received pong");
-                        self.pong_received.store(true, Ordering::Relaxed);
+                        self.signals.pong_received.store(true, Ordering::Relaxed);
                     }
                     Ok(tungstenite::Message::Frame(f)) => {
                         tracing::warn!(peer = %self.peer_id, frame = ?f, "unexpected frame");
@@ -627,9 +688,23 @@ impl<T: AsyncRead + AsyncWrite + Unpin> WebSocket<T, Sendable> {
     ///
     /// Returns the transport, a sender task, and a keepalive task —
     /// all three should be spawned. The keepalive task closes both
-    /// channels on [`KeepAliveOutcome::Timeout`]; the rest of the
-    /// stack observes the disconnect through the normal channel-closed
-    /// paths.
+    /// channels on [`KeepAliveOutcome::Timeout`] or
+    /// [`KeepAliveOutcome::StaleNoPong`]; the rest of the stack observes
+    /// the disconnect through the normal channel-closed paths.
+    ///
+    /// # Pong asymmetry
+    ///
+    /// Outbound *ping* delivery is guaranteed under drainage (queue
+    /// retries + sender-task injection), but our *pong replies* to the
+    /// peer's pings remain single-shot `try_send`s from the listener — the
+    /// read loop cannot sleep-retry without stalling inbound traffic. If a
+    /// symmetric peer runs this same unanswered-ping ceiling, a sustained
+    /// (> `MAX_UNANSWERED_PINGS` cycles) period of our outbound queue
+    /// being full at every pong-reply instant could cause *them* to reap a
+    /// healthy connection. Currently moot — browsers auto-pong natively
+    /// and cannot send application pings — but relevant for future
+    /// server↔server links; a priority slot for control frames would close
+    /// it.
     ///
     /// `sleeper` provides the in-between waits — typically
     /// [`TokioSleeper`](crate::sleep::TokioSleeper) or
@@ -656,8 +731,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> WebSocket<T, Sendable> {
             peer_id,
             this.outbound_tx.clone(),
             this.inbound_writer.clone(),
-            this.pong_received.clone(),
-            this.data_write_progress.clone(),
+            this.signals.clone(),
             sleeper,
         );
         let task = KeepAliveTask::new(body.boxed());
@@ -747,9 +821,10 @@ impl ReadErrorKind {
 
 /// Keepalive task body.
 ///
-/// Cycle: snapshot write progress → `sleep(ping)` → clear flag → send Ping
-/// (non-blocking) → `sleep(pong)` → check flag *and* progress. Threshold
-/// consecutive misses trigger disconnect.
+/// Cycle: snapshot write progress → `sleep(ping)` → clear flags → deliver
+/// Ping (non-blocking `try_send`, retried across the window; on a full
+/// queue the sender task injects it between frames — see
+/// [`KeepAliveSignals::ping_requested`]) → window elapses → evaluate.
 ///
 /// A cycle counts as alive if either a Pong arrived (end-to-end liveness)
 /// or the sender completed at least one *data* write during the cycle
@@ -758,13 +833,18 @@ impl ReadErrorKind {
 /// queue happened to be full at the ping instant; a genuinely wedged
 /// socket makes no write progress, so it still accumulates misses and is
 /// reaped at the threshold.
+#[allow(
+    clippy::too_many_lines,
+    reason = "a deliberately linear liveness state machine; the extractable \
+              units (window schedule, teardown) already live in PongWindow \
+              and reap()"
+)]
 async fn keepalive_loop<S, Async>(
     config: KeepAlive,
     peer_id: PeerId,
     outbound_tx: async_channel::Sender<Outbound>,
     inbound_writer: async_channel::Sender<Vec<u8>>,
-    pong_received: Arc<AtomicBool>,
-    data_write_progress: Arc<AtomicU64>,
+    signals: KeepAliveSignals,
     sleeper: S,
 ) -> KeepAliveOutcome
 where
@@ -788,32 +868,51 @@ where
     let threshold = config.missed_pong_threshold.get();
 
     loop {
-        let progress_snapshot = data_write_progress.load(Ordering::Relaxed);
+        let progress_snapshot = signals.data_write_progress.load(Ordering::Relaxed);
 
         sleeper.sleep(config.ping_interval).await;
 
-        // Clear before sending so a stale Pong from a previous cycle
-        // can't satisfy this one.
-        pong_received.store(false, Ordering::Relaxed);
+        // Clear before sending so a stale Pong from a previous cycle can't
+        // satisfy this one — but a pong that arrived during the interval is
+        // still evidence the peer's protocol stack answered our *previous*
+        // ping (just late, e.g. a ping delivered on the window's last
+        // attempt leaves less than a full window to reply). Credit it
+        // against the unanswered-ping ceiling so a slow-but-answering peer
+        // isn't misclassified as protocol-dead. The fast-path miss counter
+        // is deliberately not credited: late pongs say nothing about
+        // whether anything moved *this* cycle.
+        if signals.pong_received.swap(false, Ordering::Relaxed) && unanswered_pings > 0 {
+            tracing::debug!(
+                peer = %peer_id,
+                "keepalive: late pong observed; resetting unanswered-ping count"
+            );
+            unanswered_pings = 0;
+        }
+        signals.ping_injected.store(false, Ordering::Relaxed);
 
         // Attempt ping delivery across the pong window: once at the window
         // start, then again at each sub-interval boundary until it lands.
+        // If the queue is full, raise `ping_requested` so the sender task
+        // injects the ping directly into the sink between frames — parked
+        // producers competing for freed slots can't starve it.
         //
         // Non-blocking throughout: a blocking send would park *this* task
         // on the very condition (full outbound queue) it exists to detect.
-        // The retries make delivery reliable on a draining queue — a slot
-        // frees between attempts — so failing every attempt implies zero
-        // drainage, which the miss path below catches via the absent write
-        // progress. Empty ping payload: we don't verify the Pong matches a
-        // specific Ping, so a unique payload would just be overhead.
+        // Failure of every path implies zero drainage for the whole window,
+        // which the miss path below catches via the absent write progress.
+        // Empty ping payload: we don't verify the Pong matches a specific
+        // Ping, so a unique payload would just be overhead.
         let window = PongWindow::plan(config.pong_timeout);
-        let mut ping_sent = false;
+        let mut ping_queued = false;
         for attempt in 0..window.attempts {
-            if !ping_sent {
+            if !ping_queued {
                 let ping = tungstenite::Message::Ping(Vec::new().into());
                 match outbound_tx.try_send(Outbound::new(ping)) {
                     Ok(()) => {
-                        ping_sent = true;
+                        ping_queued = true;
+                        // Cancel any standing injection request from an
+                        // earlier failed attempt; one ping per cycle.
+                        signals.ping_requested.store(false, Ordering::Relaxed);
                         tracing::trace!(peer = %peer_id, attempt, "keepalive: sent ping");
                     }
                     Err(async_channel::TrySendError::Closed(_)) => {
@@ -821,10 +920,11 @@ where
                         return KeepAliveOutcome::ConnectionClosed;
                     }
                     Err(async_channel::TrySendError::Full(_)) => {
+                        signals.ping_requested.store(true, Ordering::Relaxed);
                         tracing::trace!(
                             peer = %peer_id,
                             attempt,
-                            "keepalive: outbound full; will retry ping"
+                            "keepalive: outbound full; requested sender-task injection"
                         );
                     }
                 }
@@ -833,17 +933,24 @@ where
             sleeper.sleep(window.sleep_after(attempt)).await;
         }
 
+        let ping_sent = ping_queued || signals.ping_injected.swap(false, Ordering::Relaxed);
+
         if !ping_sent {
-            // Says something about our congestion, not the peer — must not
-            // count against them. The miss path below judges this cycle by
-            // write progress alone.
+            // Cancel the standing injection request so a stale ping isn't
+            // injected long after this window (the next cycle re-requests).
+            signals.ping_requested.store(false, Ordering::Relaxed);
+            // An undelivered ping says something about our congestion, not
+            // the peer — it must not count against them. The miss path
+            // below judges this cycle by write progress alone.
+            #[cfg(feature = "metrics")]
+            subduction_core::metrics::keepalive_ping_undelivered();
             tracing::debug!(
                 peer = %peer_id,
-                "keepalive: outbound full for the whole window; ping undelivered"
+                "keepalive: zero drainage for the whole window; ping undelivered"
             );
         }
 
-        if pong_received.load(Ordering::Relaxed) {
+        if signals.pong_received.load(Ordering::Relaxed) {
             if consecutive_misses > 0 || unanswered_pings > 0 {
                 tracing::debug!(peer = %peer_id, "keepalive: pong received; counters reset");
             }
@@ -865,7 +972,7 @@ where
                     unanswered = unanswered_pings,
                     "keepalive: consecutive pings unanswered; closing connection"
                 );
-                reap(&outbound_tx, &inbound_writer);
+                reap(&outbound_tx, &inbound_writer, "keepalive timeout (no pong)");
                 return KeepAliveOutcome::StaleNoPong {
                     unanswered: unanswered_pings,
                 };
@@ -877,7 +984,7 @@ where
         // window on a link mid-bulk-transfer). Don't count a fast-path miss
         // against a connection that is making progress; a wedged socket
         // completes nothing and falls through to the miss path.
-        if data_write_progress.load(Ordering::Relaxed) != progress_snapshot {
+        if signals.data_write_progress.load(Ordering::Relaxed) != progress_snapshot {
             if consecutive_misses > 0 {
                 tracing::debug!(
                     peer = %peer_id,
@@ -904,7 +1011,7 @@ where
                 misses = consecutive_misses,
                 "keepalive: threshold reached; closing connection"
             );
-            reap(&outbound_tx, &inbound_writer);
+            reap(&outbound_tx, &inbound_writer, "keepalive timeout");
             return KeepAliveOutcome::Timeout {
                 missed: consecutive_misses,
             };
@@ -938,7 +1045,10 @@ impl PongWindow {
             (PING_DELIVERY_ATTEMPTS, Duration::from_millis(sub_ms))
         };
         // The final sub-sleep absorbs division rounding so the window's
-        // total is exactly `pong_timeout`.
+        // total is exactly `pong_timeout`. The fallback is believed
+        // unreachable (3·⌊x/4⌋ ≤ x) and is deliberately non-panicking: this
+        // code runs inside the keepalive task, whose unconditional survival
+        // is the whole point — a slightly-off window beats a dead reaper.
         let last_sleep = pong_timeout
             .checked_sub(sub_sleep * (attempts - 1))
             .unwrap_or(sub_sleep);
@@ -967,13 +1077,14 @@ impl PongWindow {
 fn reap(
     outbound_tx: &async_channel::Sender<Outbound>,
     inbound_writer: &async_channel::Sender<Vec<u8>>,
+    reason: &'static str,
 ) {
     #[cfg(feature = "metrics")]
     subduction_core::metrics::keepalive_close();
 
     let close_frame = tungstenite::Message::Close(Some(CloseFrame {
         code: CloseCode::Away,
-        reason: "keepalive timeout".into(),
+        reason: reason.into(),
     }));
     drop(outbound_tx.try_send(Outbound::new(close_frame)));
 
@@ -991,8 +1102,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin, Async: FutureForm> Clone for WebSocket<T
             ws_sender: self.ws_sender.clone(),
             inbound_writer: self.inbound_writer.clone(),
             inbound_reader: self.inbound_reader.clone(),
-            pong_received: self.pong_received.clone(),
-            data_write_progress: self.data_write_progress.clone(),
+            signals: self.signals.clone(),
             _phantom: PhantomData,
         }
     }
@@ -1120,7 +1230,6 @@ mod tests {
     async fn keepalive_loop_times_out_on_silent_peer() -> TestResult {
         let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
         let (inbound_writer, inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
 
         let outbound_drain = tokio::spawn(async move {
             let mut msgs = Vec::new();
@@ -1140,8 +1249,7 @@ mod tests {
             PeerId::new([42u8; 32]),
             outbound_tx,
             inbound_writer.clone(),
-            pong_received,
-            Arc::new(AtomicU64::new(0)),
+            KeepAliveSignals::new(),
             TokioSleeper,
         )
         .await;
@@ -1182,10 +1290,10 @@ mod tests {
     async fn keepalive_loop_does_not_time_out_with_responsive_peer() -> TestResult {
         let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
+        let signals = KeepAliveSignals::new();
 
         let responsive_peer = {
-            let pong_received = pong_received.clone();
+            let pong_received = signals.pong_received.clone();
             tokio::spawn(async move {
                 while let Ok(item) = outbound_rx.recv().await {
                     if matches!(item.msg, tungstenite::Message::Ping(_)) {
@@ -1209,8 +1317,7 @@ mod tests {
                 PeerId::new([42u8; 32]),
                 outbound_tx.clone(),
                 inbound_writer.clone(),
-                pong_received,
-                Arc::new(AtomicU64::new(0)),
+                signals,
                 TokioSleeper,
             ),
         )
@@ -1233,10 +1340,10 @@ mod tests {
     async fn keepalive_loop_resets_misses_after_recovery() -> TestResult {
         let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
+        let signals = KeepAliveSignals::new();
 
         let pattern_runner = {
-            let pong_received = pong_received.clone();
+            let pong_received = signals.pong_received.clone();
             tokio::spawn(async move {
                 let mut seen = 0u32;
                 while let Ok(item) = outbound_rx.recv().await {
@@ -1267,8 +1374,7 @@ mod tests {
                 PeerId::new([42u8; 32]),
                 outbound_tx.clone(),
                 inbound_writer.clone(),
-                pong_received,
-                Arc::new(AtomicU64::new(0)),
+                signals,
                 TokioSleeper,
             ),
         )
@@ -1293,7 +1399,6 @@ mod tests {
     async fn keepalive_loop_exits_when_outbound_closes_externally() -> TestResult {
         let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
 
         // Externally close the channel after a short delay — well before
         // the silent-peer Timeout window (1000+500 = 1500ms virtual).
@@ -1316,8 +1421,7 @@ mod tests {
             PeerId::new([42u8; 32]),
             outbound_tx,
             inbound_writer.clone(),
-            pong_received,
-            Arc::new(AtomicU64::new(0)),
+            KeepAliveSignals::new(),
             TokioSleeper,
         )
         .await;
@@ -1391,7 +1495,6 @@ mod tests {
             .await?;
 
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
 
         let config = KeepAlive {
             ping_interval: Duration::from_millis(40),
@@ -1409,8 +1512,7 @@ mod tests {
                 PeerId::new([42u8; 32]),
                 outbound_tx.clone(),
                 inbound_writer.clone(),
-                pong_received,
-                Arc::new(AtomicU64::new(0)),
+                KeepAliveSignals::new(),
                 TokioSleeper,
             ),
         )
@@ -1453,13 +1555,14 @@ mod tests {
             .await?;
 
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
-        let progress = Arc::new(AtomicU64::new(0));
+        let signals = KeepAliveSignals::new();
 
         // Simulate a sender task that keeps completing data writes even
         // though the queue stays full (producers instantly refill it).
+        // Note: no injection happens (there is no real sender task), so
+        // pings are never delivered in this test.
         let writer = {
-            let progress = progress.clone();
+            let progress = signals.data_write_progress.clone();
             tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(Duration::from_millis(15)).await;
@@ -1475,22 +1578,20 @@ mod tests {
         };
 
         // Without the gate this reaps at 2 × (40+20) = 120ms of virtual
-        // time; observe well past that. The MAX_UNANSWERED_PINGS ceiling
-        // never engages here: the queue has zero drainage, so no ping is
-        // ever delivered, and undelivered pings say something about our
-        // congestion — not the peer — so they accrue no evidence. (In
-        // reality progress implies drainage implies a retry would land;
-        // this test pokes the progress counter directly to isolate the
-        // gate.)
+        // time. The MAX_UNANSWERED_PINGS ceiling never engages here: the
+        // queue has zero drainage, so no ping is ever delivered, and
+        // undelivered pings say something about our congestion — not the
+        // peer — so they accrue no evidence. Observe past the point where
+        // a mutant that counts undelivered pings would reap (8 × 60 =
+        // 480ms) to make that claim load-bearing.
         let outcome_or_timeout = tokio::time::timeout(
-            Duration::from_millis(400),
+            Duration::from_millis(650),
             keepalive_loop(
                 config,
                 PeerId::new([42u8; 32]),
                 outbound_tx.clone(),
                 inbound_writer.clone(),
-                pong_received,
-                progress,
+                signals.clone(),
                 TokioSleeper,
             ),
         )
@@ -1520,14 +1621,13 @@ mod tests {
     async fn keepalive_reaps_progressing_peer_that_never_pongs() -> TestResult {
         let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
-        let progress = Arc::new(AtomicU64::new(0));
+        let signals = KeepAliveSignals::new();
 
         // Drain pings (so try_send succeeds) but never pong; keep write
         // progress advancing every cycle.
         let drain = tokio::spawn(async move { while outbound_rx.recv().await.is_ok() {} });
         let writer = {
-            let progress = progress.clone();
+            let progress = signals.data_write_progress.clone();
             tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(Duration::from_millis(15)).await;
@@ -1550,8 +1650,7 @@ mod tests {
                 PeerId::new([42u8; 32]),
                 outbound_tx.clone(),
                 inbound_writer.clone(),
-                pong_received,
-                progress,
+                signals.clone(),
                 TokioSleeper,
             ),
         )
@@ -1583,12 +1682,12 @@ mod tests {
 
     /// A queue that is full at the ping instant but *draining* must not
     /// cost the peer liveness evidence: the in-window retry delivers the
-    /// ping once a slot frees, the (healthy) peer pongs, and both counters
-    /// reset. Without the retry, a busy peer whose inbound queue from us
-    /// hovers at capacity would never be pinged at all and could be
-    /// falsely reaped by the unanswered-ping ceiling.
+    /// ping once a slot frees, the (healthy) peer pongs, and the cycle
+    /// counts as answered. Without the retry, a busy peer whose inbound
+    /// queue from us hovers at capacity would never be pinged at all and
+    /// could be falsely reaped by the unanswered-ping ceiling.
     #[tokio::test(start_paused = true)]
-    async fn ping_retry_delivers_on_draining_queue_and_pong_resets_counters() -> TestResult {
+    async fn ping_retry_delivers_on_draining_queue() -> TestResult {
         // Capacity 1, pre-filled: the first try_send (window start, t=40ms)
         // fails. Config: 40ms interval, 20ms window → retries at t=45/50/55.
         let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(1);
@@ -1599,15 +1698,14 @@ mod tests {
             .await?;
 
         let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
-        let pong_received = Arc::new(AtomicBool::new(false));
-        let progress = Arc::new(AtomicU64::new(0));
+        let signals = KeepAliveSignals::new();
 
         // Scripted peer: at t=47ms drain the Binary (freeing a slot between
         // the t=45 and t=50 retries), then receive the retried ping at t=50
         // and answer it. Records that a Ping was actually observed.
         let saw_ping = Arc::new(AtomicBool::new(false));
         let peer = {
-            let pong_received = pong_received.clone();
+            let pong_received = signals.pong_received.clone();
             let saw_ping = saw_ping.clone();
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_millis(47)).await;
@@ -1651,8 +1749,7 @@ mod tests {
                 PeerId::new([42u8; 32]),
                 outbound_tx.clone(),
                 inbound_writer.clone(),
-                pong_received,
-                progress,
+                signals.clone(),
                 TokioSleeper,
             ),
         )
@@ -1675,6 +1772,195 @@ mod tests {
         Ok(())
     }
 
+    /// A pong resets the unanswered-ping counter: a peer that misses some
+    /// pongs but then answers must never accumulate to the ceiling. The
+    /// progress writer suppresses the fast (miss) path so this pins the
+    /// ceiling counter's reset specifically — a non-resetting counter
+    /// would reap at the 8th cumulative unanswered ping (~540ms here).
+    #[tokio::test(start_paused = true)]
+    async fn pong_resets_unanswered_ping_counter() -> TestResult {
+        let (outbound_tx, outbound_rx) = async_channel::bounded::<Outbound>(16);
+        let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
+        let signals = KeepAliveSignals::new();
+
+        // Peer: ignores the first two pings, answers every ping after.
+        let peer = {
+            let pong_received = signals.pong_received.clone();
+            tokio::spawn(async move {
+                let mut seen = 0u32;
+                while let Ok(item) = outbound_rx.recv().await {
+                    if matches!(item.msg, tungstenite::Message::Ping(_)) {
+                        seen += 1;
+                        if seen > 2 {
+                            pong_received.store(true, Ordering::Relaxed);
+                        }
+                    }
+                }
+                seen
+            })
+        };
+
+        // Progress advances every cycle so the fast path (threshold 2)
+        // never fires; only the unanswered-ping ceiling is in play.
+        let writer = {
+            let progress = signals.data_write_progress.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(15)).await;
+                    progress.fetch_add(1, Ordering::Relaxed);
+                }
+            })
+        };
+
+        let config = KeepAlive {
+            ping_interval: Duration::from_millis(40),
+            pong_timeout: Duration::from_millis(20),
+            missed_pong_threshold: nz(2),
+        };
+
+        // A broken (non-resetting) unanswered counter reaps at the 8th
+        // cumulative unanswered ping: cycles 1-2 unanswered, so cycle 14
+        // (~840ms). Observe past that.
+        let outcome_or_timeout = tokio::time::timeout(
+            Duration::from_millis(1000),
+            keepalive_loop(
+                config,
+                PeerId::new([42u8; 32]),
+                outbound_tx.clone(),
+                inbound_writer.clone(),
+                signals.clone(),
+                TokioSleeper,
+            ),
+        )
+        .await;
+
+        writer.abort();
+        if let Ok(unexpected) = outcome_or_timeout {
+            return Err(format!(
+                "peer that resumed ponging must not be reaped, got {unexpected:?}"
+            )
+            .into());
+        }
+        assert!(!inbound_writer.is_closed());
+
+        outbound_tx.close();
+        let seen = peer.await?;
+        assert!(seen > 8, "expected many ping cycles, saw {seen}");
+        Ok(())
+    }
+
+    /// An injected ping (delivered by the sender task when the queue was
+    /// full) must count as delivered: with no pong and ongoing progress,
+    /// injected-but-unanswered pings accrue toward the ceiling and reap at
+    /// exactly `MAX_UNANSWERED_PINGS` cycles. A mutant that ignores
+    /// `ping_injected` would classify these cycles as undelivered and let
+    /// the peer live forever.
+    #[tokio::test(start_paused = true)]
+    async fn injected_ping_counts_as_delivered() -> TestResult {
+        // Capacity 1, pre-filled, never drained: every try_send fails, so
+        // delivery can only be observed via the injected flag.
+        let (outbound_tx, _outbound_rx) = async_channel::bounded::<Outbound>(1);
+        outbound_tx
+            .send(Outbound::new(tungstenite::Message::Binary(
+                vec![0xEE].into(),
+            )))
+            .await?;
+
+        let (inbound_writer, _inbound_reader) = async_channel::bounded::<Vec<u8>>(16);
+        let signals = KeepAliveSignals::new();
+
+        // Simulated sender task: keeps progress moving and "injects" the
+        // requested ping each cycle (sets ping_injected mid-window), but no
+        // pong ever arrives.
+        let simulator = {
+            let signals = signals.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(15)).await;
+                    signals.data_write_progress.fetch_add(1, Ordering::Relaxed);
+                    if signals.ping_requested.swap(false, Ordering::Relaxed) {
+                        signals.ping_injected.store(true, Ordering::Relaxed);
+                    }
+                }
+            })
+        };
+
+        let config = KeepAlive {
+            ping_interval: Duration::from_millis(40),
+            pong_timeout: Duration::from_millis(20),
+            missed_pong_threshold: nz(2),
+        };
+
+        let start = tokio::time::Instant::now();
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(10),
+            keepalive_loop(
+                config,
+                PeerId::new([42u8; 32]),
+                outbound_tx.clone(),
+                inbound_writer.clone(),
+                signals.clone(),
+                TokioSleeper,
+            ),
+        )
+        .await
+        .map_err(|_| "injected-but-unanswered pings must reap at the ceiling")?;
+        let elapsed = start.elapsed();
+        simulator.abort();
+
+        let KeepAliveOutcome::StaleNoPong { unanswered } = outcome else {
+            return Err(format!("expected StaleNoPong outcome, got {outcome:?}").into());
+        };
+        assert_eq!(unanswered, MAX_UNANSWERED_PINGS);
+        assert_eq!(
+            elapsed,
+            Duration::from_millis(u64::from(MAX_UNANSWERED_PINGS) * 60),
+            "injected pings must count from the first cycle"
+        );
+        Ok(())
+    }
+
+    /// End-to-end injection through the real sender task: when the
+    /// keepalive raises `ping_requested`, the sender injects a Ping
+    /// directly into the sink after its next completed frame, sets
+    /// `ping_injected`, and consumes the request. Data progress counts
+    /// only the data frames — the injected ping is a control frame.
+    #[tokio::test]
+    async fn sender_task_injects_ping_on_request() -> TestResult {
+        let ws = create_mock_websocket_stream().await;
+        let (websocket, sender_task): (WebSocket<_, Sendable>, _) =
+            WebSocket::new(ws, PeerId::new([7u8; 32]));
+
+        let signals = websocket.signals.clone();
+        let tx = websocket.outbound_tx.clone();
+
+        signals.ping_requested.store(true, Ordering::Relaxed);
+        tx.send(Outbound::new(tungstenite::Message::Binary(
+            vec![1, 2, 3].into(),
+        )))
+        .await?;
+        tx.send(Outbound::new(tungstenite::Message::Binary(vec![4].into())))
+            .await?;
+        tx.close();
+
+        tokio::spawn(sender_task).await??;
+
+        assert!(
+            signals.ping_injected.load(Ordering::Relaxed),
+            "sender must inject the requested ping"
+        );
+        assert!(
+            !signals.ping_requested.load(Ordering::Relaxed),
+            "the injection request must be consumed"
+        );
+        assert_eq!(
+            signals.data_write_progress.load(Ordering::Relaxed),
+            2,
+            "the injected ping is a control frame and must not count as progress"
+        );
+        Ok(())
+    }
+
     /// The progress gate must only see *data* writes: the sender task
     /// counts Binary/Text frames and excludes control frames. If the
     /// keepalive's own Ping writes moved the counter, an idle dead peer
@@ -1685,7 +1971,7 @@ mod tests {
         let (websocket, sender_task): (WebSocket<_, Sendable>, _) =
             WebSocket::new(ws, PeerId::new([7u8; 32]));
 
-        let progress = websocket.data_write_progress.clone();
+        let progress = websocket.signals.data_write_progress.clone();
         let tx = websocket.outbound_tx.clone();
 
         let sender = tokio::spawn(sender_task);
@@ -1743,7 +2029,6 @@ mod tests {
                 rt.block_on(async move {
                     let (tx, rx) = async_channel::bounded::<Outbound>(64);
                     let (inbound_tx, _) = async_channel::bounded::<Vec<u8>>(16);
-                    let pong_received = Arc::new(AtomicBool::new(false));
 
                     let drain = tokio::spawn(async move { while rx.recv().await.is_ok() {} });
 
@@ -1759,8 +2044,7 @@ mod tests {
                         PeerId::new([0u8; 32]),
                         tx,
                         inbound_tx,
-                        pong_received,
-                        Arc::new(AtomicU64::new(0)),
+                        KeepAliveSignals::new(),
                         TokioSleeper,
                     )
                     .await;


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->

Defensive code to unblock keepalive pings from the main queue so that we reap stuck channels more aggressively. This required rethinking how we measure peer liveness by resetting the timer when we successfully send a WS frame.

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [x] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
