### PR TITLE
Use version of Automerge on Crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,15 +283,16 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "automerge"
-version = "0.10.0"
-source = "git+https://github.com/automerge/automerge?branch=fragments#72a8d0ba02af32f610cb0128e254a5f521287b74"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b59cbd9e7685a1ac6bf6046ddcd8acb550fa5bf03c09f6c1056728a742b40d"
 dependencies = [
  "cfg-if",
  "flate2",
  "getrandom 0.4.3",
  "hex",
  "hexane",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "js-sys",
  "leb128",
  "rand 0.10.2",
@@ -1737,6 +1738,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2121,8 +2123,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexane"
-version = "1.0.0-alpha.1"
-source = "git+https://github.com/automerge/automerge?branch=fragments#72a8d0ba02af32f610cb0128e254a5f521287b74"
+version = "1.0.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81df830f11babb0eee9a082e09135ef0a7d8791f3fe9b279bb9485bf7eaf23e0"
 dependencies = [
  "leb128",
  "thiserror 2.0.20",
@@ -2780,6 +2783,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -7046,6 +7058,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
   "subduction_redb_storage",
   "subduction_wasm",
   "subduction_wasm_bootstrap",
-  "subduction_websocket"
+  "subduction_websocket",
 ]
 
 [workspace.package]
@@ -26,7 +26,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/inkandswitch/subduction"
 authors = [
   "Alex Good <alex@patternist.xyz>",
-  "Brooklyn Zelenka <hello@brooklynzelenka.com>"
+  "Brooklyn Zelenka <hello@brooklynzelenka.com>",
 ]
 
 [workspace.dependencies]
@@ -56,7 +56,7 @@ arbitrary = "1.4"
 async-channel = { version = "2.5", default-features = false }
 async-lock = { version = "3.4", default-features = false }
 async-tungstenite = "0.31.0"
-automerge = { git = "https://github.com/automerge/automerge", branch = "fragments" }
+automerge = "0.11.0"
 axum = "0.8"
 base58 = "0.2.0"
 base64 = { version = "0.22", default-features = false, features = ["alloc"] }
@@ -70,15 +70,24 @@ color-eyre = "0.6"
 console-subscriber = "0.5.0"
 console_error_panic_hook = { version = "0.1.7" }
 criterion = { version = "0.5", default-features = false }
-criterion_pprof = { package = "pprof", version = "0.15", default-features = false, features = ["criterion", "flamegraph"] }
+criterion_pprof = { package = "pprof", version = "0.15", default-features = false, features = [
+  "criterion",
+  "flamegraph",
+] }
 dhat = "0.3"
 ed25519-dalek = { version = "2.1", default-features = false }
 eyre = "0.6"
 from_js_ref = "0.2.0" # no_std by default
 future_form = "0.3.0"
-futures = { version = "0.3.31", default-features = false, features = ["alloc", "async-await"] }
+futures = { version = "0.3.31", default-features = false, features = [
+  "alloc",
+  "async-await",
+] }
 futures-timer = "3.0" # NOTE depends on `std`
-futures-util = { version = "0.3.31", default-features = false, features = ["alloc", "async-await"] }
+futures-util = { version = "0.3.31", default-features = false, features = [
+  "alloc",
+  "async-await",
+] }
 getrandom = "0.2" # matches ed25519-dalek transitive dep
 hex = "0.4.3"
 http-body-util = "0.1.4"
@@ -100,13 +109,20 @@ rayon = "1.11"
 redb = "4.1"
 reqwest = { version = "0.13.4", default-features = false }
 serde = { version = "1.0", default-features = false }
-serde_bytes = { version = "0.11.10", default-features = false, features = ["alloc"] }
+serde_bytes = { version = "0.11.10", default-features = false, features = [
+  "alloc",
+] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 siphasher = { version = "1.0", default-features = false }
 tempfile = "3.27"
 testresult = "0.4.1"
 thiserror = { version = "2.0", default-features = false }
-tokio = { version = "1.46", features = ["macros", "net", "rt-multi-thread", "sync"] }
+tokio = { version = "1.46", features = [
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "sync",
+] }
 tokio-test = "0.4.4"
 tokio-util = { version = "0.7.16", features = ["rt"] }
 tracing = { version = "0.1.41", default-features = false }
@@ -151,7 +167,7 @@ wildcard_enum_match_arm = "warn"
 
 all = { level = "deny", priority = -1 }
 cargo = { level = "deny", priority = -1 }
-multiple_crate_versions = "allow" # various transitive deps
+multiple_crate_versions = "allow"            # various transitive deps
 pedantic = { level = "deny", priority = -1 }
 
 [profile.release]
@@ -203,10 +219,10 @@ opt-level = 2
 # Override only the debug-info knobs needed for accurate flamegraphs.
 [profile.bench]
 codegen-units = 1
-debug = true        # Full debug symbols for flamegraphs/profiling
-lto = "thin"        # Faster link than "fat", close enough for profiling
-opt-level = 3       # Speed, not size
-strip = false       # Keep symbols for profiling tools
+debug = true      # Full debug symbols for flamegraphs/profiling
+lto = "thin"      # Faster link than "fat", close enough for profiling
+opt-level = 3     # Speed, not size
+strip = false     # Keep symbols for profiling tools
 
 # Debug-oriented Wasm profile. Preserves full DWARF so Chrome DevTools
 # (with the C/C++ DevTools Support extension) can step through.

--- a/automerge_subduction_wasm/Cargo.toml
+++ b/automerge_subduction_wasm/Cargo.toml
@@ -33,9 +33,13 @@ wasm-bindgen = { workspace = true }
 wasm_refgen = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
-# Pulled in by automerge 0.9 (fragments branch); needs explicit wasm_js opt-in.
-getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+getrandom_03 = { package = "getrandom", version = "0.3", features = [
+  "wasm_js",
+] }
+# Pulled in by automerge; needs explicit wasm_js opt-in.
+getrandom_04 = { package = "getrandom", version = "0.4", features = [
+  "wasm_js",
+] }
 
 [features]
 default = ["idb", "std", "wasm-tracing"]
@@ -53,7 +57,16 @@ std = [
 wasm-tracing = ["subduction_wasm_bootstrap/wasm-tracing"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Oz", "--enable-bulk-memory", "--enable-multivalue", "--enable-mutable-globals", "--enable-nontrapping-float-to-int", "--enable-reference-types", "--enable-sign-ext", "--enable-simd"]
+wasm-opt = [
+  "-Oz",
+  "--enable-bulk-memory",
+  "--enable-multivalue",
+  "--enable-mutable-globals",
+  "--enable-nontrapping-float-to-int",
+  "--enable-reference-types",
+  "--enable-sign-ext",
+  "--enable-simd",
+]
 
 [lints]
 workspace = true

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1785307242,
-        "narHash": "sha256-of9OQuw0E5/6yd7ab4ue7uVYoXT8+pTfKhCfRApzuco=",
-        "rev": "255d738cbacb7f30ac8629e091538c4382841ac5",
+        "lastModified": 1786548149,
+        "narHash": "sha256-NkfzG9ErGKyknpftAprpUFzKsr3gzgB26y+xGwpmlWY=",
+        "rev": "5df1f9ae934fe1bffbd3867a1ae2870ab22302ed",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1043549.255d738cbacb/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1052927.5df1f9ae934f/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -85,11 +85,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1785133411,
-        "narHash": "sha256-7S1XAczkWGQbntnS7lEDlvgyq4jYfTWBLv25CkTv7W0=",
-        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
+        "lastModified": 1786535285,
+        "narHash": "sha256-wu478baUvGLzcIMCGz8eKqSJa2uzjoUGpYSh/LTXtxo=",
+        "rev": "9f78f44a87948854445dae0b6bf82b2e87e4efb5",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.6282.2f5a153c270b/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.7526.9f78f44a8794/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -114,11 +114,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785302874,
-        "narHash": "sha256-fpKEww3TJoo1ANHO2q918ei+ayOrp0YEQAO1DuBLOB4=",
+        "lastModified": 1786507911,
+        "narHash": "sha256-w5aZRLbiu7H6TqsYXVMdRKg0S4DRaJpxyqxx86AwxVk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b99d48435bc3e34309d2c7ae6f7d45e77a156c38",
+        "rev": "39db48099ad16834af7e27485a4babf9c28b3897",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -202,7 +202,6 @@
             cargoLock = {
               lockFile = ./Cargo.lock;
               outputHashes = {
-                "automerge-0.10.0" = "sha256-WQWwl+6jYkBvNYk2oUGsnxUT87EPMhFiy1DIO/JRQDc=";
                 "wasm-tracing-3.0.0-alpha.0" = "sha256-b5XSxRM601ID/uT2aLMb0WrP3lSGALrh0bPB+7Va/6s=";
               };
             };


### PR DESCRIPTION
<!--
Thanks for the PR! A few notes to keep things smooth:

- Title: use imperative mood, no trailing period
  (e.g. "Add keepalive sleeper trait" — not "Added keepalive...")
- One logical change per PR. Big refactors are easier to review when
  split into a series.
- For protocol or API changes, link the relevant design doc in
  `design/` or call out where the discussion happened.
- Delete sections that don't apply.
-->

## Summary

<!--
What does this PR change, and why? Lead with the motivation — the
"what" is visible in the diff; the "why" is what reviewers need.
1–3 bullet points is ideal.
-->
Just what it says on the tin: use the Automerge from Crates so that WE can also get back on Crates! (We were waiting for the fragments API to land)

## Related issues

<!--
Link issues this addresses. Use `Fixes #123` to auto-close on merge,
or `Refs #123` for related-but-not-closing.
-->

-

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (API, wire format, or behavior)
- [ ] Performance improvement
- [ ] Refactor / cleanup (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [x] Dependency bump

## How was this tested?

<!--
Concrete steps: which tests / benches / manual runs. If you added
new test cases, mention them; if behavior is hard to test, explain
why.
-->

-

## Breaking changes

<!--
If you checked "Breaking change" above, describe the break and the
migration path here. Include before/after snippets where useful.
Delete this section otherwise.
-->

## Checklist

- [x] **I have personally reviewed every line of this diff.** I have read the code, understand what each change does, and am willing to defend it on its merits. AI-assisted authoring is welcome; unreviewed AI output is not.
- [x] `cargo build --workspace --all-features` succeeds
- [x] `cargo test --workspace` succeeds (or relevant subset, with rationale)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo +nightly fmt --all -- --check` is clean
- [x] Public API changes have doc comments
- [x] User-visible changes are reflected in the relevant `README.md` or `design/` doc
- [x] Required version updates for this release-blocking change have been applied
