### PR TITLE
sedimentree: fix bug in heads computation

### DIFF
--- a/sedimentree_core/src/sedimentree.rs
+++ b/sedimentree_core/src/sedimentree.rs
@@ -946,29 +946,40 @@ impl Sedimentree {
     /// [`heads`](Self::heads) when minimality isn't guaranteed.
     #[must_use]
     pub fn heads_assuming_minimal(&self) -> Vec<CommitId> {
-        let dag = commit_dag::CommitDag::from_commits(self.commits.values());
+        // The heads of the sedimentree are
+        // - Loose commit IDs which are not referenced by another commit or fragment
+        // - Fragment head IDs which are not referenced by another commit or fragment
+        //
+        // "referenced by another commit or fragment" means that the ID is
+        // either in the parent set of a commit, in the boundary set of a
+        // fragment, or in the checkpoint set of a fragment.
+        //
+        // We compute this set by first collecting all referenced IDs, then iterating
+        // over the fragment heads and loose commits to find those which are not in the
+        // referenced set.
 
-        // Precompute boundary union once: O(F) instead of an O(F²)
-        // `any()` scan inside the fragment loop.
-        let all_fragment_boundaries: Set<CommitId> = self
-            .fragments
+        let mut referenced_ids: Set<CommitId> = self
+            .commits
             .values()
-            .flat_map(|f| f.boundary().iter().copied())
+            .flat_map(|commit| commit.parents().iter().copied())
             .collect();
-
-        let mut heads = Vec::<CommitId>::new();
+        let mut referenced_checkpoints: Set<Checkpoint> = Set::new();
         for fragment in self.fragments.values() {
-            if !all_fragment_boundaries.contains(&fragment.head())
-                && fragment
-                    .boundary()
-                    .iter()
-                    .all(|end| !dag.contains_commit(end))
-            {
-                heads.extend(fragment.boundary().iter().copied());
-            }
+            referenced_ids.extend(fragment.boundary().iter().copied());
+            referenced_checkpoints.extend(fragment.checkpoints().iter().copied());
         }
-        heads.extend(dag.heads());
-        heads
+
+        let heads: Set<CommitId> = self
+            .fragments
+            .keys()
+            .copied()
+            .chain(self.commits.keys().copied())
+            .filter(|id| {
+                !referenced_ids.contains(id)
+                    && !referenced_checkpoints.contains(&Checkpoint::new(*id))
+            })
+            .collect();
+        heads.into_iter().collect()
     }
 
     /// Consume this [`Sedimentree`] and return an iterator over all its items.

--- a/sedimentree_core/src/sedimentree/commit_dag.rs
+++ b/sedimentree_core/src/sedimentree/commit_dag.rs
@@ -268,10 +268,12 @@ impl CommitDag {
         ReverseTopo::new(self, start)
     }
 
+    #[cfg(test)]
     pub(crate) fn contains_commit(&self, id: &CommitId) -> bool {
         self.node_map.contains_key(id)
     }
 
+    #[cfg(test)]
     pub(crate) fn heads(&self) -> impl Iterator<Item = CommitId> + '_ {
         self.nodes.iter().filter_map(|node| {
             if node.children.is_none() {

--- a/sedimentree_core/tests/fragment_heads.rs
+++ b/sedimentree_core/tests/fragment_heads.rs
@@ -1,0 +1,125 @@
+//! Regression tests for <https://github.com/inkandswitch/subduction/issues/286>.
+
+use std::collections::BTreeSet;
+
+use sedimentree_core::{
+    blob::{Blob, BlobMeta},
+    depth::CountLeadingZeroBytes,
+    fragment::Fragment,
+    id::SedimentreeId,
+    loose_commit::{LooseCommit, id::CommitId},
+    sedimentree::Sedimentree,
+};
+
+const SEDIMENTREE_ID: SedimentreeId = SedimentreeId::new([42; 32]);
+
+const fn fragment_id(seed: u8) -> CommitId {
+    let mut bytes = [0; 32];
+    bytes[1] = seed;
+    CommitId::new(bytes)
+}
+
+const fn deep_fragment_id(seed: u8) -> CommitId {
+    let mut bytes = [0; 32];
+    bytes[2] = seed;
+    CommitId::new(bytes)
+}
+
+const fn loose_id(seed: u8) -> CommitId {
+    CommitId::new([seed; 32])
+}
+
+fn blob_meta() -> BlobMeta {
+    BlobMeta::new(&Blob::new(Vec::new()))
+}
+
+fn fragment(head: CommitId, boundary: &[CommitId]) -> Fragment {
+    Fragment::new(
+        SEDIMENTREE_ID,
+        head,
+        boundary.iter().copied().collect(),
+        &[],
+        blob_meta(),
+    )
+}
+
+#[test]
+fn fragment_contributes_its_head_instead_of_its_boundary() {
+    let head = fragment_id(1);
+    let boundary = fragment_id(2);
+    let tree = Sedimentree::new(vec![fragment(head, &[boundary])], vec![]);
+
+    assert_eq!(tree.heads(&CountLeadingZeroBytes), vec![head]);
+}
+
+#[test]
+fn only_the_tip_of_chained_fragments_and_loose_commits_is_a_head() {
+    let first_fragment_head = fragment_id(1);
+    let second_fragment_head = fragment_id(2);
+    let loose_tip = loose_id(3);
+
+    let tree = Sedimentree::new(
+        vec![
+            fragment(first_fragment_head, &[]),
+            fragment(second_fragment_head, &[first_fragment_head]),
+        ],
+        vec![LooseCommit::new(
+            SEDIMENTREE_ID,
+            loose_tip,
+            BTreeSet::from([second_fragment_head]),
+            blob_meta(),
+        )],
+    );
+
+    assert_eq!(tree.heads(&CountLeadingZeroBytes), vec![loose_tip]);
+}
+
+#[test]
+fn disconnected_components_each_contribute_a_head() {
+    let fragment_head = fragment_id(1);
+    let loose_parent = loose_id(2);
+    let loose_tip = loose_id(3);
+
+    let tree = Sedimentree::new(
+        vec![fragment(fragment_head, &[])],
+        vec![
+            LooseCommit::new(SEDIMENTREE_ID, loose_parent, BTreeSet::new(), blob_meta()),
+            LooseCommit::new(
+                SEDIMENTREE_ID,
+                loose_tip,
+                BTreeSet::from([loose_parent]),
+                blob_meta(),
+            ),
+        ],
+    );
+
+    let heads: BTreeSet<_> = tree.heads(&CountLeadingZeroBytes).into_iter().collect();
+    assert_eq!(heads, BTreeSet::from([fragment_head, loose_tip]));
+}
+
+#[test]
+fn fragment_checkpoint_marks_a_stored_head_as_an_ancestor() {
+    let checkpoint = fragment_id(1);
+    let unrelated_boundary = fragment_id(2);
+    let covering_head = deep_fragment_id(3);
+    let covering_fragment = Fragment::new(
+        SEDIMENTREE_ID,
+        covering_head,
+        BTreeSet::new(),
+        &[checkpoint],
+        blob_meta(),
+    );
+    let tree = Sedimentree::new(
+        vec![
+            covering_fragment,
+            fragment(checkpoint, &[unrelated_boundary]),
+        ],
+        vec![],
+    );
+
+    // The unrelated boundary keeps both fragments in the minimal tree, so
+    // head computation itself must recognize the checkpoint as an ancestor.
+    let minimal = tree.minimize(&CountLeadingZeroBytes);
+    assert_eq!(minimal.fragments().count(), 2);
+    assert_eq!(minimal.heads_assuming_minimal(), vec![covering_head]);
+}


### PR DESCRIPTION
Problem: when computing the heads of a sedimentree we incorrectly include the boundaries of a fragment in the head set rather than the heads. I _think_ this is probably due to confusion around the term "boundary" and "head".  The logic looked like this:

```rust
  pub fn heads_assuming_minimal(&self) -> Vec<CommitId> {
      let dag = commit_dag::CommitDag::from_commits(self.commits.values());

      // Precompute boundary union once: O(F) instead of an O(F²)
      // `any()` scan inside the fragment loop.
      let all_fragment_boundaries: Set<CommitId> = self
          .fragments
          .values()
          .flat_map(|f| f.boundary().iter().copied())
          .collect();

      let mut heads = Vec::<CommitId>::new();
      for fragment in self.fragments.values() {
          if !all_fragment_boundaries.contains(&fragment.head())
              && fragment
                  .boundary()
                  .iter()
                  .all(|end| !dag.contains_commit(end))
          {
              // ----------------------------------------
              // The following line is the bug
              // ----------------------------------------
              heads.extend(fragment.boundary().iter().copied());
          }
      }
      heads.extend(dag.heads());
      heads
  }
```

Solution: rather than computing the full commit graph do a much simpler set based computation and return as heads all the commit IDs which are not referenced by other commits, fragment boundaries, or fragment checkpoints. This is strictly more work than is needed to fix the bug, but I think it's simpler to understand.

